### PR TITLE
Fix EC support for `cert_file_info` sub

### DIFF
--- a/feature-ssl.pl
+++ b/feature-ssl.pl
@@ -1141,9 +1141,16 @@ while(<OUT>) {
 	if (/^\s+([0-9a-f:]+)\s*$/ && $inmodulus) {
 		$rv{'modulus'} .= $1;
 		}
+	# RSA exponent
 	if (/Exponent:\s*(\d+)/) {
 		$rv{'exponent'} = $1;
 		$inmodulus = 0;
+		}
+	# ECC properties
+	elsif (/(ASN1\s+OID):\s*(\S+)/ || /(NIST\s+CURVE):\s*(\S+)/) {
+		$inmodulus = 0;
+		my $comma = $rv{'exponent'} ? ", " : "";
+		$rv{'exponent'} .= "$comma$1: $2";
 		}
 	}
 close(OUT);

--- a/feature-ssl.pl
+++ b/feature-ssl.pl
@@ -1129,10 +1129,13 @@ while(<OUT>) {
 				}
 			}
 		}
-	if (/RSA\s+Public\s+Key:\s+\((\d+)\s+bit/) {
+	if (/RSA\s+Public\s+Key:\s+\((\d+)\s*bit/) {
 		$rv{'size'} = $1;
 		}
-	if (/EC\s+Public\s+Key:\s+\((\d+)\s+bit/) {
+	elsif (/EC\s+Public\s+Key:\s+\((\d+)\s*bit/) {
+		$rv{'size'} = $1;
+		}
+	elsif (/Public-Key:\s+\((\d+)\s*bit/) {
 		$rv{'size'} = $1;
 		}
 	if (/Modulus\s*\(.*\):/ || /Modulus:/ || /pub:/) {

--- a/feature-ssl.pl
+++ b/feature-ssl.pl
@@ -1135,7 +1135,7 @@ while(<OUT>) {
 	if (/EC\s+Public\s+Key:\s+\((\d+)\s+bit/) {
 		$rv{'size'} = $1;
 		}
-	if (/Modulus\s*\(.*\):/ || /Modulus:/) {
+	if (/Modulus\s*\(.*\):/ || /Modulus:/ || /pub:/) {
 		$inmodulus = 1;
 		}
 	if (/^\s+([0-9a-f:]+)\s*$/ && $inmodulus) {

--- a/get-ssl.pl
+++ b/get-ssl.pl
@@ -73,10 +73,11 @@ if (!$chain) {
 if ($cafile) {
 	print "ca: ",$cafile,"\n";
 	}
-print "type: ",&get_ssl_key_type(
+my $keytype = &get_ssl_key_type(
 		&get_website_ssl_file($d, "key"),
-		$d->{'ssl_pass'}),"\n";
-foreach $i (@cert_attributes) {
+		$d->{'ssl_pass'});
+print "type: $keytype\n";
+foreach my $i (@cert_attributes) {
 	$v = $info->{$i};
 	if (ref($v)) {
 		foreach my $vv (@$v) {
@@ -84,6 +85,10 @@ foreach $i (@cert_attributes) {
 			}
 		}
 	elsif ($v) {
+		if ($keytype =~ /^ec/) {
+			$i = "pub" if ($i eq "modulus");
+			$i = "properties" if ($i eq "exponent");
+			}
 		print $i,": ",$v,"\n";
 		}
 	}


### PR DESCRIPTION
Jamie hi!

I have noticed that **SSL Certificate** page for a domain in Virtualmin always had turquoise button displayed at the bottom of the screen, suggesting to use this SSL certificate as the default in Webmin, Usermin, Dovecot, Postfix and MariaDB, in case virtual server used EC certificate type.

I started digging and found out that EC certificate doesn't have modulus and and exponent properties.

This PR fixes the correct handling for both RSA and EC certificate types.

Also, it fixes the key size detection to support new format.