### PR TITLE
update a path for subroutine get_php_fpm_socket_file in php-lib.pl to…

### DIFF
--- a/php-lib.pl
+++ b/php-lib.pl
@@ -1998,7 +1998,7 @@ return @rv;
 sub get_php_fpm_socket_file
 {
 my ($d, $nomkdir) = @_;
-my $base = "/var/php-fpm";
+my $base = "/var/run/php-fpm";
 if (!-d $base && !$nomkdir) {
 	&make_dir($base, 0755);
 	}


### PR DESCRIPTION
… keep SELinux happy --- as SELinux already has a rule for /var/run/php-fpm.