### PR TITLE
BUG FIX : create-route CLI bug Redirect URL is impossible to set

### DIFF
--- a/create-redirect.pl
+++ b/create-redirect.pl
@@ -59,7 +59,7 @@ while(@ARGV > 0) {
 		$url = shift(@ARGV);
 		}
 	elsif ($a eq "--alias") {
-		$dir = shift(@ARGV);
+		$webdir = shift(@ARGV);
 		}
 	elsif ($a eq "--regexp") {
 		$regexp = 1;
@@ -93,8 +93,8 @@ if ($url) {
 		&usage("The --redirect flag must be followed by a URL or ".
 		       "a URL path");
 	}
-elsif ($dir) {
-	$dir =~ /^\/\S+$/ && -d $dir ||
+elsif ($webdir) {
+	$webdir =~ /^\/\S+$/ && -d $webdir ||
 		&usage("The --alias flag must be followed by a directory");
 	}
 else {
@@ -118,8 +118,8 @@ $clash && &usage("A redirect for the path $path already exists");
 
 # Create it
 $r = { 'path' => $path,
-       'dest' => $url || $dir,
-       'alias' => $dir ? 1 : 0,
+       'dest' => $url || $webdir,
+       'alias' => $webdir ? 1 : 0,
        'regexp' => $regexp,
        'http' => $http,
        'https' => $https,


### PR DESCRIPTION
Hi guys!

Thanks for developing virtualmin, its such a great product.

We have discovered a bug in the create-route cli call for the remote api that means it currently impossible to create a redirect to external url. The issue that the dir variable seems to be getting set prior regardless of is a alias is provided in the call and as such throws out the dir check.

As a solution to this we have renamed dir to webDir and now everything works as intended!

Hopefully this temp fix might help you further troubleshoot this issue further.

Hopefully we can get this fixed implemented in the main branch!

Kind Regards,
Jack Harris