### PR TITLE
Add support to return a list of files for which permissions were fixed

### DIFF
--- a/feature-dir.pl
+++ b/feature-dir.pl
@@ -956,7 +956,7 @@ foreach my $sd ($d, &get_domain_by("parent", $d->{'id'})) {
 
 # Track changed files
 my @changed_files;
-my $change_files = sub {
+my $check_file_change = sub {
 	my ($f, $uid, $gid, $changed_files) = @_;
 	my ($curr_uid, $curr_gid) = (stat($f))[4,5];
 	my $curr_user = getpwuid($curr_uid) || $curr_uid;
@@ -988,11 +988,11 @@ LOOP: while(my $f = <FIND>) {
 	foreach my $s (@subhomes) {
 		next LOOP if ($f =~ /^\Q$s\E/);
 		}
-	$change_files->($f, $d->{'uid'}, $gid, \@changed_files);
+	$check_file_change->($f, $d->{'uid'}, $gid, \@changed_files);
 	&set_ownership_permissions($d->{'uid'}, $gid, undef, $f);
 	}
 close(FIND);
-$change_files->($d->{'home'}."/".$hd, $d->{'uid'}, $gid, \@changed_files);
+$check_file_change->($d->{'home'}."/".$hd, $d->{'uid'}, $gid, \@changed_files);
 &set_ownership_permissions($d->{'uid'}, $gid, undef, $d->{'home'}."/".$hd);
 foreach my $dir (&virtual_server_directories($d)) {
 	&set_ownership_permissions(undef, undef, oct($dir->[1]),
@@ -1002,7 +1002,7 @@ foreach my $user (@users) {
 	next if ($user->{'nocreatehome'});
 	next if (!&is_under_directory("$d->{'home'}/$hd", $user->{'home'}));
 	next if ("$d->{'home'}/$hd" eq $user->{'home'});
-	$change_files->($user->{'home'}, $user->{'uid'},
+	$check_file_change->($user->{'home'}, $user->{'uid'},
 		$user->{'gid'}, \@changed_files);
 	&system_logged("chown -R $user->{'uid'}:$user->{'gid'} ".
 		       quotemeta($user->{'home'}));

--- a/feature-dir.pl
+++ b/feature-dir.pl
@@ -979,9 +979,9 @@ if (!$d->{'parent'}) {
 foreach my $user (@users) {
 	push(@subhomes, $user->{'home'});
 	}
-
-&open_execute_command(FIND, "find ".quotemeta($d->{'home'})." ! -type l", 1);
-LOOP: while(my $f = <FIND>) {
+my $find = "FIND";
+&open_execute_command($find, "find ".quotemeta($d->{'home'})." ! -type l", 1);
+LOOP: while(my $f = <$find>) {
 	$f =~ s/\r|\n//;
 	next LOOP if ($f =~ /\/\.nodelete$/);
 	next LOOP if ($f =~ /^\Q$d->{'home'}\/$hd\/\E/);
@@ -991,7 +991,7 @@ LOOP: while(my $f = <FIND>) {
 	$check_file_change->($f, $d->{'uid'}, $gid, \@changed_files);
 	&set_ownership_permissions($d->{'uid'}, $gid, undef, $f);
 	}
-close(FIND);
+close($find);
 $check_file_change->($d->{'home'}."/".$hd, $d->{'uid'}, $gid, \@changed_files);
 &set_ownership_permissions($d->{'uid'}, $gid, undef, $d->{'home'}."/".$hd);
 foreach my $dir (&virtual_server_directories($d)) {
@@ -1002,10 +1002,17 @@ foreach my $user (@users) {
 	next if ($user->{'nocreatehome'});
 	next if (!&is_under_directory("$d->{'home'}/$hd", $user->{'home'}));
 	next if ("$d->{'home'}/$hd" eq $user->{'home'});
-	$check_file_change->($user->{'home'}, $user->{'uid'},
-		$user->{'gid'}, \@changed_files);
-	&system_logged("chown -R $user->{'uid'}:$user->{'gid'} ".
-		       quotemeta($user->{'home'}));
+	my $find = "FIND";
+	&open_execute_command($find, "find ".
+		quotemeta($user->{'home'})." ! -type l", 1);
+	while (my $f = <$find>) {
+		$f =~ s/\r|\n//;
+		$check_file_change->($f, $user->{'uid'}, $user->{'gid'},
+				     \@changed_files);
+		&set_ownership_permissions($user->{'uid'}, $user->{'gid'},
+					   undef, $f);
+		}
+	close($find);
 	}
 foreach my $sd ($d, &get_domain_by("parent", $d->{'id'})) {
 	if (defined(&set_php_wrappers_writable)) {

--- a/fix-domain-permissions.pl
+++ b/fix-domain-permissions.pl
@@ -81,12 +81,23 @@ foreach $d (@doms) {
 		&$second_print(".. does not have a home directory");
 		}
 	else {
-		$err = &set_home_ownership($d);
-		if ($err) {
-			&$second_print(".. failed : $err");
+		my (@changed_files) = &set_home_ownership($d);
+		if (@changed_files) {
+			my $details_body;
+			foreach my $changed (@changed_files) {
+				$changed->[0] =~ s/^$d->{'home'}\///;
+				$details_body .= "     ".
+					&text('fixperms_details',
+						$changed->[1],
+						$changed->[2],
+						$changed->[0]). "\n";
+				}
+			&$second_print(
+				$text{'fixperms_oklist2'}. "\n".
+				$details_body);
 			}
 		else {
-			&$second_print(".. done");
+			&$second_print($text{'setup_done'});
 			}
 		}
 	}

--- a/fixperms.cgi
+++ b/fixperms.cgi
@@ -30,12 +30,26 @@ else {
 foreach $d (@doms) {
 	&$first_print(&text('fixperms_dom', &show_domain_name($d)));
 	if (!$d->{'dir'}) {
-		&$second_print($text{'fixperms_edir'});
+		&$second_print($text{'fixperms_edirmiss'});
 		}
 	else {
-		$err = &set_home_ownership($d);
-		if ($err) {
-			&$second_print(&text('fixperms_failed', $err));
+		my (@changed_files) = &set_home_ownership($d);
+		if (@changed_files) {
+			my $details_body;
+			foreach my $changed (@changed_files) {
+				$changed->[0] =~ s/^$d->{'home'}\///;
+				$details_body .= &text('fixperms_details',
+					&html_escape($changed->[1]),
+					&html_escape($changed->[2]),
+					&html_escape($changed->[0])). "<br>";
+				}
+			&$second_print(
+				&ui_details({
+					'title' => $text{'fixperms_oklist'},
+					'content' => $details_body,
+					'class' =>'inline',
+					'html' => 1})
+				);
 			}
 		else {
 			&$second_print($text{'setup_done'});

--- a/lang/en
+++ b/lang/en
@@ -7526,8 +7526,10 @@ fixperms_err=Failed to fix permissions
 fixperms_edoms=No virtual servers selected
 fixperms_title=Fixing Permissions
 fixperms_dom=Fixing file ownership and permissions for $1 ..
-fixperms_edir=.. does not have a home directory
-fixperms_failed=.. failed : $1
+fixperms_edirmiss=.. domain does not have a home directory
+fixperms_oklist=.. done for the enclosed list of files
+fixperms_oklist2=.. done for the list of files below:
+fixperms_details=From <tt>$1</tt> to <tt>$2</tt> for file <tt>$3</tt>
 
 bkeys_title=Backup Encryption Keys
 bkeys_key=GPG key ID


### PR DESCRIPTION
Hello Jamie!

This PR adds support for returning a list of files for which permissions were fixed.

It took longer to implement than I initially expected because of the additional work needed to update themes to support the new layout.

Example:

https://github.com/user-attachments/assets/066d0143-9bea-49ae-9e9b-448564ffa191

