### PR TITLE
Add to use a new API to get domain hostname

### DIFF
--- a/feature-status.pl
+++ b/feature-status.pl
@@ -61,8 +61,7 @@ sub make_monitor
 {
 local ($d, $ssl) = @_;
 local $tmpl = &get_template($d->{'template'});
-local $host = $d->{'dns'} ? "www.".$d->{'dom'}
-			  : &get_domain_http_hostname($d);
+local $host = &get_domain_http_hostname($d);
 local $serv = { 'id' => $d->{'id'}.($ssl ? "_ssl" : "_web"),
 		'type' => 'http',
 		'desc' => $ssl ? "Website $host (SSL)" 
@@ -87,8 +86,7 @@ sub make_sslcert_monitor
 {
 local ($d) = @_;
 local $tmpl = &get_template($d->{'template'});
-local $host = $d->{'dns'} ? "www.".$d->{'dom'}
-			  : &get_domain_http_hostname($d);
+local $host = &get_domain_http_hostname($d);
 local $serv = { 'id' => $d->{'id'}."_sslcert",
 		'type' => 'sslcert',
 		'desc' => "SSL cert $host",
@@ -133,8 +131,7 @@ if ($d->{'dom'} ne $oldd->{'dom'} ||
 	# Update HTTP monitor
 	&$first_print($text{'save_status'});
 	local $serv = &status::get_service($d->{'id'}."_web");
-	local $host = $d->{'dns'} ? "www.".$d->{'dom'}
-				     : &get_domain_http_hostname($d);
+	local $host = &get_domain_http_hostname($d);
 	if ($serv) {
 		$serv->{'host'} = $host;
 		$serv->{'desc'} = "Website $host";

--- a/virtual-server-lib-funcs.pl
+++ b/virtual-server-lib-funcs.pl
@@ -18237,18 +18237,30 @@ local ($msg) = @_;
 }
 
 # get_domain_http_hostname(&domain)
-# Returns the best hostname for making HTTP requests to some domain, like
-# www.$DOM or just $DOM
+# Returns the best hostname for making HTTP requests
+# to some domain, like www.$DOM or just $DOM
 sub get_domain_http_hostname
 {
 my ($d) = @_;
+my $host = $d->{'dom'};
 foreach my $h ("www.$d->{'dom'}", $d->{'dom'}) {
 	my $ip = &to_ipaddress($h);
 	if ($ip && $ip eq $d->{'ip'}) {
-		return $h;
+		$host = $h;
+		last;
 		}
 	}
-return $d->{'dom'};	# Fallback
+if (defined(&get_http_redirect)) {
+	my $hostrs =
+	    &get_http_redirect(
+	        (&domain_has_ssl($d) ?
+	            "https" : "http")."://$host");
+	if ($hostrs->{'redir'} &&
+	    $hostrs->{'redir'}->{'host'} =~ /\Q$host\E/) {
+		$host = $hostrs->{'redir'}->{'host'};
+		}
+	}
+return $host;
 }
 
 # date_to_time(date-string, [gmt], [end-of-day])


### PR DESCRIPTION
Related to https://github.com/webmin/webmin/pull/1908 and [unable-to-install-opencart#120408](https://forum.virtualmin.com/t/virtualmin-pro-unable-to-install-opencart-using-the-autoinstaller/120408/31)

The main issue in [unable-to-install-opencart#120408](https://forum.virtualmin.com/t/virtualmin-pro-unable-to-install-opencart-using-the-autoinstaller/120408/31) is actually because a user has a redirect setup from `dom.com` to `www.dom.com`, and this is the actual reason why database setup in that ticket was failing! Before, we were checking  manually only for `www.dom.com`, however technically, a redirect can be setup to any alias, e.g. `www3.dom.com`, so I think this is the way to fix it generally, by simply testing the redirect and making sure it's inside of the main domain.

Please give it a closer look, Jamie. It worked for me in my tests!