### PR TITLE
Add consistency in features sorting

### DIFF
--- a/delete_domain.cgi
+++ b/delete_domain.cgi
@@ -39,7 +39,9 @@ if (!$in{'confirm'}) {
 		}
 
 	print "<ul>\n";
-	foreach $f (@features) {
+	my @features_ = @features;
+	features_sort(\@features_, \@features_);
+	foreach $f (@features_) {
 		if ($d->{$f} && ($config{$f} || $f eq 'unix')) {
 			my $msg = $d->{'parent'} ? $text{"sublosing_$f"}
 						 : undef;
@@ -47,7 +49,9 @@ if (!$in{'confirm'}) {
 			print "<li>",$text{'feature_'.$f}," - ",$msg,"<br>\n";
 			}
 		}
-	foreach $f (&list_feature_plugins()) {
+	my @list_feature_plugins = &list_feature_plugins();
+	features_sort(\@list_feature_plugins, \@list_feature_plugins);
+	foreach $f (@list_feature_plugins) {
 		if ($d->{$f}) {
 			print "<li>",&plugin_call($f, "feature_name")," - ",
 			     &plugin_call($f, "feature_losing"),"<br>\n";

--- a/domain_form.cgi
+++ b/domain_form.cgi
@@ -572,15 +572,7 @@ foreach $f (@fplugins) {
 		}
 	}
 features_sort(\@grid, \@grid_order_initial);
-my @grid_left = @grid;
-my $grid_tnum = scalar(@grid);
-my @grid_right = splice(@grid_left, ($grid_tnum / 2) + ($grid_tnum % 2 ? 1 : 0));
-my $style_force_no_border = 'style="border:0 !important;"';
-my $style_flex_cnt = 'style="display: flex; align-items: flex-start; justify-content: center;"';
-my $lgftable = &ui_grid_table(\@grid_left, 1, undef, undef, $style_force_no_border);
-my $rgftable = &ui_grid_table(\@grid_right, 1, undef, undef, $style_force_no_border);
-my $ftable = "<div $style_flex_cnt>" . ($lgftable .$rgftable) . "</div>";
-print &ui_table_row(undef, $ftable, 4);
+print &ui_table_row(undef, &vui_features_sorted_grid(\@grid), 4);
 print &ui_hidden_table_end("feature");
 
 # Show section for extra plugin options

--- a/domain_form.cgi
+++ b/domain_form.cgi
@@ -252,7 +252,7 @@ if ($config{'plan_auto'}) {
 	@def_features = grep { $config{$_} == 1 || $config{$_} == 3 }
 			     @dom_features;
 	@fplugins = &list_feature_plugins();
-	# push(@def_features, grep { !$plugins_inactive{$_} } @fplugins);
+	push(@def_features, grep { !$plugins_inactive{$_} } @fplugins);
 	}
 
 # Generate Javascript for plan change

--- a/domain_form.cgi
+++ b/domain_form.cgi
@@ -523,8 +523,9 @@ if ($fields) {
 
 # Show checkboxes for features
 print &ui_hidden_table_start($text{'edit_featuresect'}, "width=100%", 2,
-			     "feature", 0);
+			     "feature", 1);
 @grid = ( );
+@grid_order_initial = ( );
 $i = 0;
 $can_website = 0;
 foreach $f (@dom_features) {
@@ -546,8 +547,9 @@ foreach $f (@dom_features) {
 
 	local $txt = $parentdom ? $text{'form_sub'.$f} : undef;
 	$txt ||= $text{'form_'.$f};
+	push(@grid_order_initial, $f);
 	push(@grid, &ui_checkbox($f, 1, "", $config{$f} == 1).
-		    "<b>".&hlink($txt, $f)."</b>");
+		    " <b>".&hlink($txt, $f)."</b>");
 	}
 
 # Show checkboxes for plugins
@@ -560,16 +562,24 @@ foreach $f (@fplugins) {
 	$can_website = 1 if (&plugin_call($f, "feature_provides_web"));
 
 	$label = &plugin_call($f, "feature_label", 0);
-	$label = "<b>$label</b>";
+	$label = " <b>$label</b>";
 	$hlink = &plugin_call($f, "feature_hlink");
 	$label = &hlink($label, $hlink, $f) if ($hlink);
+	push(@grid_order_initial, $f);
 	push(@grid, &ui_checkbox($f, 1, "", !$plugins_inactive{$f}).$label);
 	if (&plugin_call($f, "feature_inputs_show", undef)) {
 		push(@input_plugins, $f);
 		}
 	}
-$ftable = &ui_grid_table(\@grid, 2, 100,
-	[ "align=left", "align=left" ]);
+features_sort(\@grid, \@grid_order_initial);
+my @grid_left = @grid;
+my $grid_tnum = scalar(@grid);
+my @grid_right = splice(@grid_left, ($grid_tnum / 2) + ($grid_tnum % 2 ? 1 : 0));
+my $style_force_no_border = 'style="border:0 !important;"';
+my $style_flex_cnt = 'style="display: flex; align-items: flex-start; justify-content: center;"';
+my $lgftable = &ui_grid_table(\@grid_left, 1, undef, undef, $style_force_no_border);
+my $rgftable = &ui_grid_table(\@grid_right, 1, undef, undef, $style_force_no_border);
+my $ftable = "<div $style_flex_cnt>" . ($lgftable .$rgftable) . "</div>";
 print &ui_table_row(undef, $ftable, 4);
 print &ui_hidden_table_end("feature");
 

--- a/domain_form.cgi
+++ b/domain_form.cgi
@@ -252,7 +252,7 @@ if ($config{'plan_auto'}) {
 	@def_features = grep { $config{$_} == 1 || $config{$_} == 3 }
 			     @dom_features;
 	@fplugins = &list_feature_plugins();
-	push(@def_features, grep { !$plugins_inactive{$_} } @fplugins);
+	# push(@def_features, grep { !$plugins_inactive{$_} } @fplugins);
 	}
 
 # Generate Javascript for plan change

--- a/edit_domain.cgi
+++ b/edit_domain.cgi
@@ -380,16 +380,7 @@ if (!$d->{'disabled'}) {
 			}
 		}
 	features_sort(\@grid, \@grid_order_initial);
-
-	my @grid_left = @grid;
-	my $grid_tnum = scalar(@grid);
-	my @grid_right = splice(@grid_left, ($grid_tnum / 2) + ($grid_tnum % 2 ? 1 : 0));
-	my $style_force_no_border = 'style="border:0 !important;"';
-	my $style_flex_cnt = 'style="display: flex; align-items: flex-start; justify-content: center;"';
-	my $lgftable = &ui_grid_table(\@grid_left, 1, undef, undef, $style_force_no_border);
-	my $rgftable = &ui_grid_table(\@grid_right, 1, undef, undef, $style_force_no_border);
-	my $ftable = "<div $style_flex_cnt>" . ($lgftable .$rgftable) . "</div>";
-	print &ui_table_row(undef, $ftable, 2);
+	print &ui_table_row(undef, &vui_features_sorted_grid(\@grid), 2);
 	print &ui_hidden_table_end("feature");
 	}
 

--- a/edit_domain.cgi
+++ b/edit_domain.cgi
@@ -324,8 +324,9 @@ if ($fields) {
 if (!$d->{'disabled'}) {
 	# Show features for this domain
 	print &ui_hidden_table_start($text{'edit_featuresect'}, "width=100%", 2,
-				     "feature", 0);
+				     "feature", 1);
 	@grid = ( );
+	@grid_order_initial = ( );
 	$i = 0;
 	foreach my $f (&list_possible_domain_features($d)) {
 		# Don't show features that are always enabled, if currently set
@@ -344,12 +345,14 @@ if (!$d->{'disabled'}) {
 		local $txt = $parentdom ? $text{'edit_sub'.$f} : undef;
 		$txt ||= $text{'edit_'.$f};
 		if (!&can_use_feature($f)) {
+			push(@grid_order_initial, $f);
 			push(@grid, &ui_checkbox($f."_dis", 1, undef,
 						$d->{$f}, undef, 1).
 				    &ui_hidden($f, $d->{$f}).
 				    " <b>".&hlink($txt, $f)."</b>");
 			}
 		else {
+			push(@grid_order_initial, $f);
 			push(@grid, &ui_checkbox($f, 1, "", $d->{$f}).
 				    " <b>".&hlink($txt, $f)."</b>");
 			}
@@ -360,23 +363,32 @@ if (!$d->{'disabled'}) {
 					$parentdom, $aliasdom, $subdom));
 
 		$label = &plugin_call($f, "feature_label", 1);
-		$label = "<b>$label</b>";
+		$label = " <b>$label</b>";
 		$hlink = &plugin_call($f, "feature_hlink");
 		$label = &hlink($label, $hlink, $f) if ($hlink);
 		if (!&can_use_feature($f)) {
+			push(@grid_order_initial, $f);
 			push(@grid, &ui_checkbox($f."_dis", 1, "",
 						 $d->{$f}, undef, 1).
 				    &ui_hidden($f, $d->{$f}).
 				    $label);
 			}
 		else {
+			push(@grid_order_initial, $f);
 			push(@grid, &ui_checkbox($f, 1, "", $d->{$f}).
 				    $label);
 			}
 		}
+	features_sort(\@grid, \@grid_order_initial, 'grid');
 
-	$ftable = &ui_grid_table(\@grid, 2, 100,
-			[ "align=left", "align=left" ]);
+	my @grid_left = @grid;
+	my $grid_tnum = scalar(@grid);
+	my @grid_right = splice(@grid_left, ($grid_tnum / 2) + ($grid_tnum % 2 ? 1 : 0));
+	my $style_force_no_border = 'style="border:0 !important;"';
+	my $style_flex_cnt = 'style="display: flex; align-items: flex-start; justify-content: center;"';
+	my $lgftable = &ui_grid_table(\@grid_left, 1, undef, undef, $style_force_no_border);
+	my $rgftable = &ui_grid_table(\@grid_right, 1, undef, undef, $style_force_no_border);
+	my $ftable = "<div $style_flex_cnt>" . ($lgftable .$rgftable) . "</div>";
 	print &ui_table_row(undef, $ftable, 2);
 	print &ui_hidden_table_end("feature");
 	}

--- a/edit_domain.cgi
+++ b/edit_domain.cgi
@@ -379,7 +379,7 @@ if (!$d->{'disabled'}) {
 				    $label);
 			}
 		}
-	features_sort(\@grid, \@grid_order_initial, 'grid');
+	features_sort(\@grid, \@grid_order_initial);
 
 	my @grid_left = @grid;
 	my $grid_tnum = scalar(@grid);

--- a/edit_limits.cgi
+++ b/edit_limits.cgi
@@ -120,6 +120,7 @@ print &ui_table_hr();
 
 # Allowed features
 @grid = ( );
+@grid_order = ( );
 foreach $f (@opt_features, "virt") {
 	next if (!&can_use_feature($f));
 	if ($config{$f} == 3) {
@@ -127,13 +128,24 @@ foreach $f (@opt_features, "virt") {
 		# bother showing it here
 		next;
 		}
+	push(@grid_order, $f);
 	push(@grid, &ui_checkbox("features", $f, $text{'feature_'.$f} || $f, $d->{"limit_$f"}));
 	}
 foreach $f (&list_feature_plugins()) {
 	next if (!&can_use_feature($f));
+	push(@grid_order, $f);
 	push(@grid, &ui_checkbox("features", $f, &plugin_call($f, "feature_name"), $d->{"limit_$f"}));
 	}
-$ftable = &ui_grid_table(\@grid, 2);
+
+features_sort(\@grid, \@grid_order);
+my @grid_left = @grid;
+my $grid_tnum = scalar(@grid);
+my @grid_right = splice(@grid_left, ($grid_tnum / 2) + ($grid_tnum % 2 ? 1 : 0));
+my $style_force_no_border = 'style="border:0 !important;"';
+my $style_flex_cnt = 'style="display: flex; align-items: flex-start; justify-content: center;"';
+my $lgftable = &ui_grid_table(\@grid_left, 1, undef, undef, $style_force_no_border);
+my $rgftable = &ui_grid_table(\@grid_right, 1, undef, undef, $style_force_no_border);
+my $ftable = "<div $style_flex_cnt>" . ($lgftable .$rgftable) . "</div>";
 print &ui_table_row(&hlink($text{'limits_features'}, "limits_features"),
 		    $ftable);
 

--- a/edit_limits.cgi
+++ b/edit_limits.cgi
@@ -111,7 +111,7 @@ print &ui_hidden_table_start($text{'limits_header2'}, "width=100%", 2,
 # Capabilities when editing a server
 @grid = ( );
 foreach $ed (@edit_limits) {
-	push(@grid, &ui_checkbox("edit", $ed, $text{'limits_edit_'.$ed} || $ed, $d->{"edit_$ed"}));
+	push(@grid, &ui_checkbox("edit", $ed, "&nbsp;".($text{'limits_edit_'.$ed} || $ed), $d->{"edit_$ed"}));
 	}
 $etable .= &ui_grid_table(\@grid, 2);
 print &ui_table_row(&hlink($text{'limits_edit'}, "limits_edit"), $etable);
@@ -129,12 +129,12 @@ foreach $f (@opt_features, "virt") {
 		next;
 		}
 	push(@grid_order, $f);
-	push(@grid, &ui_checkbox("features", $f, $text{'feature_'.$f} || $f, $d->{"limit_$f"}));
+	push(@grid, &ui_checkbox("features", $f, "&nbsp;".($text{'feature_'.$f} || $f), $d->{"limit_$f"}));
 	}
 foreach $f (&list_feature_plugins()) {
 	next if (!&can_use_feature($f));
 	push(@grid_order, $f);
-	push(@grid, &ui_checkbox("features", $f, &plugin_call($f, "feature_name"), $d->{"limit_$f"}));
+	push(@grid, &ui_checkbox("features", $f, "&nbsp;".&plugin_call($f, "feature_name"), $d->{"limit_$f"}));
 	}
 
 features_sort(\@grid, \@grid_order);

--- a/edit_limits.cgi
+++ b/edit_limits.cgi
@@ -138,16 +138,8 @@ foreach $f (&list_feature_plugins()) {
 	}
 
 features_sort(\@grid, \@grid_order);
-my @grid_left = @grid;
-my $grid_tnum = scalar(@grid);
-my @grid_right = splice(@grid_left, ($grid_tnum / 2) + ($grid_tnum % 2 ? 1 : 0));
-my $style_force_no_border = 'style="border:0 !important;"';
-my $style_flex_cnt = 'style="display: flex; align-items: flex-start; justify-content: center;"';
-my $lgftable = &ui_grid_table(\@grid_left, 1, undef, undef, $style_force_no_border);
-my $rgftable = &ui_grid_table(\@grid_right, 1, undef, undef, $style_force_no_border);
-my $ftable = "<div $style_flex_cnt>" . ($lgftable .$rgftable) . "</div>";
 print &ui_table_row(&hlink($text{'limits_features'}, "limits_features"),
-		    $ftable);
+		    &vui_features_sorted_grid(\@grid));
 
 if (defined(&list_scripts)) {
 	# Allowed scripts

--- a/edit_newfeatures.cgi
+++ b/edit_newfeatures.cgi
@@ -16,6 +16,7 @@ print &ui_form_start("save_newfeatures.cgi", "post");
 print "$text{'features_desc'}<p>\n";
 
 # Add rows for core features
+@table_order_initial = ( );
 $n = 0;
 foreach $f (@features) {
 	local @acts;
@@ -26,6 +27,7 @@ foreach $f (@features) {
 	if ($vital) {
 		# Some features are *never* disabled, but may be not checked
 		# by default
+		push(@table_order_initial, $f);
 		push(@table, [
 			ui_img("images/tick.gif", "Enabled"),
 			$text{'feature_'.$f},
@@ -39,6 +41,7 @@ foreach $f (@features) {
 		}
 	else {
 		# Other features can be disabled
+		push(@table_order_initial, $f);
 		push(@table, [
 			{ 'type' => 'checkbox', 'name' => 'fmods',
 			  'value' => $f, 'checked' => $config{$f} != 0,
@@ -78,6 +81,7 @@ foreach $m (sort { $a->{'desc'} cmp $b->{'desc'} } &get_all_module_infos()) {
 			print &ui_columns_row([ "<hr>" ],
 					      [ "colspan=".(scalar(@tds)+1) ]);
 			}
+		push(@table_order_initial, $m->{'dir'});
 		push(@table, [
 			{ 'type' => 'checkbox', 'name' => 'mods',
 			  'value' => $m->{'dir'},
@@ -102,6 +106,7 @@ foreach $m (sort { $a->{'desc'} cmp $b->{'desc'} } &get_all_module_infos()) {
 	}
 
 # Actually generate the table
+features_sort(\@table, \@table_order_initial);
 print &ui_form_columns_table(
 	"save_newfeatures.cgi",
 	[ [ "save", $text{'save'} ] ],

--- a/edit_newvalidate.cgi
+++ b/edit_newvalidate.cgi
@@ -30,10 +30,14 @@ print &ui_table_row($text{'newvalidate_servers'},
 		    &servers_input("servers", [ ], \@doms));
 
 # Features to check
-foreach $f (@validate_features) {
+my @validate_features_ = @validate_features;
+features_sort(\@validate_features_, \@validate_features_);
+foreach $f (@validate_features_) {
 	push(@fopts, [ $f, $text{'feature_'.$f} ]);
 	}
-foreach $f (&list_feature_plugins()) {
+my @list_feature_plugins = &list_feature_plugins();
+features_sort(\@list_feature_plugins, \@list_feature_plugins);
+foreach $f (@list_feature_plugins) {
 	if (&plugin_defined($f, "feature_validate")) {
 		push(@fopts, [ $f, &plugin_call($f, "feature_name") ]);
 		}

--- a/edit_plan.cgi
+++ b/edit_plan.cgi
@@ -100,15 +100,7 @@ foreach my $f (&list_feature_plugins()) {
 			 undef, $dis));
 	}
 features_sort(\@grid, \@grid_order);
-my @grid_left = @grid;
-my $grid_tnum = scalar(@grid);
-my @grid_right = splice(@grid_left, ($grid_tnum / 2) + ($grid_tnum % 2 ? 1 : 0));
-my $style_force_no_border = 'style="border:0 !important;"';
-my $style_flex_cnt = 'style="display: flex; align-items: flex-start; justify-content: center;"';
-my $lgftable = &ui_grid_table(\@grid_left, 1, undef, undef, $style_force_no_border);
-my $rgftable = &ui_grid_table(\@grid_right, 1, undef, undef, $style_force_no_border);
-my $ui_grid_tbl = "<div $style_flex_cnt>" . ($lgftable .$rgftable) . "</div>";
-$ftable .= $ui_grid_tbl.
+$ftable .= &vui_features_sorted_grid(\@grid) .
 	   &ui_links_row([ &select_all_link("featurelimits"),
 			   &select_invert_link("featurelimits") ]);
 print &ui_table_row(&hlink($text{'tmpl_featurelimits'},

--- a/edit_plan.cgi
+++ b/edit_plan.cgi
@@ -86,17 +86,29 @@ $ftable = &ui_radio('featurelimits_def', $dis,
 		    [ [ 1, $text{'tmpl_featauto'}, $dis1 ],
 		      [ 0, $text{'tmpl_below'}, $dis2 ] ])."<br>\n";
 @grid = ( );
+@grid_order = ( );
 foreach my $f (@opt_features, "virt") {
+	push(@grid_order, $f);
 	push(@grid, &ui_checkbox("featurelimits", $f,
-				 $text{'feature_'.$f} || $f,
+				 "&nbsp;".($text{'feature_'.$f} || $f),
 				 $flimits{$f}, undef, $dis));
 	}
 foreach my $f (&list_feature_plugins()) {
+	push(@grid_order, $f);
 	push(@grid, &ui_checkbox("featurelimits", $f,
-			 &plugin_call($f, "feature_name"), $flimits{$f},
+			 "&nbsp;".&plugin_call($f, "feature_name"), $flimits{$f},
 			 undef, $dis));
 	}
-$ftable .= &ui_grid_table(\@grid, 2).
+features_sort(\@grid, \@grid_order);
+my @grid_left = @grid;
+my $grid_tnum = scalar(@grid);
+my @grid_right = splice(@grid_left, ($grid_tnum / 2) + ($grid_tnum % 2 ? 1 : 0));
+my $style_force_no_border = 'style="border:0 !important;"';
+my $style_flex_cnt = 'style="display: flex; align-items: flex-start; justify-content: center;"';
+my $lgftable = &ui_grid_table(\@grid_left, 1, undef, undef, $style_force_no_border);
+my $rgftable = &ui_grid_table(\@grid_right, 1, undef, undef, $style_force_no_border);
+my $ui_grid_tbl = "<div $style_flex_cnt>" . ($lgftable .$rgftable) . "</div>";
+$ftable .= $ui_grid_tbl.
 	   &ui_links_row([ &select_all_link("featurelimits"),
 			   &select_invert_link("featurelimits") ]);
 print &ui_table_row(&hlink($text{'tmpl_featurelimits'},
@@ -123,7 +135,7 @@ $etable = &ui_radio('capabilities_def', $dis,
 @grid = ( );
 foreach my $ed (@edit_limits) {
 	push(@grid, &ui_checkbox("capabilities", $ed,
-				 $text{'limits_edit_'.$ed} || $ed,
+				 "&nbsp;".($text{'limits_edit_'.$ed} || $ed),
 				 $caps{$ed}, undef, $dis));
 	}
 $etable .= &ui_grid_table(\@grid, 2).

--- a/import.cgi
+++ b/import.cgi
@@ -611,7 +611,9 @@ else {
 		}
 
 	# Check for plugin features
-	foreach $f (&list_feature_plugins()) {
+	my @list_feature_plugins = &list_feature_plugins();
+	features_sort(\@list_feature_plugins, \@list_feature_plugins);
+	foreach $f (@list_feature_plugins) {
 		$pname = &plugin_call($f, "feature_name");
 		if (&plugin_call($f, "feature_import", $in{'dom'},
 				 $user || $in{'user'},

--- a/mass_create_form.cgi
+++ b/mass_create_form.cgi
@@ -106,15 +106,7 @@ foreach $f (&list_feature_plugins()) {
 		    "<b>$label</b>");
 	}
 features_sort(\@grid, \@grid_order);
-my @grid_left = @grid;
-my $grid_tnum = scalar(@grid);
-my @grid_right = splice(@grid_left, ($grid_tnum / 2) + ($grid_tnum % 2 ? 1 : 0));
-my $style_force_no_border = 'style="border:0 !important;"';
-my $style_flex_cnt = 'style="display: flex; align-items: flex-start; justify-content: center;"';
-my $lgftable = &ui_grid_table(\@grid_left, 1, undef, undef, $style_force_no_border);
-my $rgftable = &ui_grid_table(\@grid_right, 1, undef, undef, $style_force_no_border);
-my $ftable = "<div $style_flex_cnt>" . ($lgftable .$rgftable) . "</div>";
-print &ui_table_row(undef, $ftable, 2);
+print &ui_table_row(undef, &vui_features_sorted_grid(\@grid), 2);
 
 print &ui_table_end();
 print &ui_form_end([ [ "create", $text{'create'} ] ]);

--- a/mass_create_form.cgi
+++ b/mass_create_form.cgi
@@ -72,6 +72,7 @@ if (@resels && &master_admin()) {
 # Show checkboxes for features
 print &ui_table_hr();
 @grid = ( );
+@grid_order = ( );
 foreach $f (@opt_features) {
 	# Don't allow access to features that this user hasn't been
 	# granted for his subdomains.
@@ -85,6 +86,7 @@ foreach $f (@opt_features) {
 		}
 
 	local $txt = $text{'form_'.$f};
+	push(@grid_order, $f);
 	push(@grid, &ui_checkbox($f, 1, "", $config{$f} == 1, undef,
 			  !$config{$f} && defined($config{$f}))." ".
 		    "<b>".&hlink($txt, $f)."</b>");
@@ -99,11 +101,19 @@ foreach $f (&list_feature_plugins()) {
 	$label = &plugin_call($f, "feature_label", 0);
 	$hlink = &plugin_call($f, "feature_hlink");
 	$label = &hlink($label, $hlink, $f) if ($hlink);
+	push(@grid_order, $f);
 	push(@grid, &ui_checkbox($f, 1, "", !$inactive{$f})." ".
 		    "<b>$label</b>");
 	}
-$ftable = &ui_grid_table(\@grid, 2, 100,
-	[ "width=30% align=left", "width=70% align=left" ]);
+features_sort(\@grid, \@grid_order);
+my @grid_left = @grid;
+my $grid_tnum = scalar(@grid);
+my @grid_right = splice(@grid_left, ($grid_tnum / 2) + ($grid_tnum % 2 ? 1 : 0));
+my $style_force_no_border = 'style="border:0 !important;"';
+my $style_flex_cnt = 'style="display: flex; align-items: flex-start; justify-content: center;"';
+my $lgftable = &ui_grid_table(\@grid_left, 1, undef, undef, $style_force_no_border);
+my $rgftable = &ui_grid_table(\@grid_right, 1, undef, undef, $style_force_no_border);
+my $ftable = "<div $style_flex_cnt>" . ($lgftable .$rgftable) . "</div>";
 print &ui_table_row(undef, $ftable, 2);
 
 print &ui_table_end();

--- a/mass_domains_form.cgi
+++ b/mass_domains_form.cgi
@@ -61,7 +61,9 @@ if ($anyqb) {
 # Feature enable/disable
 print &ui_hidden_table_start($text{'massdomains_headerf'}, "width=100%", 2,
 			     "features", 0);
-foreach $f (@opt_features) {
+my @opt_features_ = @opt_features;
+features_sort(\@opt_features_, \@opt_features_);
+foreach $f (@opt_features_) {
 	if (&can_use_feature($f)) {
 		print &ui_table_row($text{'edit_'.$f},
 			&ui_radio($f, 2, [ [ 2, $text{'massdomains_leave'} ],
@@ -71,7 +73,9 @@ foreach $f (@opt_features) {
 			1, \@tds);
 		}
 	}
-foreach $f (&list_feature_plugins()) {
+my @list_feature_plugins = &list_feature_plugins();
+features_sort(\@list_feature_plugins, \@list_feature_plugins);
+foreach $f (@list_feature_plugins) {
 	if (&can_use_feature($f)) {
 		$label = &plugin_call($f, "feature_label", 1);
 		print &ui_table_row($label,
@@ -125,12 +129,16 @@ if (&can_edit_limits($doms[0])) {
 		}
 	# Allowed features
 	@opts = ( );
+	@opts_order = ( );
 	foreach $f (@opt_features, "virt") {
+		push(@opts_order, $f);
 		push(@opts, [ $f, $text{'feature_'.$f} ]);
 		}
 	foreach $f (&list_feature_plugins()) {
+		push(@opts_order, $f);
 		push(@opts, [ $f, &plugin_call($f, "feature_name") ]);
 		}
+	features_sort(\@opts, \@opts_order);
 	print &ui_table_row($text{'massdomains_features'},
 		&ui_radio("features_def", 2,
 			[ [ 2, $text{'massdomains_features2'}."<br>" ],

--- a/save_domain.cgi
+++ b/save_domain.cgi
@@ -170,13 +170,14 @@ if (!$in{'confirm'} && !$d->{'disabled'}) {
 
 		print "<p>",&text('save_rusure',"<tt>$d->{'dom'}</tt>"),"<p>\n";
 		print "<ul>\n";
-		features_sort(\@losing, \@losing);
+		features_sort(\@losing, \@losing) if (@losing);
 		foreach $f (@losing) {
 			my $msg = $d->{'parent'} ? $text{"sublosing_$f"}
 						 : undef;
 			$msg ||= $text{"losing_$f"};
 			print "<li>",$text{'feature_'.$f}," - ",$msg,"<br>\n";
 			}
+		features_sort(\@plosing, \@plosing) if (@plosing);
 		foreach $f (@plosing) {
 			print "<li>",&plugin_call($f, "feature_name")," - ",
 			     &plugin_call($f, "feature_losing"),"<br>\n";

--- a/save_domain.cgi
+++ b/save_domain.cgi
@@ -170,6 +170,7 @@ if (!$in{'confirm'} && !$d->{'disabled'}) {
 
 		print "<p>",&text('save_rusure',"<tt>$d->{'dom'}</tt>"),"<p>\n";
 		print "<ul>\n";
+		features_sort(\@losing, \@losing);
 		foreach $f (@losing) {
 			my $msg = $d->{'parent'} ? $text{"sublosing_$f"}
 						 : undef;

--- a/view_domain.cgi
+++ b/view_domain.cgi
@@ -218,16 +218,25 @@ if ($d->{'disabled'}) {
 else {
 	print &ui_hidden_table_start($text{'edit_featuresect'}, "width=100%", 2,
 				     "feature", 0);
-	@grid = ( );
-	$i = 0;
-	foreach $f (@features) {
+	my @grid = ( );
+	my @grid_order = ( );
+	foreach my $f (@features) {
+		push(@grid_order, $f) if ($d->{$f});
 		push(@grid, $text{'feature_'.$f}) if ($d->{$f});
 		}
-	foreach $f (&list_feature_plugins()) {
+	foreach my $f (&list_feature_plugins()) {
+		push(@grid_order, $f) if ($d->{$f});
 		push(@grid, &plugin_call($f, "feature_label", 1)) if ($d->{$f});
 		}
-	$featmsg .= &ui_grid_table(\@grid, 2, 100,
-				   [ "width=30%", "width=70%" ]);
+	features_sort(\@grid, \@grid_order);
+	my @grid_left = @grid;
+	my $grid_tnum = scalar(@grid);
+	my @grid_right = splice(@grid_left, ($grid_tnum / 2) + ($grid_tnum % 2 ? 1 : 0));
+	my $style_force_no_border = 'style="border:0 !important;"';
+	my $style_flex_cnt = 'style="display: flex; align-items: flex-start; justify-content: center;"';
+	my $lgftable = &ui_grid_table(\@grid_left, 1, undef, undef, $style_force_no_border);
+	my $rgftable = &ui_grid_table(\@grid_right, 1, undef, undef, $style_force_no_border);
+	my $featmsg = "<div $style_flex_cnt>" . ($lgftable .$rgftable) . "</div>";
 	print &ui_table_row(undef, $featmsg);
 	print &ui_hidden_table_end("feature");
 	}

--- a/view_domain.cgi
+++ b/view_domain.cgi
@@ -229,15 +229,7 @@ else {
 		push(@grid, &plugin_call($f, "feature_label", 1)) if ($d->{$f});
 		}
 	features_sort(\@grid, \@grid_order);
-	my @grid_left = @grid;
-	my $grid_tnum = scalar(@grid);
-	my @grid_right = splice(@grid_left, ($grid_tnum / 2) + ($grid_tnum % 2 ? 1 : 0));
-	my $style_force_no_border = 'style="border:0 !important;"';
-	my $style_flex_cnt = 'style="display: flex; align-items: flex-start; justify-content: center;"';
-	my $lgftable = &ui_grid_table(\@grid_left, 1, undef, undef, $style_force_no_border);
-	my $rgftable = &ui_grid_table(\@grid_right, 1, undef, undef, $style_force_no_border);
-	my $featmsg = "<div $style_flex_cnt>" . ($lgftable .$rgftable) . "</div>";
-	print &ui_table_row(undef, $featmsg);
+	print &ui_table_row(undef, &vui_features_sorted_grid(\@grid));
 	print &ui_hidden_table_end("feature");
 	}
 

--- a/virtual-server-lib-funcs.pl
+++ b/virtual-server-lib-funcs.pl
@@ -11749,6 +11749,71 @@ elsif ($fmt == 5) {
 return undef;
 }
 
+# features_sort(\@features_values, \@features_order, [grouped-by-two])
+# Sorts features based on given pre-sorted list,
+# and fills unlisted based on initial sorting
+sub features_sort
+{
+my ($features_values, $features_order, $grouped_by_two) = @_;
+my @order_manual =
+   ('unix', 'dir',
+    'dns', 'virtualmin-slavedns', 'virtualmin-powerdns',
+    'web', 'ssl',
+    'virtualmin-nginx', 'virtualmin-nginx-ssl',
+    'mysql', 'postgres', 'virtualmin-sqlite', 'virtualmin-oracle',
+    'mail', 'spam', 'virus',
+    'virtualmin-mailrelay', 'virtualmin-mailman', 'virtualmin-signup',
+    'logrotate',
+    'status', 'webalizer',
+    'webmin',
+    'virtualmin-awstats',
+    'virtualmin-notes', 'virtualmin-google-analytics',
+    'virtualmin-init',
+    'virtualmin-dav', 'virtualmin-registrar',
+    'virtualmin-disable',
+    'virtualmin-git', 'virtualmin-svn',
+    'virtualmin-messageoftheday',
+    'virtualmin-htpasswd',
+    'ftp', 'virtualmin-vsftpd',
+    'virtualmin-support',
+    );
+my @order_initial = @{$features_order};
+my %ordered_;
+my @ordered;
+my @unordered;
+for my $i (0 .. $#order_initial) {
+
+	# Store all features
+	$ordered_{$order_initial[$i]} = $features_values->[$i];
+
+	# Unordered keys
+	if (! grep( /^$order_initial[$i]$/, @order_manual ) ) {
+		push(@unordered, $features_values->[$i]);
+		}
+	}
+
+# Sort ordered based on manual sorting
+for my $i (0 .. $#order_manual) {
+	my $__ = $ordered_{$order_manual[$i]};
+	push(@ordered, $__) if ($__);
+}
+
+# Grid like ordering by two
+my @ordered_combined = (@ordered, @unordered);
+my @ordered_combined_grouped_by_two;
+if ($grouped_by_two) {
+	for my $i (0 .. $#ordered_combined) {
+		push(@ordered_combined_grouped_by_two, $ordered[$i]) if ($ordered[$i]);
+		push(@ordered_combined_grouped_by_two, $unordered[$i]) if ($unordered[$i]);
+		}
+	@$features_values = @ordered_combined_grouped_by_two;
+	}
+
+else {
+	@$features_values = @ordered_combined;
+	}
+}
+
 # feature_links(&domain)
 # Returns a list of links for editing specific features within a domain, such
 # as the DNS zone, apache config and so on. Includes plugins.

--- a/virtual-server-lib-funcs.pl
+++ b/virtual-server-lib-funcs.pl
@@ -11749,12 +11749,12 @@ elsif ($fmt == 5) {
 return undef;
 }
 
-# features_sort(\@features_values, \@features_order, [grouped-by-two])
+# features_sort(\@features_values, \@features_order)
 # Sorts features based on given pre-sorted list,
 # and fills unlisted based on initial sorting
 sub features_sort
 {
-my ($features_values, $features_order, $grouped_by_two) = @_;
+my ($features_values, $features_order) = @_;
 my @order_manual =
    ('unix', 'dir',
     'dns', 'virtualmin-slavedns', 'virtualmin-powerdns',
@@ -11798,20 +11798,9 @@ for my $i (0 .. $#order_manual) {
 	push(@ordered, $__) if ($__);
 }
 
-# Grid like ordering by two
+# Combine both and modify original
 my @ordered_combined = (@ordered, @unordered);
-my @ordered_combined_grouped_by_two;
-if ($grouped_by_two) {
-	for my $i (0 .. $#ordered_combined) {
-		push(@ordered_combined_grouped_by_two, $ordered[$i]) if ($ordered[$i]);
-		push(@ordered_combined_grouped_by_two, $unordered[$i]) if ($unordered[$i]);
-		}
-	@$features_values = @ordered_combined_grouped_by_two;
-	}
-
-else {
-	@$features_values = @ordered_combined;
-	}
+@$features_values = @ordered_combined;
 }
 
 # feature_links(&domain)

--- a/vui-lib.pl
+++ b/vui-lib.pl
@@ -163,4 +163,21 @@ return $rv;
 
 }
 
+# vui_features_sorted_grid(\@grid)
+# Returns HTML for grid, formatted
+# the way that it preserves the order   
+sub vui_features_sorted_grid
+{
+my ($grid) = @_;
+my @grid = @{$grid};
+my @grid_left = @grid;
+my $grid_tnum = scalar(@grid);
+my @grid_right = splice(@grid_left, ($grid_tnum / 2) + ($grid_tnum % 2 ? 1 : 0));
+my $style_force_no_border = 'style="border:0 !important;"';
+my $style_flex_cnt = 'style="display: flex; align-items: flex-start; justify-content: center;"';
+my $lgftable = &ui_grid_table(\@grid_left, 1, undef, undef, $style_force_no_border);
+my $rgftable = &ui_grid_table(\@grid_right, 1, undef, undef, $style_force_no_border);
+return "<div class=\"vui_features_sorted_grid\" $style_flex_cnt>" . ($lgftable . $rgftable) . "</div>";
+}
+
 1;

--- a/vui-lib.pl
+++ b/vui-lib.pl
@@ -173,7 +173,7 @@ my @grid = @{$grid};
 my @grid_left = @grid;
 my $grid_tnum = scalar(@grid);
 my @grid_right = splice(@grid_left, ($grid_tnum / 2) + ($grid_tnum % 2 ? 1 : 0));
-my $style_force_no_border = 'style="border:0 !important;"';
+my $style_force_no_border = 'style="border:0 !important; width: 50%;"';
 my $style_flex_cnt = 'style="display: flex; align-items: flex-start; justify-content: center;"';
 my $lgftable = &ui_grid_table(\@grid_left, 1, undef, undef, $style_force_no_border);
 my $rgftable = &ui_grid_table(\@grid_right, 1, undef, undef, $style_force_no_border);


### PR DESCRIPTION
I wasn't happy about the way features are displayed across UI, especially, changing set of features globally, pretty much resorted them when displayed under _Edit Virtual Server_.

The following PR fixes this problem and provides control the way it's displayed by ordering and grouping features accordingly, example:

![image](https://user-images.githubusercontent.com/4426533/111079590-ae47af00-850b-11eb-8386-961c9082b7df.png)

![image](https://user-images.githubusercontent.com/4426533/111079552-8a846900-850b-11eb-84da-46736487fb6e.png)


As you can see features are logically grouped and when features are disabled globally or when bundles changed (LAMP/LEMP), it will keep features at the expected place, which is important for usability.

The same logic for _Create Virtual Server_ is coming in a bit but this commit is already tested, working, independent and ready to be merged.