### PR TITLE
Fix to always try to determine the maximum username size

### DIFF
--- a/feature-mysql.pl
+++ b/feature-mysql.pl
@@ -10,23 +10,6 @@ if (!$mysql::config{'login'}) {
 	}
 %mconfig = &foreign_config("mysql");
 $mysql_user_size = $config{'mysql_user_size'} || 16;
-# Try once to determine the maximum username size
-if (!$config{'mysql_user_size'} &&
-    !$config{'mysql_user_size_auto'}) {
-	&lock_file($module_config_file);
-	eval {
-		local $main::error_must_die = 1;
-		my @str = &mysql::table_structure($mysql::master_db, "user");
-		my ($ufield) = grep { lc($_->{'field'}) eq 'user' } @str;
-		if ($ufield && $ufield->{'type'} =~ /\((\d+)\)/) {
-			$config{'mysql_user_size'} = $1;
-			$mysql_user_size = $1;
-			}
-		};
-	$config{'mysql_user_size_auto'} = 1;
-	&save_module_config();
-	&unlock_file($module_config_file);
-	}
 }
 
 sub check_module_mysql

--- a/postinstall.pl
+++ b/postinstall.pl
@@ -555,6 +555,21 @@ if (&has_home_quotas()) {
 		}
 	}
 
+# Try to determine the maximum MariaDB/MySQL username size
+if ($config{'mysql_user_size_auto'} != 1) {
+	&require_mysql();
+	eval {
+		local $main::error_must_die = 1;
+		my @str = &mysql::table_structure($mysql::master_db, "user");
+		my ($ufield) = grep { lc($_->{'field'}) eq 'user' } @str;
+		if ($ufield && $ufield->{'type'} =~ /\((\d+)\)/) {
+			$config{'mysql_user_size'} = $1;
+			}
+		};
+	$config{'mysql_user_size_auto'} = 1;
+	&save_module_config();
+	}
+
 # Create S3 account entries from scheduled backups
 &create_s3_accounts_from_backups();
 

--- a/wizard-lib.pl
+++ b/wizard-lib.pl
@@ -425,8 +425,11 @@ if (!$config{'mysql_user_size'}) {
 		my @str = &mysql::table_structure($mysql::master_db, "user");
 		my ($ufield) = grep { lc($_->{'field'}) eq 'user' } @str;
 		if ($ufield && $ufield->{'type'} =~ /\((\d+)\)/) {
+			&lock_file($module_config_file);
 			$config{'mysql_user_size'} = $1;
+			$config{'mysql_user_size_auto'} = 1;
 			&save_module_config();
+			&unlock_file($module_config_file);
 			}
 		};
 	}

--- a/wizard-lib.pl
+++ b/wizard-lib.pl
@@ -419,7 +419,7 @@ if ($in->{'delanon'}) {
 	}
 
 # Work out the max mysql username length, but only for new installs
-if (!$config{'mysql_user_size'}) {
+if ($config{'mysql_user_size_auto'} != 2) {
 	eval {
 		local $main::error_must_die = 1;
 		my @str = &mysql::table_structure($mysql::master_db, "user");
@@ -427,7 +427,7 @@ if (!$config{'mysql_user_size'}) {
 		if ($ufield && $ufield->{'type'} =~ /\((\d+)\)/) {
 			&lock_file($module_config_file);
 			$config{'mysql_user_size'} = $1;
-			$config{'mysql_user_size_auto'} = 1;
+			$config{'mysql_user_size_auto'} = 2;
 			&save_module_config();
 			&unlock_file($module_config_file);
 			}


### PR DESCRIPTION
Hey Jamie,

I found a long-standing bug: if users skip extra steps in the post-installation wizard, the default MariaDB/MySQL username is limited to 16 characters, despite modern systems supporting 32-128 characters. Specifically:

- Ubuntu 24.04/Debian 12 supports up to 128 characters
- Alma/Rocky 8/9 supports up to 80 characters
- CentOS 7 is limited to 16 characters
- MySQL 8+ supports up to 32 characters.

This patch ensures the correct username length is set for each database system.

I discovered this issue during pre-release testing on Ubuntu 24.04, where skipping the extra steps in wizard resulted in the username being cut off at terrifying 16 characters.