### PR TITLE
Fix a new PHP logging

### DIFF
--- a/edit_phpmode.cgi
+++ b/edit_phpmode.cgi
@@ -179,6 +179,21 @@ if ($canv && !$d->{'alias'} && $mode ne "mod_php") {
 		}
 	}
 
+if ($mode ne 'none') {
+	$plog = &get_domain_php_error_log($d);
+	$defplog = &get_default_php_error_log($d);
+	$mode = !$plog ? 1 :
+		$plog eq $defplog ? 2 : 0;
+	print &ui_table_row(&hlink($text{'phpmode_plog'}, 'phplog'),
+		&ui_radio_table("plog_def", $mode,
+		[ [ 1, $text{'phpmode_noplog'} ],
+		  [ 2, $text{'phpmode_defplog'},
+		       "<tt>$defplog</tt>" ],
+		  [ 0, $text{'phpmode_fileplog'},
+		    &ui_textbox("plog", $mode == 0 ? $plog : "", 60) ],
+		]));
+	}
+
 print &ui_hidden_table_end();
 
 # Show PHP information

--- a/edit_website.cgi
+++ b/edit_website.cgi
@@ -87,20 +87,6 @@ if (!$d->{'alias'} && &can_log_paths() &&
 		print &ui_table_row(&hlink($text{'phpmode_elog'}, 'errorlog'),
 			&ui_textbox("elog", $elog, 60));
 		}
-	$plog = &get_domain_php_error_log($d);
-	if (defined($plog)) {
-		$defplog = &get_default_php_error_log($d);
-		$mode = !$plog ? 1 :
-			$plog eq $defplog ? 2 : 0;
-		print &ui_table_row(&hlink($text{'phpmode_plog'}, 'phplog'),
-			&ui_radio_table("plog_def", $mode,
-			[ [ 1, $text{'phpmode_noplog'} ],
-			  [ 2, $text{'phpmode_defplog'},
-			       "<tt>$defplog</tt>" ],
-			  [ 0, $text{'phpmode_fileplog'},
-			    &ui_textbox("plog", $mode == 0 ? $plog : "", 60) ],
-			]));
-		}
 	}
 
 # Ruby execution mode

--- a/php-lib.pl
+++ b/php-lib.pl
@@ -2655,7 +2655,11 @@ my ($d) = @_;
 my $mode = &get_domain_php_mode($d);
 my $phplog;
 if ($mode eq "fpm") {
-	$phplog = &get_php_fpm_ini_value($d, "error_log") || "";
+	$phplog = &get_php_fpm_ini_value($d, "error_log") || 
+	# `error_log` can never be an empty string,
+	# otherwise it will be set to default /usr
+	# if defined but the empty string in FPM
+	undef;
 	}
 elsif ($mode ne "none" && $mode ne "mod_php") {
 	$phplog = "";

--- a/save_phpmode.cgi
+++ b/save_phpmode.cgi
@@ -145,6 +145,36 @@ if ($canv && !$d->{'alias'} && $mode && $mode ne "mod_php" &&
 		}
 	}
 
+# PHP log
+if (defined($in{'plog_def'})) {
+	my $oldplog = &get_domain_php_error_log($d);
+	my $plog;
+	if ($in{'plog_def'} == 1) {
+		# Logging disabled
+		$plog = undef;
+		}
+	elsif ($in{'plog_def'} == 2) {
+		# Use the default log
+		$plog = &get_default_php_error_log($d);
+		}
+	else {
+		# Custom path
+		$plog = $in{'plog'};
+		if ($plog && $plog !~ /^\//) {
+			$plog = $d->{'home'}.'/'.$plog;
+			}
+		$plog =~ /^\/\S+$/ || &error($text{'phpmode_eplog'});
+		}
+	if ($plog ne $oldplog) {
+		&$first_print($text{'phpmode_setplog'});
+		$err = &save_domain_php_error_log($d, $plog);
+		&$second_print(!$err ? $text{'setup_done'}
+				     : &text('phpmode_logerr', $err));
+		$anything++;
+		$logchanged++;
+		}
+	}
+
 if (!$anything) {
 	&$first_print($text{'phpmode_nothing'});
 	&$second_print($text{'phpmode_nothing_skip'});

--- a/save_website.cgi
+++ b/save_website.cgi
@@ -173,35 +173,6 @@ if (defined($in{'alog'}) && !$d->{'alias'} && &can_log_paths()) {
 		$logchanged++;
 		}
 
-	# PHP log
-	if (defined($in{'plog_def'})) {
-		$oldplog = &get_domain_php_error_log($d);
-		if ($in{'plog_def'} == 1) {
-			# Logging disabled
-			$plog = undef;
-			}
-		elsif ($in{'plog_def'} == 2) {
-			# Use the default log
-			$plog = &get_default_php_error_log($d);
-			}
-		else {
-			# Custom path
-			$plog = $in{'plog'};
-			if ($plog && $plog !~ /^\//) {
-				$plog = $d->{'home'}.'/'.$plog;
-				}
-			$plog =~ /^\/\S+$/ || &error($text{'phpmode_eplog'});
-			}
-		if ($plog ne $oldplog) {
-			&$first_print($text{'phpmode_setplog'});
-			$err = &save_domain_php_error_log($d, $plog);
-			&$second_print(!$err ? $text{'setup_done'}
-					     : &text('phpmode_logerr', $err));
-			$anything++;
-			$logchanged++;
-			}
-		}
-
 	# Update Webmin permissions
 	if ($logchanged) {
 		&refresh_webmin_user($d);


### PR DESCRIPTION
  1. If we pass an empty string to to `error_log` in FPM mode, FPM config for virtual server will be saved as such, i.e. `php_value[error_log] =` defaulting to `/usr`. It can be seen using `phpinfo()` function. This issue can be reproduced by disabling logging after it was enabled upon virtual server creation.
  2. PHP logging control should be in PHP Options page. Having it under Website Options is very confusing. Also, it must always be possible to control it, as having it magically disappear is also very confusing.