### PR TITLE
Certificate install error - unwanted replace of space to new line

### DIFF
--- a/install-cert.pl
+++ b/install-cert.pl
@@ -60,7 +60,7 @@ while(@ARGV > 0) {
 		else {
 			# In parameter
 			$f =~ s/\r//g;
-			$f =~ s/\s+/\n/g;
+			$f =~ s/\t+/\n/g;
 			push(@got, [ $g, $f ]);
 			}
 		}


### PR DESCRIPTION
- (bugfix) virtualmin api: install-cert api script removes spaces but this causes validation errors because of the required ------BEGIN CERTIFICATE----- syntax of the first and last name

(as far i can see, it isn't possible to install a string-based certificate from cli or api because of this line, because there should be a space in the first and last string)