### PR TITLE
Fix certificate key size test for RSA only

### DIFF
--- a/feature-ssl.pl
+++ b/feature-ssl.pl
@@ -1129,6 +1129,10 @@ while(<OUT>) {
 				}
 			}
 		}
+	# Try to detect key algorithm
+	if (/Key\s+Algorithm:.*?(rsa|ec)[EP]/) {
+		$rv{'algo'} = $1;
+		}
 	if (/RSA\s+Public\s+Key:\s+\((\d+)\s*bit/) {
 		$rv{'size'} = $1;
 		}
@@ -1138,8 +1142,15 @@ while(<OUT>) {
 	elsif (/Public-Key:\s+\((\d+)\s*bit/) {
 		$rv{'size'} = $1;
 		}
-	if (/Modulus\s*\(.*\):/ || /Modulus:/ || /pub:/) {
+	if (/Modulus\s*\(.*\):/ || /Modulus:/) {
 		$inmodulus = 1;
+		# RSA algo
+		$rv{'algo'} = "rsa" if (!$rv{'algo'});
+		}
+	elsif (/pub:/) {
+		$inmodulus = 1;
+		# ECC algo
+		$rv{'algo'} = 'ec' if (!$rv{'algo'});
 		}
 	if (/^\s+([0-9a-f:]+)\s*$/ && $inmodulus) {
 		$rv{'modulus'} .= $1;

--- a/virtual-server-lib-funcs.pl
+++ b/virtual-server-lib-funcs.pl
@@ -11659,7 +11659,7 @@ if ($ENV{'HTTPS'} eq 'ON') {
 	local $certfile = $miniserv{'certfile'} || $miniserv{'keyfile'};
 	if ($certfile) {
 		local $cert = &cert_file_info($certfile);
-		if ($cert->{'size'} && $cert->{'size'} < 2048) {
+		if ($cert->{'algo'} eq 'rsa' && $cert->{'size'} && $cert->{'size'} < 2048) {
 			# Too small!
 			$small = $cert;
 			}

--- a/virtual-server-lib-funcs.pl
+++ b/virtual-server-lib-funcs.pl
@@ -11676,7 +11676,12 @@ if ($small) {
 			   $small->{'issuer_o'},
 			   $small->{'issuer_cn'},
 			   )."<p>\n";
-	$alert_text .= &ui_form_start("@{[&get_webprefix_safe()]}/webmin/edit_ssl.cgi");
+	my $formlink = "@{[&get_webprefix_safe()]}/webmin/edit_ssl.cgi";
+	my $domid = &get_domain_by('dom', $small->{'cn'});
+	if ($domid) {
+		$formlink = "@{[&get_webprefix_safe()]}/$module_name/cert_form.cgi?dom=$domid";
+		}
+	$alert_text .= &ui_form_start($formlink);
 	$alert_text .= &ui_hidden("mode", $msg eq 'licence_smallself' ?
 					'create' : $small->{'issuer_o'} =~ /let.*?encrypt/i ?
 							'lets' : 'csr');

--- a/virtual-server-lib-funcs.pl
+++ b/virtual-server-lib-funcs.pl
@@ -11683,7 +11683,7 @@ if ($small) {
 		}
 	$alert_text .= &ui_form_start($formlink);
 	$alert_text .= &ui_hidden("mode", $msg eq 'licence_smallself' ?
-					'create' : $small->{'issuer_o'} =~ /let.*?encrypt/i ?
+					'create' : &is_letsencrypt_cert($small) ?
 							'lets' : 'csr');
 	$alert_text .= &ui_submit($msg eq 'licence_smallself' ?
 				$text{'licence_newcert'} :

--- a/virtual-server-lib-funcs.pl
+++ b/virtual-server-lib-funcs.pl
@@ -11670,15 +11670,16 @@ if ($small) {
 	local $msg = $small->{'issuer_c'} eq $small->{'c'} &&
 		     $small->{'issuer_o'} eq $small->{'o'} ?
 			'licence_smallself' : 'licence_smallcert';
-	$alert_text .= "<b>".&text($msg,
+	$alert_text .= &text($msg,
 			   $small->{'size'},
-			   $small->{'cn'},
-			   $small->{'c'} || $small->{'o'},
-			   $small->{'issuer_c'} || $small->{'issuer_o'},
-			   )."</b><p>\n";
+			   "<tt>$small->{'cn'}</tt>",
+			   $small->{'issuer_o'},
+			   $small->{'issuer_cn'},
+			   )."<p>\n";
 	$alert_text .= &ui_form_start("@{[&get_webprefix_safe()]}/webmin/edit_ssl.cgi");
 	$alert_text .= &ui_hidden("mode", $msg eq 'licence_smallself' ?
-					'create' : 'csr');
+					'create' : $small->{'issuer_o'} =~ /let.*?encrypt/i ?
+							'lets' : 'csr');
 	$alert_text .= &ui_submit($msg eq 'licence_smallself' ?
 				$text{'licence_newcert'} :
 				$text{'licence_newcsr'});


### PR DESCRIPTION
Hello Jamie!

After yesterday's PR, as the key size now correctly fetched, the false positive message started to appear for the certificate using EC algo, e.g.:

<img width="1095" alt="image" src="https://github.com/virtualmin/virtualmin-gpl/assets/4426533/c0cd3c04-7e50-40ae-b59d-9937698caecc">


This PR fixes that and also a few small other tightly related issues. You can see 4 commits on this PR to get perspective what was changed.