### PR TITLE
Add support for s3 compatible servers with aws-cli

### DIFF
--- a/s3-lib.pl
+++ b/s3-lib.pl
@@ -1024,12 +1024,16 @@ return 1;
 # Run the aws command for s3 with some params, and return output
 sub call_aws_cmd
 {
-my ($akey, $params) = @_;
+my ($akey, $params, $endpoint, $endpoint_param) = @_;
+$endpoint ||= $config{'s3_endpoint'};
+if (length $endpoint) {
+	$endpoint_param = "--endpoint-url=".quotemeta("https://$endpoint");
+  }
 if (ref($params)) {
 	$params = join(" ", map { quotemeta($_) } @$params);
 	}
 return &backquote_command(
-	"TZ=GMT $config{'aws_cmd'} s3 --profile=".quotemeta($akey).
+	"TZ=GMT $config{'aws_cmd'} s3 --profile=".quotemeta($akey)." ".$endpoint_param.
 	" ".$params." 2>&1");
 }
 


### PR DESCRIPTION
Currently, when aws-cli is installed, the s3_endpoint setting is ignored. 

This change allows for the use of s3 compatible servers that require signature version 4 signing (such as Backblaze B2 - https://www.backblaze.com/b2/docs/s3_compatible_api.html)

This change makes the assumption that the endpoint will be https, as there is no provision to define ports or security in settings