### PR TITLE
Fix the logic when fixing domain FPM config

### DIFF
--- a/php-lib.pl
+++ b/php-lib.pl
@@ -2038,7 +2038,7 @@ if ($file =~ m{/php/(\d+)\.(\d+)/fpm} ||     # Debian and derivatives
 		return $version;
 		}
 	}
-return $avail[0] if @avail;
+return $avail[0] if (@avail && @avail == 1); # Return the only available version
 return undef;
 }
 

--- a/php-lib.pl
+++ b/php-lib.pl
@@ -2016,7 +2016,6 @@ my @rv;
 foreach my $fpmconf (@fpmconfs) {
 	my $file = $fpmconf->{'dir'}."/".$d->{'id'}.".conf";
 	if (-r $file) {
-		$fpmconf->{'file'} = $file;
 		push(@rv, $fpmconf);
 		}
 	}

--- a/virtual-server-lib-funcs.pl
+++ b/virtual-server-lib-funcs.pl
@@ -16091,27 +16091,9 @@ if (&domain_has_website()) {
 
 			# Try to detect actually configured version
 			$dv = &detect_php_fpm_version($d);
-			# If still none exists, check template if anything
-			# is preferred otherwise fall back to highest available
-			if (!$dv) {
-				my $nf;
-				my $tmpl = &get_template($d->{'template'});
-				# If set in templates use it, or fall back to
-				# highest available later in the code below
-				my $tdv;
-				if ($tmpl->{'web_phpver'}) {
-					$tdv = $tmpl->{'web_phpver'};
-					($nf) = grep { $_->{'shortversion'} eq
-						       $tdv } @fpms
-					}
-				# Otherwise, get highest version if none found
-				# in template and domain config
-				($nf) = grep { &compare_versions(
-						$_->{'shortversion'}, $tdv) > 0 } 
-							@fpms if (!$nf);
-				$nf ||= $fpms[$#fpms];
-				$dv = $nf->{'shortversion'};
-				}
+			# If still none exists do nothing
+			next if (!$dv);
+			
 			&lock_domain($d);
 			$d->{'php_fpm_version'} = $dv;
 			&save_domain($d);

--- a/virtual-server-lib-funcs.pl
+++ b/virtual-server-lib-funcs.pl
@@ -16074,9 +16074,6 @@ if (&domain_has_website()) {
 		# Check for invalid FPM versions, in case one has been
 		# upgraded to a new release
 		my @fpmfixed;
-		# Sort to have highest version first
-		@fpms = sort { &compare_versions(
-				$b->{'version'}, $a->{'version'}) } @fpms;
 		foreach my $d (grep { &domain_has_website($_) &&
 				      !$_->{'alias'} } &list_domains()) {
 			# Check if an FPM version is stored in domain config


### PR DESCRIPTION
Hello Jamie,

As discussed in [this thread](https://github.com/virtualmin/virtualmin-gpl/issues/981#issuecomment-2530400523), you mentioned that this part of the code might be the culprit behind the original issue mentioned in the ticket. I started digging deeper into the code and found something that needed attention.

However, I’m not entirely sure if it will fix the original issue—it might, though, as there is code that expects the domain’s `php_fpm_version` option to always be set, such as `list_domain_php_directories`.

Have a look please!