### PR TITLE
Fix dependency on Postfix and other mail-related packages

### DIFF
--- a/virtual-server-lib.pl
+++ b/virtual-server-lib.pl
@@ -5,6 +5,7 @@ BEGIN { push(@INC, ".."); };
 use WebminCore;
 
 &init_config();
+$config{'mail_system'} = -1 if (!$config{'mail'});
 if (&indexof($module_root_directory, @INC) < 0) {
 	push(@INC, $module_root_directory);
 	}


### PR DESCRIPTION
Hey Jamie,

Here’s a simple fix for the issues we’ve been discussing recently, when mail is globally disabled in the "Features and Plugins" page, and Postfix or other MTA packages are removed.

The current design doesn’t allow for an easy fix. With all the latest patches applied, I tried over again, but it still failing on multiple pages.

Here’s a quick rundown of the pages I found that were failing:

"Edit Users"
"Edit Owner Limits" (when saving)
"Move Virtual Server"
"Setup SSL Certificate"
"DNS Options"
"Disk Usage"
"Delete Virtual Server"
"Post-Installation Wizard"
"Reseller Accounts" (when saving)
"Cloud Mail Delivery Providers" (when saving cloud provider)
"DomainKeys Identified Mail"
"Email Greylisting"
"Mail Rate Limiting"
"Backup Virtual Servers"
"Restore Virtual Servers"

I’m *100%* sure there *will* more pitfalls. It fails on listing and saving throughout the system, including the CLI.

I find this patch simpler, clear and *way less risky* than making multiple fixes across dozens or even hundreds of pages.