### PR TITLE
Debian file structure: Added 'shortversion' to the list of allowable …

### DIFF
--- a/php-lib.pl
+++ b/php-lib.pl
@@ -1754,7 +1754,8 @@ foreach my $pname ("php-fpm", "php5-fpm", "php7-fpm",
 		next;
 		}
 	my ($bestdir) = grep { /\Q$rv->{'version'}\E/ ||
-			       /\Q$rv->{'pkgversion'}\E/ } @verdirs;
+			       /\Q$rv->{'pkgversion'}\E/ ||
+			       /\Q$rv->{'shortversion'}\E/ } @verdirs;
 	$bestdir ||= $verdirs[0];
 	$rv->{'dir'} = $bestdir;
 


### PR DESCRIPTION
…@verdirs in list_php_fpm_configs

Debian package default file structure for pool.d locations is not handled by the current php-lib.pl in the master.

As an example on Debian 9.8, php7.3-fpm package has the full Version (in dpkg) of 7.3.2-3+0~20190208150725.31+stretch~1.gbp0912bd. php-lib.pl's list_php_fpm_config subroutine populates that data into @rv as follows:
$rv->{'version'} = 7.3.2
$rv->{'shortversion'} = 7.3
$rv->{'pkgversion'} = 73

Debian stores the pool files for this version under /etc/php/7.3/fpm/pool.d, which neither 'version' nor 'pkgversion' accounts for - this pull request adds shortversion to the list of allowable expressions to match against, which then allows virtualmin to properly detect the file locations.