### PR TITLE
Fixed translation of Let's Encrypt

### DIFF
--- a/lang/de
+++ b/lang/de
@@ -2018,6 +2018,7 @@ cert_dcopy=Kopiere zu Dovecot
 cert_pcopy=Kopiere zu Postfix
 cert_pcopydesc=Benutze dieses Zertifikat in Postfix für SSL-geschützten SMTP-Verbindungen von Mail-Clients.
 cert_header7=Signierte Zertifikate Details
+cert_tablets=Let's Encrypt
 
 csr_title=Erzeuge CSR
 csr_title2=Erzeuge Zertifikat

--- a/lang/de.auto
+++ b/lang/de.auto
@@ -980,7 +980,6 @@ cert_keywarn=Warnung - Ein Zertifikat in $1 und ein privater Schlüssel in $2 si
 cert_header6=Generieren Sie ein selbstsigniertes Zertifikat und einen Schlüssel
 cert_esconf=Virtualmin konnte die Datei <tt>openssl.cnf</tt> auf Ihrem System nicht finden, die zum Generieren eines Zertifikats mit zusätzlichen Domänennamen erforderlich ist
 cert_ccn=Name der Zertifizierungsstelle
-cert_tablets=Verschlüsseln wir
 cert_tabperip=Service-Zertifikate
 cert_etime=Zeit bis zum Ablauf
 cert_expired=% Vor 1 Tagen abgelaufen!


### PR DESCRIPTION
Let's Encrypt was translated in de.auto -> is a name that should not be translated.