### PR TITLE
Require cgi only if mail is enabled

### DIFF
--- a/virtual-server-lib-funcs.pl
+++ b/virtual-server-lib-funcs.pl
@@ -13925,7 +13925,8 @@ if ($config{'web'}) {
 	    !$apache::httpd_modules{'mod_fcgid'}) {
 		return $text{'tmpl_ephpmode2'};
 		}
-	if ($apache::httpd_modules{'core'} >= 2.4 &&
+	if ($config{'mail'} &&
+	    $apache::httpd_modules{'core'} >= 2.4 &&
 	    !$apache::httpd_modules{'mod_cgi'} &&
 	    !$apache::httpd_modules{'mod_cgid'}) {
 		return $text{'check_ewebcgi'};

--- a/virtual-server-lib-funcs.pl
+++ b/virtual-server-lib-funcs.pl
@@ -14548,10 +14548,11 @@ if ($nologin_shell && $shells{$nologin_shell->{'shell'}}) {
 	&$second_print(&text('check_eshell',
 		"<tt>$nologin_shell->{'shell'}</tt>", "<tt>/etc/shells</tt>"));
 	}
-if ($ftp_shell && !$shells{$ftp_shell->{'shell'}}) {
+if ($config{'ftp'} && $ftp_shell && !$shells{$ftp_shell->{'shell'}}) {
 	&$second_print(&text('check_eftpshell',
 		"<tt>$ftp_shell->{'shell'}</tt>", "<tt>/etc/shells</tt>"));
 	}
+
 
 # Check for problem module config settings
 if ($config{'all_namevirtual'} && $config{'dns_ip'}) {


### PR DESCRIPTION
Mail client auto-configuration requires active Apache module mod_cgi or mod_cgid. If mail is disabled on the server, cgi requirement shouldn't exist.

Issues #28 and #31

Also skip checking missing FTP shell if FTP in disabled.