### PR TITLE
Fix to clear Dovecot config cache if creating and deleting on the same call

### DIFF
--- a/virtual-server-lib-funcs.pl
+++ b/virtual-server-lib-funcs.pl
@@ -20447,6 +20447,7 @@ return &$err(join(" ", @warns)) if (@warns);
 # Create the server
 &push_all_print();
 &set_all_null_print();
+$main::setup_virtualmin_default_hostname_ssl_created++;
 my ($rs) = &create_virtual_server(
 	\%dom, undef, undef, 1, 0, $pass, $dom{'owner'});
 &pop_all_print();
@@ -20494,6 +20495,11 @@ return &$err($succ_msg, $succ, $rs);
 # Delete default hostname domain
 sub delete_virtualmin_default_hostname_ssl
 {
+# Clear cache if deleted in the same call
+if ($main::setup_virtualmin_default_hostname_ssl_created) {
+	undef(@dovecot::get_config_cache);
+	}
+
 # Test if hostname domain being deleted
 my $d = &get_domain_by("defaulthostdomain", 1);
 return if (!$d || !$d->{'dom'});


### PR DESCRIPTION
https://forum.virtualmin.com/t/re-lets-encrypt-apache-website-an-ipv6-dns-record-mydomain-org-with-address-1-exists-but-this-virtual-server-does-not-have-ipv6-enabled/125447/45?u=ilia