### PR TITLE
Fix to check if resulting password meets requirements

### DIFF
--- a/virtual-server-lib-funcs.pl
+++ b/virtual-server-lib-funcs.pl
@@ -11086,22 +11086,25 @@ my $has_uppercase = sub { return $_[0] =~ /[A-Z]/; };
 my $has_lowercase = sub { return $_[0] =~ /[a-z]/; };
 my $has_digit = sub { return $_[0] =~ /[0-9]/; };
 my $has_special = sub { return $_[0] =~ /[\@\#\$\%\^\&\*\(\)\_\+\!\-\=\[\]\{\}\;\:\'\"\,\<\.\>\/\?\~\`\\]/; };
+my $has_unicode_chars = sub { return $_[0] =~ /(?![A-Za-z])\p{L}/; };
 # Dereference $chars ref only once
 my @chars = @$chars;
 # Determine the required character types based on $chars
-my $complexity_level = 0;
-$complexity_level++ if grep { $has_uppercase->($_) } @chars;
-$complexity_level++ if grep { $has_lowercase->($_) } @chars;
-$complexity_level++ if grep { $has_digit->($_) } @chars;
-$complexity_level++ if grep { $has_special->($_) } @chars;
+my %complexity_levels;
+$complexity_levels{'has_uppercase'} = 1 if grep { $has_uppercase->($_) } @chars;
+$complexity_levels{'has_lowercase'} = 1 if grep { $has_lowercase->($_) } @chars;
+$complexity_levels{'has_digit'} = 1 if grep { $has_digit->($_) } @chars;
+$complexity_levels{'has_special'} = 1 if grep { $has_special->($_) } @chars;
+$complexity_levels{'has_unicode_chars'} = 1 if grep { $has_unicode_chars->($_) } @chars;
 # Check if the number of required types exceeds the password length
-return -1 if ($complexity_level > $len || $complexity_level == 0);
+return -1 if (scalar(keys %complexity_levels) > $len);
 # Check if $pass contains at least one of each required type
 my $valid = 1;
-$valid = 0 if $complexity_level >= 1 && !grep { $has_uppercase->($pass) } @chars;
-$valid = 0 if $complexity_level >= 2 && !grep { $has_lowercase->($pass) } @chars;
-$valid = 0 if $complexity_level >= 3 && !grep { $has_digit->($pass) } @chars;
-$valid = 0 if $complexity_level >= 4 && !grep { $has_special->($pass) } @chars;
+$valid = 0 if $complexity_levels{'has_uppercase'} && !grep { $has_uppercase->($pass) } @chars;
+$valid = 0 if $complexity_levels{'has_lowercase'} && !grep { $has_lowercase->($pass) } @chars;
+$valid = 0 if $complexity_levels{'has_digit'} && !grep { $has_digit->($pass) } @chars;
+$valid = 0 if $complexity_levels{'has_special'} && !grep { $has_special->($pass) } @chars;
+$valid = 0 if $complexity_levels{'has_unicode_chars'} && !grep { $has_unicode_chars->($pass) } @chars;
 return $valid;
 }
 

--- a/virtual-server-lib-funcs.pl
+++ b/virtual-server-lib-funcs.pl
@@ -11082,8 +11082,10 @@ for (my $i = 0; $i < $passwd_chars*100; $i++) {
 return $random_password;
 }
 
-sub random_password_validate {
+sub random_password_validate
+{
 my ($chars, $len, $pass) = @_;
+# Define character type checks in a hash
 my %check = (
 	uppercase => qr/[A-Z]/,
 	lowercase => qr/[a-z]/,
@@ -11091,16 +11093,13 @@ my %check = (
 	special   => qr/[\@\#\$\%\^\&\*\(\)\_\+\!\-\=\[\]\{\}\;\:\'\"\,\<\.\>\/\?\~\`\\]/,
 	unicode   => qr/(?![A-Za-z])\p{L}/,
 	);
-
 # Determine required character types
 my %required = map {
 	my $__ = $_;
 	grep($_ =~ $check{$__}, @{$chars}) ? ($__ => 1) : ();
 } keys %check;
-
 # Return -1 if the number of required types exceeds the password length
 return -1 if scalar(keys %required) > $len;
-
 # Check if password contains one of each required types
 my $matches = grep { $pass =~ $check{$_} } keys %required;
 return 0 unless $matches == keys %required;

--- a/virtual-server-lib-funcs.pl
+++ b/virtual-server-lib-funcs.pl
@@ -11094,10 +11094,15 @@ my %check = (
 	unicode   => qr/(?![A-Za-z])\p{L}/,
 	);
 # Determine required character types
-my %required = map {
-	my $__ = $_;
-	grep($_ =~ $check{$__}, @{$chars}) ? ($__ => 1) : ();
-} keys %check;
+my %required;
+foreach my $key (keys %check) {
+	# If any character in @$chars matches the regex for this
+	# key, add the key to %required with a value of 1
+	if (grep { $_ =~ $check{$key} } @$chars) {
+		$required{$key} = 1;
+		}
+	}
+var_dump(\%required);
 # Return -1 if the number of required types exceeds the password length
 return -1 if scalar(keys %required) > $len;
 # Check if password contains one of each required types

--- a/virtual-server-lib-funcs.pl
+++ b/virtual-server-lib-funcs.pl
@@ -11102,7 +11102,6 @@ foreach my $key (keys %check) {
 		$required{$key} = 1;
 		}
 	}
-var_dump(\%required);
 # Return -1 if the number of required types exceeds the password length
 return -1 if scalar(keys %required) > $len;
 # Check if password contains one of each required types

--- a/virtual-server-lib-funcs.pl
+++ b/virtual-server-lib-funcs.pl
@@ -11060,6 +11060,8 @@ sub random_password
 &require_useradmin();
 my $random_password;
 my $len = $_[0] || $config{'passwd_length'} || 15;
+eval "utf8::decode(\$config{'passwd_chars'})"
+	if ($config{'passwd_chars'});
 my @passwd_chars = split(//, $config{'passwd_chars'});
 if (!@passwd_chars) {
 	@passwd_chars = @useradmin::random_password_chars;

--- a/virtual-server-lib-funcs.pl
+++ b/virtual-server-lib-funcs.pl
@@ -11058,20 +11058,25 @@ sub random_password
 {
 &seed_random();
 &require_useradmin();
-local $random_password;
-local $len = $_[0] || $config{'passwd_length'} || 15;
-local @passwd_chars = split(//, $config{'passwd_chars'});
+my $random_password;
+my $len = $_[0] || $config{'passwd_length'} || 15;
+my @passwd_chars = split(//, $config{'passwd_chars'});
 if (!@passwd_chars) {
 	@passwd_chars = @useradmin::random_password_chars;
 	}
-foreach (1 .. $len) {
-	$random_password .= $passwd_chars[rand(scalar(@passwd_chars))];
-	}
+# Number of characters to operate on
+my $passwd_chars = scalar(@passwd_chars);
 # Check resulting password and try again
 # if it doesn't meet the requirements
-return &random_password(@_)
-	if (&random_password_validate(
-		\@passwd_chars, $len, $random_password) == 0);
+for (my $i = 0; $i < $passwd_chars; $i++) {
+	$random_password = '';
+	foreach (1 .. $len) {
+		$random_password .= $passwd_chars[rand($passwd_chars)];
+		}
+	return $random_password
+		if (&random_password_validate(
+			\@passwd_chars, $len, $random_password) != 0);
+	}
 return $random_password;
 }
 


### PR DESCRIPTION
Jamie, this PR address the problem discussed [here](https://forum.virtualmin.com/t/virtualmin-password-generator-is-not-including-sometimes-digits-or-upper-letters/124604/4?u=ilia).

In this case it would be better not to use a new `&substitute_pattern()` because required password option isn't a regex.