### PR TITLE
Allow link cert with different owner while modifying domain in CLI

### DIFF
--- a/modify-web.pl
+++ b/modify-web.pl
@@ -894,7 +894,11 @@ foreach $d (@doms) {
 			my @sames = &find_matching_certificate_domain($d);
 
 			# Determine if different owner linking is allowed
-			my $diff_owner_allowed = $d->{'link_certs'} == 2;
+			my $diff_owner_allowed = 2 == (
+				defined $d->{'link_certs'} ?
+				$d->{'link_certs'} :
+				$config{'nolink_certs'}
+				);
 
 			# Initialize priority stack
 			my @priorities = (


### PR DESCRIPTION
Linking cert is perfectly working while creating a domain, however it was not allowed to do so while modifying it.

This change allows linking a certificate when modifying a domain, based on the domain's `link_cert` configuration or falling back to the main `nolink_certs` main configuration.

This may required an additional option `--always-link-ssl-cert` similar to what we have in create-domain, but I'm not sure how to handle the domain config : `--link-cert`in modify-web does not originally save `link_cert` configuration on the domain and this config is mostly never saved unless you had specified `--break-ssl-cert` or `--link-ssl-cert` in the create-domain CLI only,

Anyway, this change brings an easy way to switch to a existing wildcard certificate owned by an other domain.

Thanks