### PR TITLE
Update existing domain Virtualmin website default page

### DIFF
--- a/lang/en
+++ b/lang/en
@@ -7492,6 +7492,7 @@ deftmplt_website_disabled=Website Disabled
 deftmplt_website_enabled=Website Enabled
 deftmplt_default_slog=domain owner may login to the control<br>panel to manage this website
 deftmplt_disable_slog=this website was disabled<br>by server administrator
+deftmplt_under_construction=Under Construction
 
 2fa_title=Two-Factor Authentication
 2fa_euser=Webmin user does not exist!

--- a/postinstall.pl
+++ b/postinstall.pl
@@ -369,8 +369,10 @@ my %uconfig = &foreign_config("useradmin");
 my $uhome   = $uconfig{'home_base'};
 my $readdir = sub {
     my ($dir) = @_;
+    my @hdirs;
+    return @hdirs if (!-d $dir);
     opendir(my $udir, $dir);
-    my @hdirs = map {&simplify_path("$dir/$_")}
+    @hdirs = map {&simplify_path("$dir/$_")}
       grep {$_ ne '.' && $_ ne '..'} readdir($udir);
     closedir($udir);
     return @hdirs;

--- a/postinstall.pl
+++ b/postinstall.pl
@@ -392,16 +392,18 @@ if (&foreign_check("useradmin")) {
 	                if ($l =~ /\s*<title>(.*?)<\/title>/) {
 	                    $eptitle = $1;
 	                    }
-	                if ($l =~ /\*\s(Virtualmin\sLanding|Website\sDefault\sPage)\sv([\d+\.]+)/) {
+	                
+	                # Test to make sure that given file is Virtualmin website default page
+	                if (!$efix && $l =~ /\*\s(Virtualmin\sLanding|Website\sDefault\sPage)\sv([\d+\.]+)$/) {
 	                    my $tmplver = $2;
-	                    if ($tmplver && &compare_version_numbers($tmplver, "2.0") < 0) {
-	                        $efix++;
-	                        }
+	                    $efix++ if ($tmplver && &compare_version_numbers($tmplver, "2.0") < 0);
 	                    }
+	                $efix++ if ($efix == 1 && $l =~ /\*\sCopyright\s+[\d]{4}\sVirtualmin,\sInc\.$/);
+                    $efix++ if ($efix == 2 && $l =~ /\*\sLicensed\sunder\sMIT$/);
 
 	                # If existing file is a template and needs a fix extract
 	                # current values to preserve to keep user happy too
-	                if ($efix) {
+	                if ($efix == 3) {
 	                    # Get existing page error label
 	                    if ($l =~ /\s*<h1.*?class=".*?error-message.*?">(.*?)<.*?(h1|br)>/) {
 	                        $eerr = $1;
@@ -423,7 +425,7 @@ if (&foreign_check("useradmin")) {
 
 	            # After existing file is read and if update
 	            # to existing default page is needed
-	            if ($efix) {
+	            if ($efix == 3) {
 	                my $domtmplfile = "$default_content_dir/index.html";
 	                if (-r $domtmplfile) {
 	                    my $domtmplfilecontent = &read_file_contents($domtmplfile);

--- a/postinstall.pl
+++ b/postinstall.pl
@@ -365,104 +365,102 @@ foreach my $m ("mysql", "postgresql", "ldap-client", "ldap-server",
 
 # Always update outdated (lower than v2.0)
 # Virtualmin website default (landing) page
-if (&foreign_check("useradmin")) {
-	my %uconfig = &foreign_config("useradmin");
-	my $uhome   = $uconfig{'home_base'};
-	my $readdir = sub {
-	    my ($dir) = @_;
-	    opendir(my $udir, $dir);
-	    my @hdirs = map {&simplify_path("$dir/$_")}
-	      grep {$_ ne '.' && $_ ne '..'} readdir($udir);
-	    closedir($udir);
-	    return @hdirs;
-	};
+my %uconfig = &foreign_config("useradmin");
+my $uhome   = $uconfig{'home_base'};
+my $readdir = sub {
+    my ($dir) = @_;
+    opendir(my $udir, $dir);
+    my @hdirs = map {&simplify_path("$dir/$_")}
+      grep {$_ ne '.' && $_ ne '..'} readdir($udir);
+    closedir($udir);
+    return @hdirs;
+};
+my @hdirs = &$readdir($uhome);
+foreach my $hdir (@hdirs) {
+    my $d       = &get_domain_by('home', $hdir);
+    my $dpubdir = $d->{'public_html_path'};
+    if (-d $dpubdir) {
+        my @dpubifiles = &$readdir($dpubdir);
+        @dpubifiles = grep (/^$dpubdir\/(index\.html|disabled_by_virtualmin\.html)$/, @dpubifiles);
+        foreach my $dpubifile (@dpubifiles) {
+            my $dpubifilelines = &read_file_lines($dpubifile, 1);
+            my ($efix, $eptitle, $eerr, $edom, $etitle, $emessage);
+            foreach my $l (@{$dpubifilelines}) {
+            	
+            	# Get beginning of the string for speed and run
+            	# extra check to make sure we have a needed file
+            	$l = substr($l, 0, 256);
 
-	my @hdirs = &$readdir($uhome);
-	foreach my $hdir (@hdirs) {
-	    my $d       = &get_domain_by('home', $hdir);
-	    my $dpubdir = $d->{'public_html_path'};
-	    if (-d $dpubdir) {
-	        my @dpubifiles = &$readdir($dpubdir);
-	        @dpubifiles = grep (/^$dpubdir\/(index\.html|disabled_by_virtualmin\.html)$/, @dpubifiles);
-	        foreach my $dpubifile (@dpubifiles) {
-	            my $dpubifilelines = &read_file_lines($dpubifile, 1);
-	            my ($efix, $eptitle, $eerr, $edom, $etitle, $emessage);
-	            foreach my $l (@{$dpubifilelines}) {
-	            	
-	            	# Get beginning of the string for speed and run
-	            	# extra check to make sure we have a needed file
-	            	$l = substr($l, 0, 256);
+                # Get existing page title
+                if ($l =~ /\s*<title>(.*?)<\/title>/) {
+                    $eptitle = $1;
+                    }
+                
+                # Test to make sure that given file is Virtualmin website default page
+                $efix++ if (!$efix && $l =~ /iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAMAAABEpIrGAAAABGdBTUEAALGPC/);
+                if ($efix == 1 && $l =~ /\*\s(Virtualmin\sLanding|Website\sDefault\sPage)\sv([\d+\.]+)$/) {
+                    my $tmplver = $2;
+                    $efix++ if ($tmplver && &compare_version_numbers($tmplver, "2.0") < 0);
+                    }
+                $efix++ if ($efix == 2 && $l =~ /\*\sCopyright\s+[\d]{4}\sVirtualmin,\sInc\.$/);
+                $efix++ if ($efix == 3 && $l =~ /\*\sLicensed\sunder\sMIT$/);
 
-	                # Get existing page title
-	                if ($l =~ /\s*<title>(.*?)<\/title>/) {
-	                    $eptitle = $1;
-	                    }
-	                
-	                # Test to make sure that given file is Virtualmin website default page
-	                $efix++ if (!$efix && $l =~ /iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAMAAABEpIrGAAAABGdBTUEAALGPC/);
-	                if ($efix == 1 && $l =~ /\*\s(Virtualmin\sLanding|Website\sDefault\sPage)\sv([\d+\.]+)$/) {
-	                    my $tmplver = $2;
-	                    $efix++ if ($tmplver && &compare_version_numbers($tmplver, "2.0") < 0);
-	                    }
-	                $efix++ if ($efix == 2 && $l =~ /\*\sCopyright\s+[\d]{4}\sVirtualmin,\sInc\.$/);
-                    $efix++ if ($efix == 3 && $l =~ /\*\sLicensed\sunder\sMIT$/);
+                # If existing file is a template and needs a fix extract
+                # current values to preserve to keep user happy too
+                if ($efix == 4) {
+                    # Get existing page error label
+                    if ($l =~ /\s*<h1.*?class=".*?error-message.*?">(.*?)<.*?(h1|br)>/) {
+                        $eerr = $1;
+                        }
+                    # Get existing page domain name
+                    if ($l =~ /\s*<h4.*?class=".*?domain.*?">(.*?)<.*?h4>/) {
+                        $edom = $1;
+                        }
+                    # Get existing page title
+                    if ($l =~ /\s*<h1.*?class=".*?default-title.*?">(.*?)<.*?h1>/) {
+                        my $__ = $1;
+                        $etitle = $__
+                            if ($__ != $text{'deftmplt_under_construction'});
+                    	}
+                    # Get existing page message
+                    if ($l =~ /\s*<h5.*?class=".*?message.*?">(.*?)<.*?h5>/) {
+                        $emessage = $1;
+                        }
+                    }
+                }
 
-	                # If existing file is a template and needs a fix extract
-	                # current values to preserve to keep user happy too
-	                if ($efix == 4) {
-	                    # Get existing page error label
-	                    if ($l =~ /\s*<h1.*?class=".*?error-message.*?">(.*?)<.*?(h1|br)>/) {
-	                        $eerr = $1;
-	                        }
-	                    # Get existing page domain name
-	                    if ($l =~ /\s*<h4.*?class=".*?domain.*?">(.*?)<.*?h4>/) {
-	                        $edom = $1;
-	                        }
-	                    # Get existing page title
-	                    if ($l =~ /\s*<h1.*?class=".*?default-title.*?">(.*?)<.*?h1>/) {
-                            my $__ = $1;
-                            $etitle = $__
-                                if ($__ != $text{'deftmplt_under_construction'});
-                        	}
-	                    # Get existing page message
-	                    if ($l =~ /\s*<h5.*?class=".*?message.*?">(.*?)<.*?h5>/) {
-	                        $emessage = $1;
-	                        }
-	                    }
-	                }
-
-	            # After existing file is read and if update
-	            # to existing default page is needed
-	            if ($efix == 4) {
-	                my $domtmplfile = "$default_content_dir/index.html";
-	                if (-r $domtmplfile) {
-	                    my $domtmplfilecontent = &read_file_contents($domtmplfile);
-	                    my %hashtmp            = %$d;
-	                    my $ddis               = $dpubifile =~ /disabled_by_virtualmin\.html/;
-	                    $hashtmp{'TMPLTPAGETITLE'} = $eptitle  || $text{'deftmplt_default_page'};
-	                    $hashtmp{'TMPLTERROR'}     = $eerr     || $text{'deftmplt_error'};
-	                    $hashtmp{'dom'}            = $edom     || $d->{'dom'};
-	                    $hashtmp{'TMPLTTITLE'}     = $etitle   ||
-                                                     ($ddis ? $text{'deftmplt_website_disabled'} :
-                                                              $text{'deftmplt_website_enabled'});
-	                    $hashtmp{'TMPLTCONTENT'}   = $emessage || "";
-	                    $hashtmp{'TMPLTSLOGAN'}    = $ddis ? $text{'deftmplt_disable_slog'} :
-	                                                         $text{'deftmplt_default_slog'};
-	                    $domtmplfilecontent =
-	                      &substitute_virtualmin_template($domtmplfilecontent, \%hashtmp);
-	                    eval {
-	                        my $fh;
-	                        &open_tempfile_as_domain_user($d, $fh, ">$dpubifile");
-	                        &print_tempfile($fh, $domtmplfilecontent);
-	                        &close_tempfile_as_domain_user($d, $fh);
-	                        &set_permissions_as_domain_user($d, 0644, $dpubifile);
-	                        };
-	                    }
-	                }
-	            }
-	        }
-	    }
-	}
+            # After existing file is read and if update
+            # to existing default page is needed
+            if ($efix == 4) {
+                my $domtmplfile = "$default_content_dir/index.html";
+                if (-r $domtmplfile) {
+                    my $domtmplfilecontent = &read_file_contents($domtmplfile);
+                    my %hashtmp            = %$d;
+                    my $ddis               = $dpubifile =~ /disabled_by_virtualmin\.html/;
+                    $hashtmp{'TMPLTPAGETITLE'} = $eptitle  || $text{'deftmplt_default_page'};
+                    $hashtmp{'TMPLTERROR'}     = $eerr     || $text{'deftmplt_error'};
+                    $hashtmp{'dom'}            = $edom     || $d->{'dom'};
+                    $hashtmp{'TMPLTTITLE'}     = $etitle   ||
+                                                 ($ddis ? $text{'deftmplt_website_disabled'} :
+                                                          $text{'deftmplt_website_enabled'});
+                    $hashtmp{'TMPLTCONTENT'}   = $emessage || "";
+                    $hashtmp{'TMPLTSLOGAN'}    = $ddis ? $text{'deftmplt_disable_slog'} :
+                                                         $text{'deftmplt_default_slog'};
+                    $domtmplfilecontent =
+                      &substitute_virtualmin_template($domtmplfilecontent, \%hashtmp);
+                    eval {
+                        my $fh;
+                        &open_tempfile_as_domain_user($d, $fh, ">$dpubifile");
+                        &print_tempfile($fh, $domtmplfilecontent);
+                        &close_tempfile_as_domain_user($d, $fh);
+                        &set_permissions_as_domain_user($d, 0644, $dpubifile);
+                        };
+                    }
+                }
+            }
+        }
+    }
+###################
 
 # Create API helper script /usr/bin/virtualmin
 &create_virtualmin_api_helper_command();

--- a/postinstall.pl
+++ b/postinstall.pl
@@ -365,8 +365,6 @@ foreach my $m ("mysql", "postgresql", "ldap-client", "ldap-server",
 
 # Always update outdated (lower than v2.0)
 # Virtualmin website default (landing) page
-my %uconfig = &foreign_config("useradmin");
-my $uhome   = $uconfig{'home_base'};
 my $readdir = sub {
     my ($dir) = @_;
     my @hdirs;
@@ -377,9 +375,7 @@ my $readdir = sub {
     closedir($udir);
     return @hdirs;
     };
-my @hdirs = &$readdir($uhome);
-foreach my $hdir (@hdirs) {
-    my $d       = &get_domain_by('home', $hdir);
+foreach my $d (@doms) {
     my $dpubdir = $d->{'public_html_path'};
     if (-d $dpubdir) {
         my @dpubifiles = &$readdir($dpubdir);

--- a/postinstall.pl
+++ b/postinstall.pl
@@ -381,7 +381,7 @@ if (&foreign_check("useradmin")) {
 	foreach my $hdir (@hdirs) {
 	    my $d       = &get_domain_by('home', $hdir);
 	    my $dpubdir = $d->{'public_html_path'};
-	    if ($dpubdir) {
+	    if (-d $dpubdir) {
 	        my @dpubifiles = &$readdir($dpubdir);
 	        @dpubifiles = grep (/^$dpubdir\/(index\.html|disabled_by_virtualmin\.html)$/, @dpubifiles);
 	        foreach my $dpubifile (@dpubifiles) {

--- a/postinstall.pl
+++ b/postinstall.pl
@@ -388,6 +388,11 @@ if (&foreign_check("useradmin")) {
 	            my $dpubifilelines = &read_file_lines($dpubifile, 1);
 	            my ($efix, $eptitle, $eerr, $edom, $etitle, $emessage);
 	            foreach my $l (@{$dpubifilelines}) {
+	            	
+	            	# Get beginning of the string for speed and run
+	            	# extra check to make sure we have a needed file
+	            	$l = substr($l, 0, 160 / ($efix ? 4 : 1));
+
 	                # Get existing page title
 	                if ($l =~ /\s*<title>(.*?)<\/title>/) {
 	                    $eptitle = $1;

--- a/postinstall.pl
+++ b/postinstall.pl
@@ -363,6 +363,95 @@ foreach my $m ("mysql", "postgresql", "ldap-client", "ldap-server",
 		}
 	}
 
+# Always update outdated (lower than v2.0)
+# Virtualmin website default (landing) page
+if (&foreign_check("useradmin")) {
+	my %uconfig = &foreign_config("useradmin");
+	my $uhome   = $uconfig{'home_base'};
+	my $readdir = sub {
+	    my ($dir) = @_;
+	    opendir(my $udir, $dir);
+	    my @hdirs = map {&simplify_path("$dir/$_")}
+	      grep {$_ ne '.' && $_ ne '..'} readdir($udir);
+	    closedir($udir);
+	    return @hdirs;
+	};
+
+	my @hdirs = &$readdir($uhome);
+	foreach my $hdir (@hdirs) {
+	    my $d       = &get_domain_by('home', $hdir);
+	    my $dpubdir = $d->{'public_html_path'};
+	    if ($dpubdir) {
+	        my @dpubifiles = &$readdir($dpubdir);
+	        @dpubifiles = grep (/^$dpubdir\/(index\.html|disabled_by_virtualmin\.html)$/, @dpubifiles);
+	        foreach my $dpubifile (@dpubifiles) {
+	            my $dpubifilelines = &read_file_lines($dpubifile, 1);
+	            my ($efix, $eptitle, $eerr, $edom, $etitle, $emessage);
+	            foreach my $l (@{$dpubifilelines}) {
+	                # Get existing page title
+	                if ($l =~ /\s*<title>(.*?)<\/title>/) {
+	                    $eptitle = $1;
+	                    }
+	                if ($l =~ /\*\s(Virtualmin\sLanding|Website\sDefault\sPage)\sv([\d+\.]+)/) {
+	                    my $tmplver = $2;
+	                    if ($tmplver && &compare_version_numbers($tmplver, "2.0") < 0) {
+	                        $efix++;
+	                        }
+	                    }
+
+	                # If existing file is a template and needs a fix extract
+	                # current values to preserve to keep user happy too
+	                if ($efix) {
+	                    # Get existing page error label
+	                    if ($l =~ /\s*<h1.*?class=".*?error-message.*?">(.*?)<.*?(h1|br)>/) {
+	                        $eerr = $1;
+	                        }
+	                    # Get existing page domain name
+	                    if ($l =~ /\s*<h4.*?class=".*?domain.*?">(.*?)<.*?h4>/) {
+	                        $edom = $1;
+	                        }
+	                    # Get existing page title
+	                    if ($l =~ /\s*<h1.*?class=".*?default-title.*?">(.*?)<.*?h1>/) {
+	                        ($etitle) = $1;
+	                        }
+	                    # Get existing page message
+	                    if ($l =~ /\s*<h5.*?class=".*?message.*?">(.*?)<.*?h5>/) {
+	                        $emessage = $1;
+	                        }
+	                    }
+	                }
+
+	            # After existing file is read and if update
+	            # to existing default page is needed
+	            if ($efix) {
+	                my $domtmplfile = "$default_content_dir/index.html";
+	                if (-r $domtmplfile) {
+	                    my $domtmplfilecontent = &read_file_contents($domtmplfile);
+	                    my %hashtmp            = %$d;
+	                    $hashtmp{'TMPLTPAGETITLE'} = $eptitle  || $text{'deftmplt_default_page'};
+	                    $hashtmp{'TMPLTERROR'}     = $eerr     || $text{'deftmplt_error'};
+	                    $hashtmp{'dom'}            = $edom     || $d->{'dom'};
+	                    $hashtmp{'TMPLTTITLE'}     = $etitle   || $text{'deftmplt_website_enabled'};
+	                    $hashtmp{'TMPLTCONTENT'}   = $emessage || "";
+	                    $hashtmp{'TMPLTSLOGAN'}    = $dpubifile =~ /disabled_by_virtualmin\.html/ ? 
+	                                                     $text{'deftmplt_disable_slog'} : 
+	                                                     $text{'deftmplt_default_slog'};
+	                    $domtmplfilecontent =
+	                      &substitute_virtualmin_template($domtmplfilecontent, \%hashtmp);
+	                    eval {
+	                        my $fh;
+	                        &open_tempfile_as_domain_user($d, $fh, ">$dpubifile");
+	                        &print_tempfile($fh, $domtmplfilecontent);
+	                        &close_tempfile_as_domain_user($d, $fh);
+	                        &set_permissions_as_domain_user($d, 0644, $dpubifile);
+	                        };
+	                    }
+	                }
+	            }
+	        }
+	    }
+	}
+
 # Create API helper script /usr/bin/virtualmin
 &create_virtualmin_api_helper_command();
 

--- a/postinstall.pl
+++ b/postinstall.pl
@@ -418,9 +418,9 @@ foreach my $hdir (@hdirs) {
                         }
                     # Get existing page title
                     if ($l =~ /\s*<h1.*?class=".*?default-title.*?">(.*?)<.*?h1>/) {
-                        my $__ = $1;
-                        $etitle = $__
-                            if ($__ != $text{'deftmplt_under_construction'});
+                        my $etitle_tmp = $1;
+                        $etitle = $etitle_tmp
+                            if ($etitle_tmp != $text{'deftmplt_under_construction'});
                     	}
                     # Get existing page message
                     if ($l =~ /\s*<h5.*?class=".*?message.*?">(.*?)<.*?h5>/) {

--- a/postinstall.pl
+++ b/postinstall.pl
@@ -376,7 +376,7 @@ my $readdir = sub {
       grep {$_ ne '.' && $_ ne '..'} readdir($udir);
     closedir($udir);
     return @hdirs;
-	};
+    };
 my @hdirs = &$readdir($uhome);
 foreach my $hdir (@hdirs) {
     my $d       = &get_domain_by('home', $hdir);

--- a/postinstall.pl
+++ b/postinstall.pl
@@ -387,7 +387,7 @@ foreach my $d (@doms) {
             	
             	# Get beginning of the string for speed and run
             	# extra check to make sure we have a needed file
-            	$l = substr($l, 0, 256);
+            	$l = substr($l, 0, 512);
 
                 # Get existing page title
                 if ($l =~ /\s*<title>(.*?)<\/title>/) {

--- a/postinstall.pl
+++ b/postinstall.pl
@@ -391,7 +391,7 @@ if (&foreign_check("useradmin")) {
 	            	
 	            	# Get beginning of the string for speed and run
 	            	# extra check to make sure we have a needed file
-	            	$l = substr($l, 0, 160 / ($efix ? 4 : 1));
+	            	$l = substr($l, 0, 256);
 
 	                # Get existing page title
 	                if ($l =~ /\s*<title>(.*?)<\/title>/) {
@@ -420,8 +420,10 @@ if (&foreign_check("useradmin")) {
 	                        }
 	                    # Get existing page title
 	                    if ($l =~ /\s*<h1.*?class=".*?default-title.*?">(.*?)<.*?h1>/) {
-	                        ($etitle) = $1;
-	                        }
+                            my $__ = $1;
+                            $etitle = $__
+                                if ($__ != $text{'deftmplt_under_construction'});
+                        	}
 	                    # Get existing page message
 	                    if ($l =~ /\s*<h5.*?class=".*?message.*?">(.*?)<.*?h5>/) {
 	                        $emessage = $1;
@@ -436,14 +438,16 @@ if (&foreign_check("useradmin")) {
 	                if (-r $domtmplfile) {
 	                    my $domtmplfilecontent = &read_file_contents($domtmplfile);
 	                    my %hashtmp            = %$d;
+	                    my $ddis               = $dpubifile =~ /disabled_by_virtualmin\.html/;
 	                    $hashtmp{'TMPLTPAGETITLE'} = $eptitle  || $text{'deftmplt_default_page'};
 	                    $hashtmp{'TMPLTERROR'}     = $eerr     || $text{'deftmplt_error'};
 	                    $hashtmp{'dom'}            = $edom     || $d->{'dom'};
-	                    $hashtmp{'TMPLTTITLE'}     = $etitle   || $text{'deftmplt_website_enabled'};
+	                    $hashtmp{'TMPLTTITLE'}     = $etitle   ||
+                                                     ($ddis ? $text{'deftmplt_website_disabled'} :
+                                                              $text{'deftmplt_website_enabled'});
 	                    $hashtmp{'TMPLTCONTENT'}   = $emessage || "";
-	                    $hashtmp{'TMPLTSLOGAN'}    = $dpubifile =~ /disabled_by_virtualmin\.html/ ? 
-	                                                     $text{'deftmplt_disable_slog'} : 
-	                                                     $text{'deftmplt_default_slog'};
+	                    $hashtmp{'TMPLTSLOGAN'}    = $ddis ? $text{'deftmplt_disable_slog'} :
+	                                                         $text{'deftmplt_default_slog'};
 	                    $domtmplfilecontent =
 	                      &substitute_virtualmin_template($domtmplfilecontent, \%hashtmp);
 	                    eval {

--- a/postinstall.pl
+++ b/postinstall.pl
@@ -376,7 +376,7 @@ my $readdir = sub {
       grep {$_ ne '.' && $_ ne '..'} readdir($udir);
     closedir($udir);
     return @hdirs;
-};
+	};
 my @hdirs = &$readdir($uhome);
 foreach my $hdir (@hdirs) {
     my $d       = &get_domain_by('home', $hdir);

--- a/postinstall.pl
+++ b/postinstall.pl
@@ -394,16 +394,17 @@ if (&foreign_check("useradmin")) {
 	                    }
 	                
 	                # Test to make sure that given file is Virtualmin website default page
-	                if (!$efix && $l =~ /\*\s(Virtualmin\sLanding|Website\sDefault\sPage)\sv([\d+\.]+)$/) {
+	                $efix++ if (!$efix && $l =~ /iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAMAAABEpIrGAAAABGdBTUEAALGPC/);
+	                if ($efix == 1 && $l =~ /\*\s(Virtualmin\sLanding|Website\sDefault\sPage)\sv([\d+\.]+)$/) {
 	                    my $tmplver = $2;
 	                    $efix++ if ($tmplver && &compare_version_numbers($tmplver, "2.0") < 0);
 	                    }
-	                $efix++ if ($efix == 1 && $l =~ /\*\sCopyright\s+[\d]{4}\sVirtualmin,\sInc\.$/);
-                    $efix++ if ($efix == 2 && $l =~ /\*\sLicensed\sunder\sMIT$/);
+	                $efix++ if ($efix == 2 && $l =~ /\*\sCopyright\s+[\d]{4}\sVirtualmin,\sInc\.$/);
+                    $efix++ if ($efix == 3 && $l =~ /\*\sLicensed\sunder\sMIT$/);
 
 	                # If existing file is a template and needs a fix extract
 	                # current values to preserve to keep user happy too
-	                if ($efix == 3) {
+	                if ($efix == 4) {
 	                    # Get existing page error label
 	                    if ($l =~ /\s*<h1.*?class=".*?error-message.*?">(.*?)<.*?(h1|br)>/) {
 	                        $eerr = $1;
@@ -425,7 +426,7 @@ if (&foreign_check("useradmin")) {
 
 	            # After existing file is read and if update
 	            # to existing default page is needed
-	            if ($efix == 3) {
+	            if ($efix == 4) {
 	                my $domtmplfile = "$default_content_dir/index.html";
 	                if (-r $domtmplfile) {
 	                    my $domtmplfilecontent = &read_file_contents($domtmplfile);

--- a/postinstall.pl
+++ b/postinstall.pl
@@ -446,13 +446,11 @@ foreach my $d (@doms) {
                                                          $text{'deftmplt_default_slog'};
                     $domtmplfilecontent =
                       &substitute_virtualmin_template($domtmplfilecontent, \%hashtmp);
-                    eval {
-                        my $fh;
-                        &open_tempfile_as_domain_user($d, $fh, ">$dpubifile");
-                        &print_tempfile($fh, $domtmplfilecontent);
-                        &close_tempfile_as_domain_user($d, $fh);
-                        &set_permissions_as_domain_user($d, 0644, $dpubifile);
-                        };
+                    my $fh;
+                    &open_tempfile_as_domain_user($d, $fh, ">$dpubifile", 1);
+                    &print_tempfile($fh, $domtmplfilecontent);
+                    &close_tempfile_as_domain_user($d, $fh);
+                    &set_permissions_as_domain_user($d, 0644, $dpubifile);
                     }
                 }
             }


### PR DESCRIPTION
This patch will solve the problem with existing and outdated Virtualmin website default (landing) page.

* Update template but preserve user existing values on the `index.html` file
* Update template but preserve existing values on the `disabled_by_virtualmin.html` file