### PR TITLE
Add PHP log controls improvements

### DIFF
--- a/edit_phpmode.cgi
+++ b/edit_phpmode.cgi
@@ -191,14 +191,18 @@ if (&can_php_error_log($mode)) {
 	$defplog = &get_default_php_error_log($d);
 	$mode = !$plog ? 1 :
 		$plog eq $defplog ? 2 : 0;
-	print &ui_table_row(&hlink($text{'phpmode_plog'}, 'phplog'),
-		&ui_radio_table("plog_def", $mode,
-		[ [ 1, $text{'phpmode_noplog'} ],
+	my $opts = [ [ 1, $text{'phpmode_noplog'} ],
 		  [ 2, $text{'phpmode_defplog'},
-		       "<tt>$defplog</tt>" ],
-		  [ 0, $text{'phpmode_fileplog'},
-		    &ui_textbox("plog", $mode == 0 ? $plog : "", 60) ],
-		]));
+		       "<tt>$defplog</tt>" ]
+		];
+	my $logmanual;
+	if (&master_admin()) {
+		$logmanual = [ 0, $text{'phpmode_fileplog'},
+			    &ui_textbox("plog", $mode == 0 ? $plog : "", 60) ];
+		push(@{$opts}, $logmanual);
+		}
+	print &ui_table_row(&hlink($text{'phpmode_plog'}, 'phplog'),
+		&ui_radio_table("plog_def", $mode, $opts));
 	}
 
 print &ui_hidden_table_end();

--- a/edit_phpmode.cgi
+++ b/edit_phpmode.cgi
@@ -186,23 +186,25 @@ if ($canv && !$d->{'alias'} && $mode ne "mod_php") {
 	}
 
 # Show PHP error log
-if (&can_php_error_log($mode)) {
+if ($can && &can_php_error_log($mode)) {
 	$plog = &get_domain_php_error_log($d);
 	$defplog = &get_default_php_error_log($d);
 	$mode = !$plog ? 1 :
 		$plog eq $defplog ? 2 : 0;
-	my $opts = [ [ 1, $text{'phpmode_noplog'} ],
-		  [ 2, $text{'phpmode_defplog'},
-		       "<tt>$defplog</tt>" ]
-		];
-	my $logmanual;
-	if (&master_admin()) {
-		$logmanual = [ 0, $text{'phpmode_fileplog'},
-			    &ui_textbox("plog", $mode == 0 ? $plog : "", 60) ];
-		push(@{$opts}, $logmanual);
+	if ($mode != 0 || &master_admin()) {
+		my $opts = [ [ 1, $text{'phpmode_noplog'} ],
+			  [ 2, $text{'phpmode_defplog'},
+			       "<tt>$defplog</tt>" ]
+			];
+		my $logmanual;
+		if (&master_admin()) {
+			$logmanual = [ 0, $text{'phpmode_fileplog'},
+				    &ui_textbox("plog", $mode == 0 ? $plog : "", 60) ];
+			push(@{$opts}, $logmanual);
+			}
+		print &ui_table_row(&hlink($text{'phpmode_plog'}, 'phplog'),
+			&ui_radio_table("plog_def", $mode, $opts));
 		}
-	print &ui_table_row(&hlink($text{'phpmode_plog'}, 'phplog'),
-		&ui_radio_table("plog_def", $mode, $opts));
 	}
 
 print &ui_hidden_table_end();

--- a/save_phpmode.cgi
+++ b/save_phpmode.cgi
@@ -98,6 +98,7 @@ if ($canv && !$d->{'alias'} && $mode && $mode ne "mod_php" &&
 				}
 			}
 		elsif ($in{"ver_$i"} ne $in{"oldver_$i"}) {
+			$phpnewver++;
 			# Directory version can be updated
 			&$first_print(&text('phpmode_savedir',
 				"<tt>".&html_escape($sd)."</tt>",
@@ -145,6 +146,9 @@ if (&can_php_error_log($mode)) {
 		elsif ($in{'plog_def'} == 2) {
 			# Use the default log
 			$plog = $defplog;
+			if ($mode ne $oldmode || $phpnewver) {
+				$oldplog = -1;
+				}
 			}
 		else {
 			# Custom path

--- a/save_phpmode.cgi
+++ b/save_phpmode.cgi
@@ -143,7 +143,8 @@ if (&can_php_error_log($mode)) {
 			if ($plog && $plog !~ /^\//) {
 				$plog = $d->{'home'}.'/'.$plog;
 				}
-			$plog =~ /^\/\S+$/ || &error($text{'phpmode_eplog'});
+			($plog =~ /^\/\S+$/ && &master_admin()) ||
+				&error($text{'phpmode_eplog'});
 			}
 		}
 	else {


### PR DESCRIPTION
Hello, Jamie!

This PR adds important improvements to how PHP error log file is controlled:

  1. Only master admin can set custom log file path
  2. If master admin has imposed custom log file path users won't be able to change it
  3. Respect `Server Owner Limits / Can edit PHP and website options` option before displaying PHP error log file option
  4. Don't loose error log path when changing PHP versions
