### PR TITLE
Use static value for pm.max_spare_servers

### DIFF
--- a/php-lib.pl
+++ b/php-lib.pl
@@ -2839,8 +2839,7 @@ return int($max);
 sub get_php_max_spare_servers
 {
 my ($defchildren) = @_;
-my $defmaxspare = $defchildren <= 1 ? $defchildren :
-        $defchildren >= 4 ? int($defchildren / 2) : 2;
+my $defmaxspare = $defchildren <= 1 ? $defchildren : 2;
 return int($defmaxspare);
 }
 


### PR DESCRIPTION
Setting pm.max_children to a high value causes a lot of excess memory usage as vhost count grows. Use a static value to stop that.

Fixes #954