### PR TITLE
Fixing the "Add sub-domain DNS records to parent domain?” doesn’t work for aliases issue

### DIFF
--- a/feature-dns.pl
+++ b/feature-dns.pl
@@ -53,7 +53,7 @@ if ($d->{'subdom'}) {
 	# Special subdom mode, always under that domain
 	$dnsparent = &get_domain($d->{'subdom'});
 	}
-elsif (!$d->{'alias'} && $tmpl->{'dns_sub'} eq 'yes' && $d->{'parent'}) {
+elsif ($tmpl->{'dns_sub'} eq 'yes' && $d->{'parent'}) {
 	# Find most suitable domain with the same owner that has it's own file
 	foreach my $pd (sort { length($b->{'dom'}) cmp length($a->{'dom'}) }
 			     (&get_domain_by("parent", $d->{'parent'}),


### PR DESCRIPTION
This pull request is based on this discussion here: https://forum.virtualmin.com/t/add-sub-domain-dns-records-to-parent-domain-doesnt-work-for-aliases/109187

It would be nice to have the possibility to create alias virtual servers with no separate DNS zone file, just adding the necessary DNS records to the parent zone file in case it's a subdomain of the parent.