### PR TITLE
solved node 42087 MySQL password hashes fail

### DIFF
--- a/migration-directadmin.pl
+++ b/migration-directadmin.pl
@@ -517,7 +517,7 @@ if ($got{'mysql'}) {
 			&read_env_file("$backup/$db.conf", \%dbusers);
 			foreach my $myuser (keys %dbusers) {
 				next if ($myuser eq $user);
-				next if ($dbusers{$myuser} !~ /passwd=([^=]+)/);
+				next if ($dbusers{$myuser} !~ /passwd=([^&]+)/);
 				my $mypass = $1;
 				local $myuinfo = &create_initial_user(\%dom);
 				$myuinfo->{'user'} = $myuser;


### PR DESCRIPTION
The error which is solved is the following:
Failed to migrate virtual server : SQL set password for 'dbuser'@'localhost' = '*B1DFB503E89D3BEDEAB2386570D000510B9E3162&references_priv' failed : Password hash should be a 41-digit hexadecimal number

The reason was, is that the algorithm was selecting everything after password= untill it found another '=', I have changed the regular expression to stop when finding a '&'