### PR TITLE
Forbid allowing MariaDB users to re-grant privileges

### DIFF
--- a/feature-mysql.pl
+++ b/feature-mysql.pl
@@ -246,7 +246,7 @@ if ($variant eq "mariadb" && &compare_versions($ver, "10.4") >= 0 ||
 			if ($qddb ne $qdb) {
 				eval {
 					local $main::error_must_die = 1;
-					&execute_dom_sql($d, $mysql::master_db, "grant all privileges on `$qddb`.* to '$user'\@'$host' with grant option");
+					&execute_dom_sql($d, $mysql::master_db, "grant all privileges on `$qddb`.* to '$user'\@'$host'");
 					}
 				}
 			}
@@ -254,7 +254,7 @@ if ($variant eq "mariadb" && &compare_versions($ver, "10.4") >= 0 ||
 	# Update given database
 	eval {
 		local $main::error_must_die = 1;
-		&execute_dom_sql($d, $mysql::master_db, "grant all privileges on `$qdb`.* to '$user'\@'$host' with grant option");
+		&execute_dom_sql($d, $mysql::master_db, "grant all privileges on `$qdb`.* to '$user'\@'$host'");
 		}
 	}
 else {
@@ -2975,7 +2975,7 @@ if ($variant eq "mariadb" && &compare_versions($ver, "10.4") >= 0 ||
 			};
 		eval {
 			local $main::error_must_die = 1;
-			&execute_dom_sql($d, $mysql::master_db, "grant all privileges on $dbs to '$user'\@'$r->[0]' with grant option");
+			&execute_dom_sql($d, $mysql::master_db, "grant all privileges on $dbs to '$user'\@'$r->[0]'");
 			};
 		}
 	}


### PR DESCRIPTION
Hey Jamie!

The `WITH GRANT OPTION` clause in SQL is used to give a user the ability to grant the privileges they possess to _other users_. Essentially, it allows a user not only to perform actions permitted by their privileges but also to extend those same privileges to others.

If done outside of Virtualmin, it can cause dissonance during backup and restore. This PR fixes this potential issue.