### PR TITLE
Fix detection of external IPv4

### DIFF
--- a/domain_form.cgi
+++ b/domain_form.cgi
@@ -669,7 +669,7 @@ else {
 
 # Show DNS IP address field
 if (&can_dnsip()) {
-	my $def_dns_ip = &get_dns_ip($resel);
+	my $def_dns_ip = $config{'external_ip_cache'} || &get_dns_ip($resel);
 	my $defmsg = $def_dns_ip || $text{'spf_default2'};
 	print &ui_table_row(&hlink($text{'edit_dnsip'}, "edit_dnsip"),
 		&ui_opt_textbox("dns_ip",

--- a/lang/en
+++ b/lang/en
@@ -1957,6 +1957,8 @@ check_defip=Default IPv4 address for virtual servers is $1
 check_defip6=Default IPv6 address for virtual servers is $1
 check_dnsip1=External IP address for DNS records is set to $1, which matches the detected external address
 check_dnsip2=Default IP address is set to $1, which matches the detected external address
+check_dnsip3=Detected external IPv4 address is $1
+check_ednsip3=Could not detect external IPv4 address
 check_ednsip1=External IP address for DNS records is set to $1, but the detected external address is actually $2. This may cause DNS records for Virtualmin domains to point to the wrong system
 check_ednsip2=Default IP address is set to $1, but the detected external address is actually $2. This is typically the result of being behind a NAT firewall, and should be corrected on the <a href='$3'>module configuration</a> page
 check_ewebsuexecbin=The <tt>suexec</tt> command was not found on your system

--- a/virtual-server-lib-funcs.pl
+++ b/virtual-server-lib-funcs.pl
@@ -15912,6 +15912,15 @@ if ($config{'dns_ip'} ne '*') {
 				"../config.cgi?$module_name"), 'warn'));
 		}
 	}
+else {
+	my $ext_ip = &get_external_ip_address();
+	if ($ext_ip) {
+		&$second_print(&text('check_dnsip3', $ext_ip));
+		}
+	else {
+		&$second_print(&ui_text_color($text{'check_ednsip3'}, 'warn'));
+		}
+	}
 
 # Make sure local group exists
 if ($config{'localgroup'} && !defined(getgrnam($config{'localgroup'}))) {


### PR DESCRIPTION
This PR address [this](https://forum.virtualmin.com/t/load-the-page-create-virtual-server-takes-forever/123035/17) reported issue.

  1. It will show previously cached IPv4 address if available.
  2. Upon config check external IP address cache will be updated 
