### PR TITLE
Fix to parse original log name with `tee` command

### DIFF
--- a/feature-web.pl
+++ b/feature-web.pl
@@ -1419,6 +1419,7 @@ else {
 sub extract_writelogs_path
 {
 local ($log, $dom) = @_;
+my $log_ = $log;
 local $w = &apache::wsplit($log);	# Extract first word
 $log = $w->[0];
 if ($log =~ /^\|\Q$writelogs_cmd\E\s+(\S+)\s+(\S+)/) {
@@ -1434,8 +1435,8 @@ if ($log =~ /^\|\Q$writelogs_cmd\E\s+(\S+)\s+(\S+)/) {
 			}
 		}
 	}
-elsif ($log =~ /^(?:"|'|\\"|\\')?\|(\$)?(tee|\S+\/tee)(\s+\-a)?.*?([^'"\s]+(?:\Q$dom\E|\d{10,20})[^'"\s]+)/ ||
-       $log =~ /^(?:"|'|\\"|\\')?\|(\$)?(tee|\S+\/tee)(\s+\-a)?.*?([^'"\s]+.?[^'"\s]+)/) {
+elsif ($log_ =~ /^(?:"|'|\\"|\\')?\|(\$)?(tee|\S+\/tee)(\s+\-a)?.*?([^'"\s]+(?:\Q$dom\E|\d{10,20})[^'"\s]+)/ ||
+       $log_ =~ /^(?:"|'|\\"|\\')?\|(\$)?(tee|\S+\/tee)(\s+\-a)?.*?([^'"\s]+.?[^'"\s]+)/) {
 	# Log via the tee command
 	$log = $4;
 	$log = $1 if ($log =~ /^"(.*)"$/);


### PR DESCRIPTION
This addresses the issue when the directive in Apache config starts with a single quote. 

For example this is parsed correctly by `apache::wsplit`:

```
ErrorLog "|/usr/bin/tee -a '/var/log/apache2/error.log' '/var/log/virtualmin/ubuntu22-pro.virtualmin.dev_error_log'"
```


but not this one:

```
ErrorLog '|/usr/bin/tee -a "/var/log/apache2/error.log" "/var/log/virtualmin/ubuntu22-pro.virtualmin.dev_error_log"'
```


which produces (after parsed by `apache::wsplit`) undesirable results, like:

```
[
  '\'|/usr/bin/tee',
  '-a',
  '/var/log/apache2/error.log',
  '/var/log/virtualmin/ubuntu22-pro.virtualmin.dev_error_log',
  '\''
]

```

So, the solution that works in all cases is to just parse on the original string.