### PR TITLE
Fix to set default domain serve as default service certificate

### DIFF
--- a/virtual-server-lib-funcs.pl
+++ b/virtual-server-lib-funcs.pl
@@ -20379,8 +20379,8 @@ if (&can_default_website(\%dom)) {
 &push_all_print();
 &set_all_null_print();
 foreach my $st (&list_service_ssl_cert_types()) {
-	($a) = grep { !$_->{'d'} && $_->{'id'} eq $st->{'id'} }
-		&get_all_domain_service_ssl_certs(\%dom);
+	my ($a) = grep { !$_->{'d'} && $_->{'id'} eq $st->{'id'} }
+			&get_all_domain_service_ssl_certs(\%dom);
 	if (!$a) {
 		my $cfunc = "copy_".$st->{'id'}."_ssl_service";
 		&$cfunc(\%dom);

--- a/virtual-server-lib-funcs.pl
+++ b/virtual-server-lib-funcs.pl
@@ -20375,6 +20375,18 @@ $config{'default_domain_ssl'} = 1
 if (&can_default_website(\%dom)) {
 	&set_default_website(\%dom);
 	}
+# Enable as default domain for all services
+&push_all_print();
+&set_all_null_print();
+foreach my $st (&list_service_ssl_cert_types()) {
+	($a) = grep { !$_->{'d'} && $_->{'id'} eq $st->{'id'} }
+		&get_all_domain_service_ssl_certs(\%dom);
+	if (!$a) {
+		my $cfunc = "copy_".$st->{'id'}."_ssl_service";
+		&$cfunc(\%dom);
+		}
+	}
+&pop_all_print();
 &run_post_actions_silently();
 &unlock_domain(\%dom);
 &unlock_domain_name($system_host_name);


### PR DESCRIPTION
This patch addresses what was [discussed here](https://forum.virtualmin.com/t/how-to-manage-default-ssl-cert-for-hostname/126970/15?u=ilia). 