### PR TITLE
Fix to preserve certificates original paths

### DIFF
--- a/feature-ssl.pl
+++ b/feature-ssl.pl
@@ -2874,7 +2874,7 @@ $d->{'ssl_pass'} = undef;
 
 # And the chained file
 if ($chain) {
-	$chainfile = &default_certificate_file($d, 'ca');
+	$chainfile = $d->{'ssl_chain'} || &default_certificate_file($d, 'ca');
 	$chain_text = &read_file_contents($chain);
 	&lock_file($chainfile);
 	&write_ssl_file_contents($d, $chainfile, $chain_text);
@@ -2939,7 +2939,7 @@ if ($d->{'ssl_same'}) {
 	}
 
 # Create file of all the certs
-my $combfile = &default_certificate_file($d, 'combined');
+my $combfile = $d->{'ssl_combined'} || &default_certificate_file($d, 'combined');
 &lock_file($combfile);
 &create_ssl_certificate_directories($d);
 my $comb = &read_file_contents($d->{'ssl_cert'})."\n";
@@ -2951,7 +2951,7 @@ if (-r $d->{'ssl_chain'}) {
 $d->{'ssl_combined'} = $combfile;
 
 # Create file of all the certs, and the key
-my $everyfile = &default_certificate_file($d, 'everything');
+my $everyfile = $d->{'ssl_everything'} || &default_certificate_file($d, 'everything');
 &lock_file($everyfile);
 my $every = &read_file_contents($d->{'ssl_key'})."\n".
 	    &read_file_contents($d->{'ssl_cert'})."\n";

--- a/feature-ssl.pl
+++ b/feature-ssl.pl
@@ -2874,7 +2874,8 @@ $d->{'ssl_pass'} = undef;
 
 # And the chained file
 if ($chain) {
-	$chainfile = $d->{'ssl_chain'} || &default_certificate_file($d, 'ca');
+	$chainfile = $d->{'ssl_chain'} ||
+	    &default_certificate_file($d, 'ca');
 	$chain_text = &read_file_contents($chain);
 	&lock_file($chainfile);
 	&write_ssl_file_contents($d, $chainfile, $chain_text);
@@ -2939,7 +2940,8 @@ if ($d->{'ssl_same'}) {
 	}
 
 # Create file of all the certs
-my $combfile = $d->{'ssl_combined'} || &default_certificate_file($d, 'combined');
+my $combfile = $d->{'ssl_combined'} ||
+       &default_certificate_file($d, 'combined');
 &lock_file($combfile);
 &create_ssl_certificate_directories($d);
 my $comb = &read_file_contents($d->{'ssl_cert'})."\n";
@@ -2951,7 +2953,8 @@ if (-r $d->{'ssl_chain'}) {
 $d->{'ssl_combined'} = $combfile;
 
 # Create file of all the certs, and the key
-my $everyfile = $d->{'ssl_everything'} || &default_certificate_file($d, 'everything');
+my $everyfile = $d->{'ssl_everything'} ||
+       &default_certificate_file($d, 'everything');
 &lock_file($everyfile);
 my $every = &read_file_contents($d->{'ssl_key'})."\n".
 	    &read_file_contents($d->{'ssl_cert'})."\n";


### PR DESCRIPTION
Fix for the issue `#1` at [Ref.](https://forum.virtualmin.com/t/ssl-for-sub-server-certificate-and-key-do-not-match-certificate-data-is-not-valid/119313/39?u=ilia) thread.