### PR TITLE
Update feature-dir.pl to add SELinux setting for /tmp directory

### DIFF
--- a/feature-dir.pl
+++ b/feature-dir.pl
@@ -1047,7 +1047,12 @@ if ($d->{'dir'}) {
 	local $tmp = "$d->{'home'}/tmp";
 	if (!-d $tmp) {
 		&make_dir_as_domain_user($d, $tmp, 0750, 1);
-		}
+		if (&has_command("chcon")) {
+			&execute_command("chcon -t tmp_t ".
+				quotemeta("$tmp").
+				">/dev/null 2>&1");
+			}
+  }
 	return $tmp;
 	}
 else {


### PR DESCRIPTION
If the SELinux utility chcon is available, its likely SELinux is enabled on the system.  If so, set the tmp directory to the specific security context of  "tmp_t".