### PR TITLE
Add support for forbidding features when creating or modifying some domains

### DIFF
--- a/create-domain.pl
+++ b/create-domain.pl
@@ -949,6 +949,13 @@ $derr = &virtual_server_depends(\%dom);
 $cerr = &virtual_server_clashes(\%dom);
 &usage($cerr) if ($cerr);
 
+# Check if features are not forbidden
+if (!$skipwarnings) {
+	foreach my $ff (&forbidden_domain_features(\%dom, 1)) {
+		$dom{$ff} && &usage("The feature $ff is not allowed for virtual server matching the hostname unless the --skip-warnings flag is given.");
+		}
+	}
+
 # Check for warnings, unless overriding
 @warns = &virtual_server_warnings(\%dom);
 if (@warns) {

--- a/domain_setup.cgi
+++ b/domain_setup.cgi
@@ -457,6 +457,11 @@ $cerr = &virtual_server_clashes(\%dom);
 $lerr = &virtual_server_limits(\%dom);
 &error($lerr) if ($lerr);
 
+# Check if features are not forbidden
+foreach my $ff (&forbidden_domain_features(\%dom, 1)) {
+	$dom{$ff} && &error(&text('setup_efeatforbidhostdef', $ff));
+	}
+
 # Update custom fields
 &parse_custom_fields(\%dom, \%in);
 

--- a/edit_domain.cgi
+++ b/edit_domain.cgi
@@ -342,7 +342,9 @@ if (!$d->{'disabled'}) {
 	@grid = ( );
 	@grid_order_initial = ( );
 	$i = 0;
-	foreach my $f (&list_possible_domain_features($d)) {
+	my @domain_possible_features = &list_possible_domain_features($d);
+	&filter_possible_domain_features(\@domain_possible_features, $d);
+	foreach my $f (@domain_possible_features) {
 		# Don't show features that are chained from another, if both
 		# are in the same state
 		my @ch = &can_chained_feature($f, 1);

--- a/enable-feature.pl
+++ b/enable-feature.pl
@@ -102,8 +102,9 @@ foreach $d (sort { ($a->{'alias'} ? 2 : $a->{'parent'} ? 1 : 0) <=>
 	my $f;
 	foreach $f (&list_ordered_features(\%newdom)) {
 		if ($feature{$f} || $plugin{$f}) {
-			if (grep {$_ eq $f} @forbidden_domain_features) {
-				&$second_print(".. the feature $f cannot be enabled for this type of virtual server");
+			if (!$skipwarnings &&
+			    grep {$_ eq $f} @forbidden_domain_features) {
+				&$second_print(".. the feature $f cannot be enabled for this type of virtual server unless the --skip-warnings flag is given");
 				$failed = 1;
 				next DOMAIN;
 				}

--- a/enable-feature.pl
+++ b/enable-feature.pl
@@ -93,6 +93,7 @@ $failed = 0;
 DOMAIN:
 foreach $d (sort { ($a->{'alias'} ? 2 : $a->{'parent'} ? 1 : 0) <=>
 		   ($b->{'alias'} ? 2 : $b->{'parent'} ? 1 : 0) } @doms) {
+	my @forbidden_domain_features = &forbidden_domain_features($d);
 	&$first_print("Updating server $d->{'dom'} ..");
 
 	# Check for various clashes
@@ -101,6 +102,11 @@ foreach $d (sort { ($a->{'alias'} ? 2 : $a->{'parent'} ? 1 : 0) <=>
 	my $f;
 	foreach $f (&list_ordered_features(\%newdom)) {
 		if ($feature{$f} || $plugin{$f}) {
+			if (grep {$_ eq $f} @forbidden_domain_features) {
+				&$second_print(".. the feature $f cannot be enabled for this type of virtual server");
+				$failed = 1;
+				next DOMAIN;
+				}
 			$newdom{$f} = 1;
 			if (!$d->{$f}) {
 				$check{$f}++;

--- a/lang/en
+++ b/lang/en
@@ -532,6 +532,7 @@ setup_edefip=New virtual server has no IP address! Perhaps Virtualmin could not 
 setup_qmailme=This domain name cannot be used for Qmail, as it is the same as the server's hostname $1 (from the <tt>control/me</tt> file)
 setup_eslashpass=Passwords containing a backslash are not supported by MySQL
 setup_etmpl=You are not allowed to use the selected template
+setup_efeatforbid=The feature $1 is not allowed for this virtual server
 
 setup_title=Setting Up Virtual Server
 setup_group=Creating administration group $1 ..

--- a/lang/en
+++ b/lang/en
@@ -532,7 +532,6 @@ setup_edefip=New virtual server has no IP address! Perhaps Virtualmin could not 
 setup_qmailme=This domain name cannot be used for Qmail, as it is the same as the server's hostname $1 (from the <tt>control/me</tt> file)
 setup_eslashpass=Passwords containing a backslash are not supported by MySQL
 setup_etmpl=You are not allowed to use the selected template
-setup_efeatforbid=The feature $1 is not allowed for this virtual server
 setup_efeatforbidhostdef=The feature $1 is not allowed for virtual server matching the hostname
 
 setup_title=Setting Up Virtual Server

--- a/lang/en
+++ b/lang/en
@@ -533,6 +533,7 @@ setup_qmailme=This domain name cannot be used for Qmail, as it is the same as th
 setup_eslashpass=Passwords containing a backslash are not supported by MySQL
 setup_etmpl=You are not allowed to use the selected template
 setup_efeatforbid=The feature $1 is not allowed for this virtual server
+setup_efeatforbidhostdef=The feature $1 is not allowed for virtual server matching the hostname
 
 setup_title=Setting Up Virtual Server
 setup_group=Creating administration group $1 ..

--- a/save_domain.cgi
+++ b/save_domain.cgi
@@ -94,9 +94,14 @@ if (&has_home_quotas() && !$d->{'parent'} && &can_edit_quotas($d)) {
 	$newdom{'quota'} = $in{'quota_def'} ? undef :
 				&quota_parse('quota', "home");
 	}
+my @forbidden_domain_features = &forbidden_domain_features($d);
 if (!$d->{'disabled'}) {
 	foreach $f (@dom_features, &list_feature_plugins()) {
 		if ($in{$f}) {
+			if (grep {$_ eq $f} @forbidden_domain_features) {
+				&error(&text('setup_efeatforbid',
+					"<tt>@{[&html_escape($f)]}</tt>"));
+				}
 			$newdom{$f} = 1;
 			if (!$d->{$f}) {
 				$check{$f}++;

--- a/save_domain.cgi
+++ b/save_domain.cgi
@@ -99,7 +99,7 @@ if (!$d->{'disabled'}) {
 	foreach $f (@dom_features, &list_feature_plugins()) {
 		if ($in{$f}) {
 			if (grep {$_ eq $f} @forbidden_domain_features) {
-				&error(&text('setup_efeatforbid',
+				&error(&text('setup_efeatforbidhostdef',
 					"<tt>@{[&html_escape($f)]}</tt>"));
 				}
 			$newdom{$f} = 1;

--- a/virtual-server-lib-funcs.pl
+++ b/virtual-server-lib-funcs.pl
@@ -19714,6 +19714,7 @@ sub forbidden_domain_features
 {
 my ($d) = @_;
 my @rv;
+return @rv if ($config{'nocheck_forbidden_domain_features'});
 # Not allowed features for host default domain
 if ($d->{'dom'} eq $config{'defaultdomain_name'}) {
 	push(@rv, 'spam', 'virus', 'mail');

--- a/virtual-server-lib-funcs.pl
+++ b/virtual-server-lib-funcs.pl
@@ -19708,6 +19708,30 @@ foreach my $f (&domain_features($d)) {
 return @rv;
 }
 
+# forbidden_domain_features(&domain)
+# Returns a list of features that cannot be enabled for some domain
+sub forbidden_domain_features
+{
+my ($d) = @_;
+my @rv;
+# Not allowed features for host default domain
+if ($d->{'dom'} eq $config{'defaultdomain_name'}) {
+	push(@rv, 'spam', 'virus', 'mail');
+	}
+return @rv;
+}
+
+# filter_possible_domain_features(&features, &domain)
+# Given a list of features, returns only those that aren't forbidden for domain
+sub filter_possible_domain_features
+{
+my ($features, $d) = @_;
+my @forbidden = forbidden_domain_features($d);
+@$features = grep {
+	my $feature = $_;
+        !grep { $feature eq $_ } @forbidden; } @$features;
+}
+
 # list_possible_domain_plugins(&domain)
 # Given a domain, returns a list of plugin features that can possibly be enabled
 # or disabled for it

--- a/virtual-server-lib-funcs.pl
+++ b/virtual-server-lib-funcs.pl
@@ -19717,7 +19717,11 @@ my @rv;
 return @rv if ($config{'nocheck_forbidden_domain_features'});
 # Not allowed features for host default domain
 if ($d->{'dom'} eq &get_system_hostname()) {
-	push(@rv, 'spam', 'virus', 'mail');
+	my @forbidden = ('spam', 'virus', 'mail');
+	foreach $ff (@forbidden) {
+		# If not already forced-enabled using CLI
+		push(@rv, $ff) if (!$d->{$ff});
+		}
 	}
 return @rv;
 }

--- a/virtual-server-lib-funcs.pl
+++ b/virtual-server-lib-funcs.pl
@@ -19716,7 +19716,7 @@ my ($d) = @_;
 my @rv;
 return @rv if ($config{'nocheck_forbidden_domain_features'});
 # Not allowed features for host default domain
-if ($d->{'dom'} eq $config{'defaultdomain_name'}) {
+if ($d->{'dom'} eq &get_system_hostname()) {
 	push(@rv, 'spam', 'virus', 'mail');
 	}
 return @rv;
@@ -19727,7 +19727,7 @@ return @rv;
 sub filter_possible_domain_features
 {
 my ($features, $d) = @_;
-my @forbidden = forbidden_domain_features($d);
+my @forbidden = &forbidden_domain_features($d);
 @$features = grep {
 	my $feature = $_;
         !grep { $feature eq $_ } @forbidden; } @$features;

--- a/virtual-server-lib-funcs.pl
+++ b/virtual-server-lib-funcs.pl
@@ -19708,30 +19708,30 @@ foreach my $f (&domain_features($d)) {
 return @rv;
 }
 
-# forbidden_domain_features(&domain)
+# forbidden_domain_features(&domain, [creating])
 # Returns a list of features that cannot be enabled for some domain
 sub forbidden_domain_features
 {
-my ($d) = @_;
+my ($d, $new) = @_;
 my @rv;
 return @rv if ($config{'nocheck_forbidden_domain_features'});
 # Not allowed features for host default domain
 if ($d->{'dom'} eq &get_system_hostname()) {
-	my @forbidden = ('spam', 'virus', 'mail');
+	my @forbidden = ('mail', 'spam', 'virus');
 	foreach $ff (@forbidden) {
 		# If not already forced-enabled using CLI
-		push(@rv, $ff) if (!$d->{$ff});
+		push(@rv, $ff) if (!$d->{$ff} || $new);
 		}
 	}
 return @rv;
 }
 
-# filter_possible_domain_features(&features, &domain)
+# filter_possible_domain_features(&features, &domain, [creating])
 # Given a list of features, returns only those that aren't forbidden for domain
 sub filter_possible_domain_features
 {
-my ($features, $d) = @_;
-my @forbidden = &forbidden_domain_features($d);
+my ($features, $d, $new) = @_;
+my @forbidden = &forbidden_domain_features($d, $new);
 @$features = grep {
 	my $feature = $_;
         !grep { $feature eq $_ } @forbidden; } @$features;


### PR DESCRIPTION
Hey Jamie!

As discussed in [this thread](https://forum.virtualmin.com/t/new-installer-questions-about-the-default-ssl-certificate/126684/10?u=ilia) this PR protects users from enabling mail for a virtual server that matches hostname.