### PR TITLE
Suggest installing aws-cli when webmin fails to upload to S3

### DIFF
--- a/s3-lib.pl
+++ b/s3-lib.pl
@@ -969,7 +969,7 @@ while(defined($buf = &read_http_connection($h, 1024))) {
 &close_http_connection($h);
 
 if ($line !~ /^HTTP\/1\..\s+(200|30[0-9])(\s+|$)/) {
-	return (0, "Upload failed : $line");
+	return (0, "Upload failed : $line\nTry installing aws-cli");
 	}
 elsif (!$rheader{'etag'}) {
 	return (0, "Response missing etag header : $out");


### PR DESCRIPTION
As seen at https://www.virtualmin.com/node/25170, aws-cli is needed for buckets outside US. Then, it would be nice to give this hint to the user. However, I am not sure if it is the best place to put this message.