### PR TITLE
Add basic support for IPv6-only systems

### DIFF
--- a/domain_form.cgi
+++ b/domain_form.cgi
@@ -673,7 +673,7 @@ else {
 
 # Show DNS IP address field
 if (&can_dnsip()) {
-	my $def_dns_ip = $config{'external_ip_cache'} || &get_dns_ip($resel);
+	my $def_dns_ip = &get_any_external_ip_address() || &get_dns_ip($resel);
 	my $dns_ip = $parentdom ? $parentdom->{'dns_ip'} : undef;
 	my @opts;
 	if ($def_dns_ip) {

--- a/dynip-lib.pl
+++ b/dynip-lib.pl
@@ -63,10 +63,14 @@ my $ip = sub {
 	return undef;
 	};
 my $now = time();
-if (!$nocache && $config{'external_ip_cache'} &&
-    $now - $config{'external_ip_cache_time'} < 24*60*60) {
+my $cache_optname = $type == 4 ?
+	'external_ip_cache' : 'external_ipv6_cache';
+my $cache_time_optname = $type == 4 ?
+	'external_ip_cache_time' : 'external_ipv6_cache_time';
+if (!$nocache && $config{$cache_optname} &&
+    $now - $config{$cache_time_optname} < 24*60*60) {
 	# Can use last cached value
-	return $ip->($config{'external_ip_cache'});
+	return $ip->($config{$cache_optname});
 	}
 my $url = "http://software.virtualmin.com/cgi-bin/ip.cgi";
 my ($host, $port, $page, $ssl) = &parse_http_url($url);
@@ -77,12 +81,12 @@ $out =~ s/\r|\n//g;
 $out = $ip->($out);
 if ($error) {
 	# Fall back to last cached value
-	return $ip->($config{'external_ip_cache'});
+	return $ip->($config{$cache_optname});
 	}
 # Cache it for future calls
 &lock_file($module_config_file);
-$config{'external_ip_cache'} = $out;
-$config{'external_ip_cache_time'} = $now;
+$config{$cache_optname} = $out;
+$config{$cache_time_optname} = $now;
 &save_module_config();
 &unlock_file($module_config_file);
 return $out;

--- a/dynip-lib.pl
+++ b/dynip-lib.pl
@@ -70,8 +70,7 @@ my $ip = sub {
 my $now = time();
 my $cache_optname = $type == 4 ?
 	'external_ip_cache' : 'external_ipv6_cache';
-my $cache_time_optname = $type == 4 ?
-	'external_ip_cache_time' : 'external_ipv6_cache_time';
+my $cache_time_optname = $cache_optname.'_time';
 if (!$nocache && $config{$cache_optname} &&
     $now - $config{$cache_time_optname} < 24*60*60) {
 	# Can use last cached value

--- a/dynip-lib.pl
+++ b/dynip-lib.pl
@@ -92,6 +92,17 @@ $config{$cache_time_optname} = $now;
 return $out;
 }
 
+# get_any_external_ip_address([no-cache], [prefer-ip-type])
+# Returns the IP address of this system, as seen by other hosts on the Internet,
+# either IPv4 or IPv6, preferring IPv4 by default.
+sub get_any_external_ip_address
+{
+my ($nocache, $prefer) = shift;
+my $ip4 = &get_external_ip_address($nocache, 4) if (!$prefer || $prefer != 6);
+my $ip6 = &get_external_ip_address($nocache, 6) if (!$prefer || $prefer != 4);
+return $prefer == 4 ? $ip4 : $ip6 || $ip4;
+}
+
 # update_dynip_service(new-ip, old-ip)
 # Talk to the configured dynamic DNS service, and return the set IP address
 # and an error message (if any)

--- a/dynip-lib.pl
+++ b/dynip-lib.pl
@@ -74,7 +74,8 @@ my $cache_time_optname = $cache_optname.'_time';
 if (!$nocache && $config{$cache_optname} &&
     $now - $config{$cache_time_optname} < 24*60*60) {
 	# Can use last cached value
-	return $ip->($config{$cache_optname});
+	my $ipaddr = $ip->($config{$cache_optname});
+	return $ipaddr if ($ipaddr);
 	}
 # Fetch IP using DNS
 if ((my $dig = &has_command("dig")) &&

--- a/dynip.pl
+++ b/dynip.pl
@@ -16,7 +16,7 @@ $from = &get_global_from_address();
 
 # Check if we need to update
 ($oldip, $oldwhen) = &get_last_dynip_update($config{'dynip_service'});
-$newip = $config{'dynip_auto'} ? &get_external_ip_address()
+$newip = $config{'dynip_auto'} ? &get_any_external_ip_address()
 			       : &get_default_ip();
 if (!$newip) {
 	# Failed to get current IP address .. so do nothing

--- a/edit_newdynip.cgi
+++ b/edit_newdynip.cgi
@@ -66,7 +66,7 @@ print &ui_table_row($text{'newdynip_iface'},
 
 # External IP
 print &ui_table_row($text{'newdynip_external'},
-		    "<tt>".&get_external_ip_address()."</tt>");
+		    "<tt>".&get_any_external_ip_address()."</tt>");
 
 print &ui_table_end();
 print &ui_form_end([ [ "ok", $text{'newdynip_ok'} ] ]);

--- a/lang/en
+++ b/lang/en
@@ -2084,7 +2084,8 @@ check_defip6=Default IPv6 address for virtual servers is $1
 check_dnsip1=External IP address for DNS records is set to $1, which matches the detected external address
 check_dnsip2=Default IP address is set to $1, which matches the detected external address
 check_dnsip3=Detected external IPv4 address is $1
-check_ednsip3=Could not detect external IPv4 address
+check_dnsip3v6=Detected external IPv6 address is $1
+check_ednsip3=Could not detect external IP address
 check_ednsip1=External IP address for DNS records is set to $1, but the detected external address is actually $2. This may cause DNS records for Virtualmin domains to point to the wrong system
 check_ednsip2=Default IP address is set to $1, but the detected external address is actually $2. This is typically the result of being behind a NAT firewall, and should be corrected on the <a href='$3'>module configuration</a> page
 check_ewebsuexecbin=The <tt>suexec</tt> command was not found on your system
@@ -2139,6 +2140,7 @@ check_postgresnopass=PostgreSQL is installed and running, but does not have any 
 check_webalizerok=Webalizer is installed
 check_ifaceok=Using network interface $1 for virtual IPs
 check_enetmask6=IPv6 netmask $1 is not valid - it should be a number, like 64
+check_iface4=IPv4 addresses are not available on this system
 check_iface6=IPv6 addresses are available, using interface $1
 check_ifacezone=Network interface will be detected automatically at virtual server creation time
 check_sendmailok=Mail server Sendmail is installed and configured

--- a/save_newdynip.cgi
+++ b/save_newdynip.cgi
@@ -55,7 +55,7 @@ elsif (!$in{'enabled'} && $job) {
 &ui_print_header(undef, $text{'newdynip_title'}, "");
 
 if ($in{'enabled'}) {
-	$ip = $in{'auto'} ? &get_external_ip_address() : &get_default_ip();
+	$ip = $in{'auto'} ? &get_any_external_ip_address() : &get_default_ip();
 	print &text('newdynip_on', "<tt>$ip</tt>"),"<p>\n";
 	}
 else {

--- a/virtual-server-lib-funcs.pl
+++ b/virtual-server-lib-funcs.pl
@@ -15642,7 +15642,7 @@ if ($config{'dns'}) {
 				$mastermsg ||= &text('check_dnsmaster2',
 						     "<tt>$master</tt>");
 				}
-			elsif ($masterip ne &get_external_ip_address(1) &&
+			elsif ($masterip ne &get_any_external_ip_address(1) &&
 			       $masterip ne &get_dns_ip() &&
 			       &indexof($masterip, &active_ip_addresses()) < 0) {
 				$mastermsg ||= &text('check_dnsmaster2',
@@ -16567,7 +16567,7 @@ $config{'old_defip6'} ||= $defip6;
 # Make sure the external IP is set if needed
 if ($config{'dns_ip'} ne '*') {
 	local $dns_ip = $config{'dns_ip'} || $defip;
-	local $ext_ip = &get_external_ip_address(1);
+	local $ext_ip = &get_any_external_ip_address(1);
 	if ($ext_ip && $ext_ip eq $dns_ip) {
 		# Looks OK
 		&$second_print(&text($config{'dns_ip'} ? 'check_dnsip1' :
@@ -16581,7 +16581,7 @@ if ($config{'dns_ip'} ne '*') {
 		}
 	}
 else {
-	my $ext_ip = &get_external_ip_address(1);
+	my $ext_ip = &get_any_external_ip_address(1);
 	if ($ext_ip) {
 		my $msg = $ext_ip =~ /:/ ? "check_dnsip3v6" : "check_dnsip3";
 		&$second_print(&text($msg, $ext_ip));
@@ -19098,7 +19098,7 @@ if (defined(&get_reseller)) {
 		}
 	}
 if ($config{'dns_ip'} eq '*') {
-	local $rv = &get_external_ip_address();
+	local $rv = &get_any_external_ip_address();
 	$rv || &error($text{'newdynip_eext'});
 	return $rv;
 	}

--- a/virtual-server-lib-funcs.pl
+++ b/virtual-server-lib-funcs.pl
@@ -16583,8 +16583,8 @@ if ($config{'dns_ip'} ne '*') {
 else {
 	my $ext_ip = &get_external_ip_address(1);
 	if ($ext_ip) {
-		my $ipv6 = $ext_ip =~ /:/ ? "v6" : "";
-		&$second_print(&text("check_dnsip3$ipv6", $ext_ip));
+		my $msg = $ext_ip =~ /:/ ? "check_dnsip3v6" : "check_dnsip3";
+		&$second_print(&text($msg, $ext_ip));
 		}
 	else {
 		&$second_print(&ui_text_color($text{'check_ednsip3'}, 'warn'));


### PR DESCRIPTION
G'day Jamie!

This PR introduces basic support for IPv6-only systems, making sure it continues to work smoothly without failing when IPv4 is _not_ available.

There are a few more complicated patches that needs to be done in `add_name_virtual` and/or `add_listen` sub to make sure `VirtualHost` record isn't created as:

```
<VirtualHost :80 [fdb2:2c26:f4e4:0:21c:2222:1111:0000]:80>
```

To be clear, `/cgi-bin/ip.cgi` already returns IPv6 address correctly.

Please have a look!