### PR TITLE
Fix redirects to site root

### DIFF
--- a/save_redirect.cgi
+++ b/save_redirect.cgi
@@ -45,7 +45,7 @@ else {
 		}
 	elsif ($in{'mode'} == 3) {
 		# Redirect to a URL path on this host
-		$in{'urlpath'} =~ /^\/\S+$/ ||
+		$in{'urlpath'} =~ /^\/\S*$/ ||
 			&error($text{'redirect_eurlpath'});
 		$r->{'dest'} = $in{'urlpath'};
 		$r->{'alias'} = 0;


### PR DESCRIPTION
Howdy Jamie!

As discussed earlier, when **Source URL path** is set to `/some-path` and **URL on this website** is set to `/`, it used to produce a false-positive error:

```
Failed to save redirect : Missing or invalid destination URL path
```

This PR fixes it.