### PR TITLE
Fix PHP logging controls

### DIFF
--- a/edit_phpmode.cgi
+++ b/edit_phpmode.cgi
@@ -179,6 +179,21 @@ if ($canv && !$d->{'alias'} && $mode ne "mod_php") {
 		}
 	}
 
+if ($mode ne 'none') {
+	$plog = &get_domain_php_error_log($d);
+	$defplog = &get_default_php_error_log($d);
+	$mode = !$plog ? 1 :
+		$plog eq $defplog ? 2 : 0;
+	print &ui_table_row(&hlink($text{'phpmode_plog'}, 'phplog'),
+		&ui_radio_table("plog_def", $mode,
+		[ [ 1, $text{'phpmode_noplog'} ],
+		  [ 2, $text{'phpmode_defplog'},
+		       "<tt>$defplog</tt>" ],
+		  [ 0, $text{'phpmode_fileplog'},
+		    &ui_textbox("plog", $mode == 0 ? $plog : "", 60) ],
+		]));
+	}
+
 print &ui_hidden_table_end();
 
 # Show PHP information

--- a/edit_phpmode.cgi
+++ b/edit_phpmode.cgi
@@ -179,7 +179,7 @@ if ($canv && !$d->{'alias'} && $mode ne "mod_php") {
 		}
 	}
 
-if ($mode ne 'none') {
+if ($mode ne 'none' && $mode ne 'mod_php') {
 	$plog = &get_domain_php_error_log($d);
 	$defplog = &get_default_php_error_log($d);
 	$mode = !$plog ? 1 :

--- a/edit_website.cgi
+++ b/edit_website.cgi
@@ -87,20 +87,6 @@ if (!$d->{'alias'} && &can_log_paths() &&
 		print &ui_table_row(&hlink($text{'phpmode_elog'}, 'errorlog'),
 			&ui_textbox("elog", $elog, 60));
 		}
-	$plog = &get_domain_php_error_log($d);
-	if (defined($plog)) {
-		$defplog = &get_default_php_error_log($d);
-		$mode = !$plog ? 1 :
-			$plog eq $defplog ? 2 : 0;
-		print &ui_table_row(&hlink($text{'phpmode_plog'}, 'phplog'),
-			&ui_radio_table("plog_def", $mode,
-			[ [ 1, $text{'phpmode_noplog'} ],
-			  [ 2, $text{'phpmode_defplog'},
-			       "<tt>$defplog</tt>" ],
-			  [ 0, $text{'phpmode_fileplog'},
-			    &ui_textbox("plog", $mode == 0 ? $plog : "", 60) ],
-			]));
-		}
 	}
 
 # Ruby execution mode

--- a/save_phpmode.cgi
+++ b/save_phpmode.cgi
@@ -145,6 +145,35 @@ if ($canv && !$d->{'alias'} && $mode && $mode ne "mod_php" &&
 		}
 	}
 
+# PHP log
+if (defined($in{'plog_def'})) {
+	my $oldplog = &get_domain_php_error_log($d);
+	my $plog;
+	if ($in{'plog_def'} == 1) {
+		# Logging disabled
+		$plog = undef;
+		}
+	elsif ($in{'plog_def'} == 2) {
+		# Use the default log
+		$plog = &get_default_php_error_log($d);
+		}
+	else {
+		# Custom path
+		$plog = $in{'plog'};
+		if ($plog && $plog !~ /^\//) {
+			$plog = $d->{'home'}.'/'.$plog;
+			}
+		$plog =~ /^\/\S+$/ || &error($text{'phpmode_eplog'});
+		}
+	if ($plog ne $oldplog) {
+		&$first_print($text{'phpmode_setplog'});
+		$err = &save_domain_php_error_log($d, $plog);
+		&$second_print(!$err ? $text{'setup_done'}
+				     : &text('phpmode_logerr', $err));
+		$anything++;
+		}
+	}
+
 if (!$anything) {
 	&$first_print($text{'phpmode_nothing'});
 	&$second_print($text{'phpmode_nothing_skip'});

--- a/save_phpmode.cgi
+++ b/save_phpmode.cgi
@@ -171,6 +171,14 @@ if (defined($in{'plog_def'})) {
 		&$second_print(!$err ? $text{'setup_done'}
 				     : &text('phpmode_logerr', $err));
 		$anything++;
+		if ($newmode eq 'cgi' || $newmode eq 'fcgid') {
+			if ($p eq "web") {
+				&register_post_action(\&restart_apache);
+				}
+			elsif ($p) {
+				&plugin_call($p, "feature_restart_web_php", $d);
+				}
+			}
 		}
 	}
 

--- a/save_website.cgi
+++ b/save_website.cgi
@@ -173,35 +173,6 @@ if (defined($in{'alog'}) && !$d->{'alias'} && &can_log_paths()) {
 		$logchanged++;
 		}
 
-	# PHP log
-	if (defined($in{'plog_def'})) {
-		$oldplog = &get_domain_php_error_log($d);
-		if ($in{'plog_def'} == 1) {
-			# Logging disabled
-			$plog = undef;
-			}
-		elsif ($in{'plog_def'} == 2) {
-			# Use the default log
-			$plog = &get_default_php_error_log($d);
-			}
-		else {
-			# Custom path
-			$plog = $in{'plog'};
-			if ($plog && $plog !~ /^\//) {
-				$plog = $d->{'home'}.'/'.$plog;
-				}
-			$plog =~ /^\/\S+$/ || &error($text{'phpmode_eplog'});
-			}
-		if ($plog ne $oldplog) {
-			&$first_print($text{'phpmode_setplog'});
-			$err = &save_domain_php_error_log($d, $plog);
-			&$second_print(!$err ? $text{'setup_done'}
-					     : &text('phpmode_logerr', $err));
-			$anything++;
-			$logchanged++;
-			}
-		}
-
 	# Update Webmin permissions
 	if ($logchanged) {
 		&refresh_webmin_user($d);


### PR DESCRIPTION
This PR changes and fixes:

  1. Changes the location of PHP log controls to be placed inside of PHP Options page. This will also correspond with what we currently have in Templates, where PHP log controls are under PHP Options section as well https://github.com/virtualmin/virtualmin-gpl/commit/03f2d546ed07224ab4322ba4c14bc3c8aabd3253
  2. Fixes a problem where in CGI/FCGID mode a new changes to `error_log` was not applied https://github.com/virtualmin/virtualmin-gpl/commit/88bbbf2bdba0549e7b385148bc6fb03abcffa784