### PR TITLE
7.20.2

### DIFF
--- a/cert_form.cgi
+++ b/cert_form.cgi
@@ -237,10 +237,8 @@ if (&domain_has_ssl_cert($d)) {
 
 	# Show button to copy to the default location
 	if (!$d->{'ssl_same'} &&
-	    (&get_website_ssl_file($d, "cert") ne 
-	     &default_certificate_file($d, "cert")) ||
-	    (&get_website_ssl_file($d, "key") ne 
-	     &default_certificate_file($d, "key"))) {
+	    &get_website_ssl_file($d, "key") ne 
+	     &default_certificate_file($d, "key")) {
 		my $defcert_dir = &default_certificate_file($d, "cert");
 		$defcert_dir =~ s|/[^/]+$||;
 		print &ui_hr() if (!$ui_hr++);

--- a/default/index.html
+++ b/default/index.html
@@ -32,7 +32,7 @@
   <div class="container ${IF-TMPLTPAGECONTAINERTYPE}${TMPLTPAGECONTAINERTYPE} ${ENDIF-TMPLTPAGECONTAINERTYPE}py-4">
     <header>
       <div class="d-flex flex-column flex-lg-row align-items-center pb-3 mb-4 border-bottom-light">
-        <a href="https://www.virtualmin.com/documentation/website-default-page/" target="_blank"
+        <a href="https://www.virtualmin.com/docs/server-components/website-default-page/" target="_blank"
           class="d-flex align-items-center text-body-secondary text-decoration-none">
           <span class="fs-3">
             ${IF-TMPLTPAGEHEADTITLE}${TMPLTPAGEHEADTITLE}${ENDIF-TMPLTPAGEHEADTITLE}

--- a/feature-ssl.pl
+++ b/feature-ssl.pl
@@ -3013,7 +3013,8 @@ else {
 push(@dnames, "*.".$d->{'dom'}) if ($d->{'letsencrypt_dwild'});
 my $fdnames = &filter_ssl_wildcards(\@dnames);
 @dnames = @$fdnames;
-if (!$d->{'letsencrypt_nodnscheck'}) {
+if (defined($d->{'letsencrypt_nodnscheck'}) &&
+    !$d->{'letsencrypt_nodnscheck'}) {
 	my @badnames;
 	my $fok = &filter_external_dns(\@dnames, \@badnames);
 	if (!@dnames) {

--- a/system_info.pl
+++ b/system_info.pl
@@ -667,11 +667,7 @@ return @rv;
 
 sub get_virtualmin_docs
 {               
-return &master_admin() ?
-		"https://www.virtualmin.com/documentation" :
-       &reseller_admin() ?
-		"https://www.virtualmin.com/documentation/users/reseller" :
-       		"https://www.virtualmin.com/documentation/users/server-owner";
+return "https://www.virtualmin.com/docs/";
 }      
 
 sub parse_license_date

--- a/virtual-server-lib-funcs.pl
+++ b/virtual-server-lib-funcs.pl
@@ -20440,7 +20440,7 @@ my %dom;
 # Set initial features
 $dom{'dir'} = 1;
 $dom{'unix'} = 1;
-$dom{'dns'} = 1;
+$dom{'dns'} = $config{'dns'};
 $dom{'mail'} = 0;
 my $webf = &domain_has_website();
 my $sslf = &domain_has_ssl();

--- a/virtual-server-lib-funcs.pl
+++ b/virtual-server-lib-funcs.pl
@@ -8593,11 +8593,15 @@ my $before = &before_letsencrypt_website($d);
 my @beforecerts = &get_all_domain_service_ssl_certs($d);
 my ($ok, $cert, $key, $chain) =
 	&request_domain_letsencrypt_cert($d, \@dnames);
-if (!$ok) {
+if ($ok) {
+	$d->{'letsencrypt_nodnscheck'} = 1;
+	}
+else {
 	# Try again with just externally resolvable hostnames
 	my @badnames;
 	my $fok = &filter_external_dns(\@dnames, \@badnames);
 	if ($fok == 0 && @dnames) {
+		$d->{'letsencrypt_nodnscheck'} = 0;
 		($ok, $cert, $key, $chain) =
 			&request_domain_letsencrypt_cert($d, \@dnames);
 		}

--- a/virtual-server-lib-funcs.pl
+++ b/virtual-server-lib-funcs.pl
@@ -16663,7 +16663,7 @@ if ($gconfig{'os_type'} =~ /^(redhat-linux|debian-linux)$/) {
 		if (!$repofound) {
 			&$second_print(&ui_text_color(
 				&text('check_repoeoutdate',
-					"$virtualmin_link/documentation/repositories/"), 'warn'));
+					"$virtualmin_link/docs/installation/troubleshooting-repositories/"), 'warn'));
 			}
 		}
 	}


### PR DESCRIPTION
This is Virtualmin 7.20.2 release. All crucial changes were cherry-picked on to _master_ of 7.20.1 tagged release.

This can be used to create a new realease with the following log:

* Fix external DNS filter to consider CNAME and IPv6 records
* Fix not to trigger DNS filter for existing Let's Encrypt renewals
* Fix false positive message to move SSL certificate to default location
* FIx old documentation links

