### PR TITLE
Add option to choose DNS method for detecting external IP

### DIFF
--- a/config.info
+++ b/config.info
@@ -18,6 +18,7 @@ defip6=Default virtual server IPv6 address,3,From network interface
 iface6=Network interface for IPv6 addresses,3,Same as IPv4
 netmask6=Netmask size for IPv6 addresses,3,Default (64)
 ip6enabled=Use default IPv6 address for new virtual servers?,1,1-Yes,0-No
+dns_resolver=Detect system external IP address using DNS,3,No,50
 
 line1.4=User interface settings,11
 display_max=Maximum number of domains to display,3,Unlimited

--- a/config.info
+++ b/config.info
@@ -18,6 +18,7 @@ defip6=Default virtual server IPv6 address,3,From network interface
 iface6=Network interface for IPv6 addresses,3,Same as IPv4
 netmask6=Netmask size for IPv6 addresses,3,Default (64)
 ip6enabled=Use default IPv6 address for new virtual servers?,1,1-Yes,0-No
+ip_lookup_url=HTTP service URL for system external IP detection,3,Default (<tt>software.virtualmin.com/cgi-bin/ip.cgi</tt>),40
 dns_resolver=Detect system external IP address using DNS,3,No,50
 
 line1.4=User interface settings,11

--- a/dynip-lib.pl
+++ b/dynip-lib.pl
@@ -85,7 +85,12 @@ if ((my $dig = &has_command("dig")) &&
 	}
 # Fetch IP using http
 if ($error || !$out) {
-	my $url = "http://software.virtualmin.com/cgi-bin/ip.cgi";
+	my $url = $config{'ip_lookup_url'} || 
+		"http://software.virtualmin.com/cgi-bin/ip.cgi";
+	my $url4 = $url;
+	my $url6 = $url;
+	($url4, $url6) = split(/ /, $url) if ($url =~ / /);
+	$url = $type == 4 ? $url4 : $url6;
 	my ($host, $port, $page, $ssl) = &parse_http_url($url);
 	&http_download($host, $port, $page, \$out, \$error, undef, $ssl,
 		undef, undef, $timeout, 0, 1);

--- a/dynip-lib.pl
+++ b/dynip-lib.pl
@@ -63,8 +63,8 @@ my $ip = sub {
 	my $ipaddr = shift;
 	return undef if (!$ipaddr);
 	$ipaddr =~ s/\r|\n//g;
-	return $ipaddr if ($type == 4 && $ipaddr =~ /^(\d+\.\d+\.\d+\.\d+)$/);
-	return $ipaddr if ($type == 6 && $ipaddr =~ /^([0-9a-fA-F:]+)$/);
+	return $ipaddr if ($type == 4 && &check_ipaddress($ipaddr));
+	return $ipaddr if ($type == 6 && &check_ip6address($ipaddr));
 	return undef;
 	};
 my $now = time();

--- a/dynip-lib.pl
+++ b/dynip-lib.pl
@@ -45,26 +45,55 @@ else {
 	}
 }
 
-# get_external_ip_address([no-cache])
+# get_external_ip_address([no-cache], [type])
 # Returns the IP address of this system, as seen by other hosts on the Internet.
+# If the no-cache flag is set, the IP is always fetched from the network. If the
+# type is set to 6 ("ipv6"), an IPv6 address is returned. Default is 4 (IPv4).
+# For DNS resolver to work, the config option "dns_resolver" must be set to a
+# string like "myip.opendns.com resolver1.opendns.com".
 sub get_external_ip_address
 {
-my ($nocache) = @_;
+my ($nocache, $type) = @_;
+my ($out, $error);
+my $timeout = 5;
+# Validate type
+$type = 4 if (!$type || ($type != 4 && $type != 6));
+# Internal sub to validate an IP address of the correct type
+my $ip = sub {
+	my $ipaddr = shift;
+	return undef if (!$ipaddr);
+	$ipaddr =~ s/\r|\n//g;
+	return $ipaddr if ($type == 4 && $ipaddr =~ /^(\d+\.\d+\.\d+\.\d+)$/);
+	return $ipaddr if ($type == 6 && $ipaddr =~ /^([0-9a-fA-F:]+)$/);
+	return undef;
+	};
 my $now = time();
 if (!$nocache && $config{'external_ip_cache'} &&
     $now - $config{'external_ip_cache_time'} < 24*60*60) {
 	# Can use last cached value
-	return $config{'external_ip_cache'};
+	return $ip->($config{'external_ip_cache'});
 	}
-my $url = "http://software.virtualmin.com/cgi-bin/ip.cgi";
-my ($host, $port, $page, $ssl) = &parse_http_url($url);
-my ($out, $error);
-&http_download($host, $port, $page, \$out, \$error, undef, $ssl,
-	       undef, undef, 5, 0, 1);
-$out =~ s/\r|\n//g;
+# Fetch IP using DNS
+if ((my $dig = &has_command("dig")) &&
+    $config{'dns_resolver'} =~ /^(?<qname>\S+)\s+(?<nserv>\S+)$/) {
+	my $qname = $+{qname};
+	my $nserv    = $+{nserv};
+	my $dig_cmd = "$dig +time=$timeout +short -".($type == 6 ? "6" : "4").
+		      " $qname \@" . $nserv;
+	&execute_command($dig_cmd, undef, \$out, \$error);
+	$out = $ip->($out);
+	}
+# Fetch IP using http
+if ($error || !$out) {
+	my $url = "http://software.virtualmin.com/cgi-bin/ip.cgi";
+	my ($host, $port, $page, $ssl) = &parse_http_url($url);
+	&http_download($host, $port, $page, \$out, \$error, undef, $ssl,
+		undef, undef, $timeout, 0, 1);
+	$out = $ip->($out);
+	}
 if ($error) {
 	# Fall back to last cached value
-	return $config{'external_ip_cache'};
+	return $ip->($config{'external_ip_cache'});
 	}
 # Cache it for future calls
 &lock_file($module_config_file);

--- a/dynip-lib.pl
+++ b/dynip-lib.pl
@@ -76,8 +76,8 @@ if (!$nocache && $config{'external_ip_cache'} &&
 # Fetch IP using DNS
 if ((my $dig = &has_command("dig")) &&
     $config{'dns_resolver'} =~ /^(?<qname>\S+)\s+(?<nserv>\S+)$/) {
-	my $qname = $+{qname};
-	my $nserv    = $+{nserv};
+	my $qname = quotemeta($+{qname});
+	my $nserv    = quotemeta($+{nserv});
 	my $dig_cmd = "$dig +time=$timeout +short -".($type == 6 ? "6" : "4").
 		      " $qname \@" . $nserv;
 	&execute_command($dig_cmd, undef, \$out, \$error);

--- a/help/config_dns_resolver.html
+++ b/help/config_dns_resolver.html
@@ -1,0 +1,14 @@
+<header>Detect system external IP address using DNS</header>
+
+This option uses the <tt>dig</tt> command to query a DNS server and detect the
+system's external IP address. For instance, you can set this field to
+<tt>myip.opendns.com resolver1.opendns.com</tt> (a space-separated query name
+and nameserver). This avoids relying on HTTP-based method and retrieves the IP
+address directly from the DNS server.<p>
+
+However, DNS method should be used with care if the system is behind a NAT,
+proxy, or VPN, as the detected IP may not reflect the actual public IP of the
+machine. It may instead show the external IP of the NAT gateway, proxy, or VPN
+endpoint.<p>
+
+<footer>

--- a/help/config_ip_lookup_url.html
+++ b/help/config_ip_lookup_url.html
@@ -1,0 +1,13 @@
+<header>HTTP service URL for system external IP detection</header>
+
+This option specifies the HTTP service URL used to detect the system’s external
+IP address. It queries a web service to retrieve the public IP of this system.
+By default, the URL is set to
+<tt>https://software.virtualmin.com/cgi-bin/ip.cgi</tt>.<p>
+
+You can also use other services like <tt>https://ifconfig.me</tt> or
+<tt>https://icanhazip.com</tt>. Furthermore, you can specify separate URLs for
+IPv4 and IPv6 detection by separating them with a space, such as
+<tt>https://api.ipify.org https://api6.ipify.org</tt>.<p>
+
+<footer>


### PR DESCRIPTION
This PR adds the ability to choose how the external IP is detected. We discussed this a while ago, and Joe mentioned he liked this DNS-based method.

However, it shouldn’t be enabled by default.

We can also make the default HTTP URL for retrieving the IP configurable.