### PR TITLE
Fix to prioritize sub-domains over aliases in sorting

### DIFF
--- a/virtual-server-lib-funcs.pl
+++ b/virtual-server-lib-funcs.pl
@@ -159,7 +159,7 @@ if ($sortfield eq 'user' || $sortfield eq 'sub') {
 			push(@catdoms, $sd);
 			foreach my $ad (grep { $_->{'alias'} eq $sd->{'id'} }
 					     @doms) {
-				$ad->{'indent'} = 2;
+				$ad->{'indent'} = 3;
 				push(@catdoms, $ad);
 				}
 			}

--- a/virtual-server-lib-funcs.pl
+++ b/virtual-server-lib-funcs.pl
@@ -153,10 +153,6 @@ if ($sortfield eq 'user' || $sortfield eq 'sub') {
 	local @catdoms;
 	foreach my $d (grep { !$_->{'parent'} } @doms) {
 		push(@catdoms, $d);
-		foreach my $ad (grep { $_->{'alias'} eq $d->{'id'} } @doms) {
-			$ad->{'indent'} = 2;
-			push(@catdoms, $ad);
-			}
 		foreach my $sd (grep { $_->{'parent'} eq $d->{'id'} &&
 				       !$_->{'alias'} } @doms) {
 			$sd->{'indent'} = 1;
@@ -166,6 +162,10 @@ if ($sortfield eq 'user' || $sortfield eq 'sub') {
 				$ad->{'indent'} = 2;
 				push(@catdoms, $ad);
 				}
+			}
+		foreach my $ad (grep { $_->{'alias'} eq $d->{'id'} } @doms) {
+			$ad->{'indent'} = 2;
+			push(@catdoms, $ad);
 			}
 		}
 	# Any domains that we missed due to their parent not being included


### PR DESCRIPTION
I noticed that domains in index page and nav menu aren't sorted correctly. Currently it prioritizes aliases over sub servers, and also doesn't make any difference between alias of top-level server and alias of sub-server e.g.:

<img width="960" alt="image" src="https://github.com/virtualmin/virtualmin-gpl/assets/4426533/21349954-09cc-4669-bd05-0000fb4d3cc7">


This changes makes it displayed correctly, e.g.:

<img width="957" alt="image" src="https://github.com/virtualmin/virtualmin-gpl/assets/4426533/a0c18d43-3745-4fa9-89f6-7d35a22cb0c8">

All tests were done with default sorting mode (`domains_sort` set to `sub`).