### PR TITLE
Fix PHP-FPM detection in openSUSE

### DIFF
--- a/php-lib.pl
+++ b/php-lib.pl
@@ -2050,6 +2050,7 @@ foreach my $pname (@pkgnames) {
 	my @verdirs;
 	DIR: foreach my $cdir ("/etc/php-fpm.d",
 			       "/etc/php*/fpm/pool.d",
+			       "/etc/php*/fpm/php-fpm.d",
 			       "/etc/php/*/fpm/pool.d",
 			       "/etc/opt/remi/php*/php-fpm.d",
 			       "/etc/opt/rh/rh-php*/php-fpm.d",


### PR DESCRIPTION
The PHP-FPM pool files are located in `/etc/php8/fpm/php-fpm.d` by default in openSUSE.