### PR TITLE
Additional post backup status partial

### DIFF
--- a/backup.pl
+++ b/backup.pl
@@ -173,6 +173,17 @@ if ($@) {
 	$output .= $@;
 	}
 
+# Determine backup status for environment variable
+if ($ok && !@$errdoms) {
+    $backup_status = "ok";  # Complete success
+}
+elsif ($ok && @$errdoms) {
+    $backup_status = "partial";  # Partial success
+}
+else {
+    $backup_status = "failed";  # Complete failure
+}	
+
 # If purging old backups, do that now
 @purges = &get_scheduled_backup_purges($sched);
 @perrs = ( );
@@ -196,8 +207,8 @@ if ($ok || $sched->{'errors'} == 1) {
 
 # Run any after command
 if ($sched->{'after'}) {
-	&$first_print("Running post-backup command ..");
-	&set_backup_envs($sched, \@doms, $ok);
+    &$first_print("Running post-backup command ..");
+    &set_backup_envs($sched, \@doms, $backup_status);
 	$out = &backquote_command("($sched->{'after'}) 2>&1 </dev/null");
 	&reset_backup_envs();
 	print $out;

--- a/backups-lib.pl
+++ b/backups-lib.pl
@@ -6953,12 +6953,15 @@ if ($sched->{'strftime'}) {
             }
         }
     }
-	$ENV{'BACKUP_DOMAIN_NAMES'} = join(" ", map { $_->{'dom'} } @$doms);
-	if (defined($status)) {
-		$ENV{'BACKUP_STATUS'} = $status eq 'ok' ? 1 :
-									$status eq 'partial' ? 2 : 0;
-	}
+$ENV{'BACKUP_DOMAIN_NAMES'} = join(" ", map { $_->{'dom'} } @$doms);
+if (defined($status)) {
+    # Set both text and numeric status
+    $ENV{'BACKUP_STATUS'} = $status;
+    $ENV{'BACKUP_STATUS_CODE'} = $status eq 'ok' ? 1 :
+                                $status eq 'partial' ? 2 : 0;
 }
+}
+
 
 # reset_backup_envs()
 # Clear variables set by set_backup_envs

--- a/backups-lib.pl
+++ b/backups-lib.pl
@@ -6937,24 +6937,27 @@ return $file =~ /\.zip$/i ? 3 :
        $file =~ /\.tar$/i ? 2 : -1;
 }
 
-# set_backup_envs(&backup, &doms, [ok|failed])
+# set_backup_envs(&backup, &doms, [ok|failed|partial])
 # Set environment variables from a backup object
 sub set_backup_envs
 {
 my ($sched, $doms, $status) = @_;
 foreach my $k (keys %$sched) {
-	$ENV{'BACKUP_'.uc($k)} = $sched->{$k};
-	}
+    $ENV{'BACKUP_'.uc($k)} = $sched->{$k};
+    }
 if ($sched->{'strftime'}) {
-	# Expand out date-based paths
-	foreach my $k (keys %$sched) {
-		if ($k eq 'dest' || $k =~ /^dest\d+$/) {
-			$ENV{'BACKUP_'.uc($k)} = &backup_strftime($sched->{$k});
-			}
-		}
+    # Expand out date-based paths
+    foreach my $k (keys %$sched) {
+        if ($k eq 'dest' || $k =~ /^dest\d+$/) {
+            $ENV{'BACKUP_'.uc($k)} = &backup_strftime($sched->{$k});
+            }
+        }
+    }
+	$ENV{'BACKUP_DOMAIN_NAMES'} = join(" ", map { $_->{'dom'} } @$doms);
+	if (defined($status)) {
+		$ENV{'BACKUP_STATUS'} = $status eq 'ok' ? 1 :
+									$status eq 'partial' ? 2 : 0;
 	}
-$ENV{'BACKUP_DOMAIN_NAMES'} = join(" ", map { $_->{'dom'} } @$doms);
-$ENV{'BACKUP_STATUS'} = $status if (defined($status));
 }
 
 # reset_backup_envs()


### PR DESCRIPTION
This is a proposal set set an additional environment variable to indicate if a backup was a partial success as opposed to a hard success or fail. We are using centralised software to keep track of all backups and it would be useful for our operators to know when backups were partial.

- My IDE has small tab/spacing issues that I couldn't correct easily
- In theory we would have 0 for fail, 1 for success, and 2 for partial and avoid have duplicate environment variables so perhaps there is some redundancy that the team wants to consider.