### PR TITLE
Fix to always store last LE error

### DIFF
--- a/generate-letsencrypt-cert.pl
+++ b/generate-letsencrypt-cert.pl
@@ -239,6 +239,13 @@ $before = &before_letsencrypt_website($d);
 	$leserver_key, $leserver_hmac);
 &after_letsencrypt_website($d, $before);
 if (!$ok) {
+	# Always store last Certbot error
+	&lock_domain($d);
+	$d->{'letsencrypt_last_failure'} = time();
+	$d->{'letsencrypt_last_err'} = $cert;
+	$d->{'letsencrypt_last_err'} =~ s/\r?\n/\t/g;
+	&save_domain($d);
+	&unlock_domain($d);
 	&$second_print(".. failed : $cert");
 	exit(1);
 	}

--- a/letsencrypt.cgi
+++ b/letsencrypt.cgi
@@ -139,6 +139,13 @@ else {
 					$in{'ctype'});
 	&after_letsencrypt_website($d, $before);
 	if (!$ok) {
+		# Always store last Certbot error
+		&lock_domain($d);
+		$d->{'letsencrypt_last_failure'} = time();
+		$d->{'letsencrypt_last_err'} = $cert;
+		$d->{'letsencrypt_last_err'} =~ s/\r?\n/\t/g;
+		&save_domain($d);
+		&unlock_domain($d);
 		&$second_print(&text('letsencrypt_failed', $cert));
 		}
 	else {

--- a/virtual-server-lib-funcs.pl
+++ b/virtual-server-lib-funcs.pl
@@ -20474,7 +20474,10 @@ $succ = 2 if ($rs->{'ssl_same'});
 my $elelast;
 if ($config{'err_letsencrypt'}) {
 	$elelast = $rs->{'letsencrypt_last_err'};
-	$elelast =~ s/\t/\n/g, $elelast = " : $elelast" if ($elelast);
+	if ($elelast) {
+		$elelast =~ s/\t/\n/g;
+		$elelast = " : $elelast";
+		}
 	}
 my $succ_msg = $succ ? 
 	&text($succ == 2 ? 'check_defhost_sharedsucc' : 'check_defhost_succ', $system_host_name) :

--- a/virtual-server-lib-funcs.pl
+++ b/virtual-server-lib-funcs.pl
@@ -8550,14 +8550,18 @@ if ($valid) {
 		}
 	my @errs = &validate_letsencrypt_config($d, $vcheck);
 	if (@errs) {
+		# Always store last Certbot error
+		my @estr;
+		foreach my $e (@errs) {
+			push(@estr, $e->{'desc'}." : ".
+					&html_strip($e->{'error'}));
+			}
+		my $err = &html_escape(join(", ", @estr));
+		$d->{'letsencrypt_last_failure'} = time();
+		$d->{'letsencrypt_last_err'} = $err;
+		$d->{'letsencrypt_last_err'} =~ s/\r?\n/\t/g;
 		if ($showerrors) {
-			my @estr;
-			foreach my $e (@errs) {
-				push(@estr, $e->{'desc'}." : ".
-					    &html_strip($e->{'error'}));
-				}
-			&$second_print(&text('letsencrypt_evalid',
-				&html_escape(join(", ", @estr))));
+			&$second_print(&text('letsencrypt_evalid', $err));
 			}
 		else {
 			&$second_print($text{'letsencrypt_doing3failed'});
@@ -8568,9 +8572,14 @@ if ($valid) {
 		@errs = &check_domain_connectivity(
 			$d, { 'mail' => 1, 'ssl' => 1 });
 		if (@errs) {
+			# Always store last Certbot error
+			my $e = &html_escape(join(", ",
+				map { $_->{'desc'} } @errs));
+			$d->{'letsencrypt_last_failure'} = time();
+			$d->{'letsencrypt_last_err'} = $e;
+			$d->{'letsencrypt_last_err'} =~ s/\r?\n/\t/g;
 			if ($showerrors) {
-				&$second_print(&text('letsencrypt_econnect',
-					&html_escape(join(", ", map { $_->{'desc'} } @errs))));
+				&$second_print(&text('letsencrypt_econnect', $e));
 				}
 			else {
 				&$second_print($text{'letsencrypt_doing3failed'});
@@ -8595,6 +8604,10 @@ if (!$ok) {
 	}
 &after_letsencrypt_website($d, $before);
 if (!$ok) {
+	# Always store last Certbot error
+	$d->{'letsencrypt_last_failure'} = time();
+	$d->{'letsencrypt_last_err'} = $cert;
+	$d->{'letsencrypt_last_err'} =~ s/\r?\n/\t/g;
 	if ($showerrors) {
 		&$second_print(&text('letsencrypt_failed', $cert));
 		}
@@ -20458,9 +20471,14 @@ if ($rs && ref($rs) ne 'HASH') {
 my $succ = $rs->{'letsencrypt_last'} ? 1 : 0;
 # Perhaps shared SSL certificate was installed, trust it
 $succ = 2 if ($rs->{'ssl_same'});
+my $elelast;
+if ($config{'err_letsencrypt'}) {
+	$elelast = $rs->{'letsencrypt_last_err'};
+	$elelast =~ s/\t/\n/g, $elelast = " : $elelast" if ($elelast);
+	}
 my $succ_msg = $succ ? 
 	&text($succ == 2 ? 'check_defhost_sharedsucc' : 'check_defhost_succ', $system_host_name) :
-    &text('check_defhost_err', $system_host_name);
+    &text('check_defhost_err', $system_host_name).$elelast;
 $config{'defaultdomain_name'} = $dom{'dom'};
 $config{'default_domain_ssl'} = 1
 	if ($succ && !$config{'default_domain_ssl'});


### PR DESCRIPTION
Hey Jamie!

This PR suppresses #844 and always stores the LE error in the domain config file, making it accessible at all times on the **SSL Certificate** page to avoid obscurity.

To be clear, even though we save these errors, they are not displayed in the UI upon creation time unless enabled in the Virtualmin configuration page explicitly.