### PR TITLE
Add support for enabling/disabling password hashing for existing servers

### DIFF
--- a/edit_domain.cgi
+++ b/edit_domain.cgi
@@ -220,11 +220,14 @@ if (!$parentdom) {
 
 	$smsg = &get_password_synced_types($d) ?
 			"<br>".$text{'edit_dbsync'} : "";
+	my $checked_domain_hashpass = &check_domain_hashpass($d);
+	my $optsextra = $checked_domain_hashpass ? ['hashpass_enable'] : undef;
 	print &ui_table_row($text{'edit_passwd'},
 		&ui_opt_textbox("passwd", undef, 20,
 				$text{'edit_lv'}." ".&show_password_popup($d),
-				$text{'edit_set'}, undef, undef, undef,
+				$text{'edit_set'}, undef, $optsextra, undef,
 			 	"autocomplete=new-password").
+		$checked_domain_hashpass.
 		$smsg);
 	}
 

--- a/edit_domain.cgi
+++ b/edit_domain.cgi
@@ -227,7 +227,7 @@ if (!$parentdom) {
 				$text{'edit_lv'}." ".&show_password_popup($d),
 				$text{'edit_set'}, undef, $optsextra, undef,
 			 	"autocomplete=new-password").
-		$checked_domain_hashpass.
+		($checked_domain_hashpass ? &get_domain_hashpass_checkbox($d) : "").
 		$smsg);
 	}
 

--- a/edit_domain.cgi
+++ b/edit_domain.cgi
@@ -227,7 +227,10 @@ if (!$parentdom) {
 				$text{'edit_lv'}." ".&show_password_popup($d),
 				$text{'edit_set'}, undef, $optsextra, undef,
 			 	"autocomplete=new-password").
-		($checked_domain_hashpass ? &get_domain_hashpass_checkbox($d) : "").
+		($checked_domain_hashpass ? 
+			("&nbsp;&nbsp;&nbsp;&nbsp;".&ui_checkbox("hashpass_enable", 1, 
+				$text{'edit_hash'}, $d->{'hashpass'})) :
+			"").
 		$smsg);
 	}
 

--- a/lang/en
+++ b/lang/en
@@ -1109,6 +1109,7 @@ edit_passwd=Administration password
 edit_dbsync=Warning - any database passwords will also be updated if the admin password is changed
 edit_parent=Parent virtual server
 edit_lv=Leave unchanged
+edit_hash=Hash password
 edit_set=Set to ..
 edit_save=Save Virtual Server
 edit_quota=Total server quota

--- a/save_domain.cgi
+++ b/save_domain.cgi
@@ -236,9 +236,20 @@ if (!$in{'passwd_def'}) {
 		$d->{'disabled_mysqlpass'} = undef;
 		$d->{'disabled_postgrespass'} = undef;
 		}
+	
+	# Password was changed and we need to
+	# check if passwords should be hashed
+	my $hashmode = $in{'hashpass_enable'} ? 1 : 0;
+	my $updated_domain_hashpass = &update_domain_hashpass($d, $hashmode);
+
 	$d->{'pass'} = $in{'passwd'};
 	$d->{'pass_set'} = 1;	# indicates that the password has been changed
 	&generate_domain_password_hashes($d, 0);
+
+	# Clean after hashpass switch
+	if ($updated_domain_hashpass) {
+		&post_update_domain_hashpass($d, $hashmode, $in{'passwd'});
+		}
 	}
 else {
 	$d->{'pass_set'} = 0;

--- a/virtual-server-lib-funcs.pl
+++ b/virtual-server-lib-funcs.pl
@@ -10754,7 +10754,7 @@ my ($d, $mode) = @_;
 if (&check_domain_hashpass($d)) {
 	$d->{'hashpass'} = $mode;
 	if (!$mode) {
-		my @encpass_opts = grep { $_ =~ /enc_pass$/ } keys %{$d};
+		my @encpass_opts = grep { /enc_pass$/ } keys %{$d};
 		foreach my $encpass_opt (@encpass_opts) {
 			delete($d->{$encpass_opt});
 			}

--- a/virtual-server-lib-funcs.pl
+++ b/virtual-server-lib-funcs.pl
@@ -10763,14 +10763,12 @@ my ($d, $mode, $pass) = @_;
 if ($mode) {
 	# On switching to hashed mode some passwords
 	# services need to be reset to plain text	
-	my @opts = ('mysql_enc_pass');
-	foreach my $opt (@opts) {
-		if ($d->{$opt}) {
-			my $fn = $opt;
-			$fn =~ s/enc_//;
-			$d->{$fn} = $pass;
-			delete($d->{$opt});
-			}
+	my $opt = 'mysql_enc_pass';
+	if ($d->{$opt}) {
+		my $fn = $opt;
+		$fn =~ s/enc_//;
+		$d->{$fn} = $pass;
+		delete($d->{$opt});
 		}
 	}
 }

--- a/virtual-server-lib-funcs.pl
+++ b/virtual-server-lib-funcs.pl
@@ -10729,13 +10729,20 @@ sub check_domain_hashpass
 {
 my ($d) = @_;
 my $tmpl = &get_template($d->{'template'});
-my $rs = "";
 if (defined($d->{'hashpass'}) && defined($tmpl->{'hashpass'}) &&
     $d->{'hashpass'} != $tmpl->{'hashpass'}) {
-	$rs = "&nbsp;&nbsp;&nbsp;&nbsp;".&ui_checkbox("hashpass_enable", 1, 
-		$text{'edit_hash'}, $d->{'hashpass'});
+	return 1;
 	}
-return $rs;
+return 0;
+}
+
+# check_domain_hashpass(&domain)
+# Returns hashpass checkbox
+sub get_domain_hashpass_checkbox
+{
+my ($d) = @_;
+return "&nbsp;&nbsp;&nbsp;&nbsp;".&ui_checkbox("hashpass_enable", 1, 
+		$text{'edit_hash'}, $d->{'hashpass'});
 }
 
 # update_domain_hashpass(&dom, mode)

--- a/virtual-server-lib-funcs.pl
+++ b/virtual-server-lib-funcs.pl
@@ -10736,15 +10736,6 @@ if (defined($d->{'hashpass'}) && defined($tmpl->{'hashpass'}) &&
 return 0;
 }
 
-# check_domain_hashpass(&domain)
-# Returns hashpass checkbox
-sub get_domain_hashpass_checkbox
-{
-my ($d) = @_;
-return "&nbsp;&nbsp;&nbsp;&nbsp;".&ui_checkbox("hashpass_enable", 1, 
-		$text{'edit_hash'}, $d->{'hashpass'});
-}
-
 # update_domain_hashpass(&dom, mode)
 # Updates domain hashpass option if needed, and
 # delete all *_enc_pass if disabling hashing


### PR DESCRIPTION
Jamie, I have taken a deeper look into adding support for switching password hash mode for existing domains. As we [discussed here](https://forum.virtualmin.com/t/i-cant-see-mail-paswords-in-edit-user-page-after-virtualmin-authentic-theme-update/118831/17?u=ilia), if template and domain `hashpass` options don't match then we will show a nice checkbox and let user change `hashpass` mode.



Heavily tested and working well for me, yet still a PR.

<img width="1049" alt="image" src="https://user-images.githubusercontent.com/4426533/214684920-1d1282c6-b98b-40a1-9890-f8cc0e7ab2eb.png">


As you can see there is a new `Hash password` checkbox appears but only of `hashpass` value on the template doesn't equal `hashpass` value on the domain config. In all other, standard cases it won't be shown.
