### PR TITLE
Require 'mysqli' PHP module for phpMyAdmin

### DIFF
--- a/scripts/phpmyadmin.pl
+++ b/scripts/phpmyadmin.pl
@@ -62,7 +62,7 @@ return ( 5 );
 
 sub script_phpmyadmin_php_modules
 {
-return ("mysql");
+return ("mysqli");
 }
 
 sub script_phpmyadmin_php_optional_modules


### PR DESCRIPTION
PHP7 has removed 'mysql' module, so I can't install/upgrade phpMyAdmin on PHP7.

Use 'mysqli' instead