### PR TITLE
Initial install doesn't have MySQL version file

### DIFF
--- a/virtual-server-lib.pl
+++ b/virtual-server-lib.pl
@@ -15,6 +15,15 @@ use Time::Local;
 my $mysql_module_version = &read_file_contents(
 	"$config_directory/mysql/version"); 
 chop($mysql_module_version);
+if (!$mysql_module_version) {
+	if ($config{'mysql'}) {
+		&foreign_require("mysql");
+		if (defined(&mysql::get_mysql_version)) {
+			$mysql_module_version = &mysql::get_mysql_version();
+			&mysql::save_mysql_version($mysql_module_version);
+			}
+		}
+	}
 if ($mysql_module_version =~ /mariadb/i) {
 	foreach my $t (keys %text) {
 		$text{$t} =~ s/MySQL/MariaDB/g if ($t !~ /^newmysqls_ver/);


### PR DESCRIPTION
If we install Virtualmin and go to  straight to post-install wizard (what most users would do), there would be no **`/etc/webmin/mysql/version`**  in place, and thus MariaDB would be displayed all over incorrectly as MySQL.

This patch makes sure that the version file is generated and stored, and a user sees correct database variant name. **`&require_mysql`** cannot be called at this stage, so without moving the code around, this seems as optimal solution.

Creating PR, in case I'm not seeing something as part of a bigger picture, which could potentially introduce a bug.