### PR TITLE
Fix to check if jail is enabled first

### DIFF
--- a/php-lib.pl
+++ b/php-lib.pl
@@ -2420,8 +2420,10 @@ else {
 		}
 	}
 my $parent = $d->{'parent'} ? &get_domain_by($d->{'parent'}) : $d;
-my $dir = &get_domain_jailkit($parent);
-&save_php_fpm_config_value($d, "chroot", $dir);
+if ($parent->{'jail'}) {
+	my $dir = &get_domain_jailkit($parent);
+	&save_php_fpm_config_value($d, "chroot", $dir);
+	}
 &unlock_file($file);
 if ($port =~ /^\// && !-e $port) {
 	# Pre-create the socket file


### PR DESCRIPTION
Jamie, I don't think we need to create `chroot` in FPM pool unless jail for domain is enabled.


https://github.com/virtualmin/virtualmin-gpl/issues/658#issuecomment-1744540392