### PR TITLE
Fix new WebSockets proxy API after extensive testings

### DIFF
--- a/balancer-lib.pl
+++ b/balancer-lib.pl
@@ -41,7 +41,7 @@ foreach my $pp (&apache::find_directive("ProxyPass", $vconf)) {
 		       'none' => 1 };
 		}
 	if ($b) {
-		my ($rwr) = grep { /^\Q$b->{'path'}\E\s+ws:\/\// } @rwr;
+		my ($rwr) = grep { /^\Q^$b->{'path'}?(.*)\E\s+"ws?s:\/\// } @rwr;
 		$b->{'websockets'} = 1 if ($rwr);
 		push(@rv, $b);
 		}
@@ -156,7 +156,7 @@ foreach my $port (@ports) {
 		push(@rwc, &websockets_rewriteconds());
 		&apache::save_directive("RewriteCond", \@rwc, $vconf, $conf, 1);
 		my @rwr = &apache::find_directive("RewriteRule", $vconf);
-		push(@rwr, "$balancer->{'path'} $wsurl [P]");
+		push(@rwr, "^$balancer->{'path'}?(.*) \"$wsurl\" [P]");
 		&apache::save_directive("RewriteRule", \@rwr, $vconf, $conf, 1);
 		}
 	&flush_file_lines($virt->{'file'});
@@ -234,7 +234,7 @@ foreach my $port (@ports) {
 	# Remove any rewrite directives for websockets
 	my @rwc = &apache::find_directive("RewriteCond", $vconf);
 	my @rwr = &apache::find_directive("RewriteRule", $vconf);
-	my ($rwr) = grep { /^\Q$balancer->{'path'}\E\s+ws:/ } @rwr;
+	my ($rwr) = grep { /^\Q^$balancer->{'path'}?(.*)\E\s+"ws?s:/ } @rwr;
 	if ($rwr) {
 		# There is one, delete it
 		@rwr = grep { $_ ne $rwr } @rwr;
@@ -316,7 +316,7 @@ foreach my $port (@ports) {
 	# Fix any RewriteRule for websockets
 	my @rwc = &apache::find_directive("RewriteCond", $vconf);
 	my @rwr = &apache::find_directive("RewriteRule", $vconf);
-	my ($rwr) = grep { /^\Q$oldb->{'path'}\E\s+ws:/ } @rwr;
+	my ($rwr) = grep { /^\Q^$oldb->{'path'}?(.*)\E\s+"ws?s:/ } @rwr;
 	my $wsurl;
 	my $wsprot;
 	if (!$b->{'none'} && $b->{'websockets'}) {
@@ -336,14 +336,14 @@ foreach my $port (@ports) {
 	elsif (!$b->{'none'} && $b->{'websockets'} && $rwr) {
 		# Need to update path
 		my $idx = &indexof($rwr, @rwr);
-		$rwr[$idx] = "$b->{'path'} $wsurl [P]";
+		$rwr[$idx] = "^$b->{'path'}?(.*) \"$wsurl\" [P]";
 		&apache::save_directive("RewriteRule", \@rwr, $vconf, $conf);
 		}
 	elsif (!$b->{'none'} && $b->{'websockets'} && !$rwr) {
 		# Need to add
 		push(@rwc, &websockets_rewriteconds());
 		&apache::save_directive("RewriteCond", \@rwc, $vconf, $conf, 1);
-		push(@rwr, "$b->{'path'} $wsurl [P]");
+		push(@rwr, "^$b->{'path'}?(.*) \"$wsurl\" [P]");
 		&apache::save_directive("RewriteRule", \@rwr, $vconf, $conf, 1);
 		}
 

--- a/balancer-lib.pl
+++ b/balancer-lib.pl
@@ -270,7 +270,7 @@ foreach my $port (@ports) {
 	next if (!$virt);
 
 	# Find and fix the ProxyPass and ProxyPassReverse
-	my $slash = $b->{'path'} eq '/' ? '/' : undef;
+	my $slash = $b->{'path'} eq '/' || $b->{'path'} =~ /\/$/ ? '/' : undef;
 	foreach my $dir ("ProxyPass", "ProxyPassReverse") {
 		my @npp;
 		foreach my $pp (&apache::find_directive($dir, $vconf)) {

--- a/balancer-lib.pl
+++ b/balancer-lib.pl
@@ -148,9 +148,10 @@ foreach my $port (@ports) {
 	if ($balancer->{'websockets'} && !$balancer->{'none'}) {
 		# Add RewriteCond and RewriteRule for the path
 		my $wsurl = $balancer->{'urls'}->[0];
+		my $wsprot = $wsurl =~ /^https:/i ? "wss" : "ws";
 		$wsurl =~ s/^(http|https):\/\///;
 		$wsurl =~ s/\/$//;
-		$wsurl = "ws://$wsurl%{REQUEST_URI}";
+		$wsurl = "$wsprot://$wsurl/\$1";
 		my @rwc = &apache::find_directive("RewriteCond", $vconf);
 		push(@rwc, &websockets_rewriteconds());
 		&apache::save_directive("RewriteCond", \@rwc, $vconf, $conf, 1);
@@ -317,11 +318,13 @@ foreach my $port (@ports) {
 	my @rwr = &apache::find_directive("RewriteRule", $vconf);
 	my ($rwr) = grep { /^\Q$oldb->{'path'}\E\s+ws:/ } @rwr;
 	my $wsurl;
+	my $wsprot;
 	if (!$b->{'none'} && $b->{'websockets'}) {
 		$wsurl = $b->{'urls'}->[0];
+		$wsprot = $wsurl =~ /^https:/i ? "wss" : "ws";
 		$wsurl =~ s/^(http|https):\/\///;
 		$wsurl =~ s/\/$//;
-		$wsurl = "ws://$wsurl%{REQUEST_URI}";
+		$wsurl = "$wsprot://$wsurl/\$1";
 		}
 	if (($b->{'none'} || !$b->{'websockets'}) && $rwr) {
 		# Need to remove entirely


### PR DESCRIPTION
Hey Jamie!

As it was [discussed here](https://github.com/virtualmin/virtualmin-gpl/issues/305#issuecomment-2151405458), I decided to run tests using this new feature and found and fixed a few crucial bugs!

1. We must avoid mixed content by using correct protocol for the WebSocket;
2. Using `%{REQUEST_URI}` inserts the full original request URI, including `$b->{'path'}` and everything after it, so it just won't work, and therefore we should use `RewriteRule` with substitution string;
3. If a balancer path originally ends with `/`, like `/webmin/` then it would break everything just by a simple form re-save (without making any changes)

The test case was a proxy to Webmin.

Apache config: 
  1. Path was set to `/webmin/`;
  2. Backend URL was set to `https://localhost:10000/`.

Webmin:
 1. `/etc/webmin/config` file:
    ```
    referers=127.0.0.1 ubuntu24-pro.virtualmin.dev
    webprefix=/webmin
    webprefixnoredir=1
    ```
 2. `/etc/webmin/miniserv.conf` file:
    ```
    cookiepath=/webmin
    ```
    
    