### PR TITLE
Fix to return error when downgraded from Pro to GPL

### DIFF
--- a/feature-dns.pl
+++ b/feature-dns.pl
@@ -3776,6 +3776,10 @@ if ($d->{'dns_cloud'}) {
 	# actual file.
 	my $ctype = $d->{'dns_cloud'};
 	my $gfunc = "dnscloud_".$ctype."_get_records";
+	if (!defined(&$gfunc)) {
+		return ("This cloud DNS provider isn't supported in ".
+		        "Virtualmin GPL");
+		}
 	my $info = { 'domain' => $d->{'dom'},
 		     'id' => $d->{'dns_cloud_id'},
 		     'location' => $d->{'dns_cloud_location'} };


### PR DESCRIPTION
Hello Jamie!

This small patch address the [issue](https://forum.virtualmin.com/t/cloudflare-dns-issue-on-gpl-downgrade/129712?u=ilia) and failure when Virtualmin was downgraded from Pro to GPL.
