### PR TITLE
Add support for the new navigation menu layout

### DIFF
--- a/domain_form.cgi
+++ b/domain_form.cgi
@@ -81,8 +81,7 @@ if ($in{'subdom'}) {
 	$subdom = &get_domain($in{'subdom'});
 	$subdom || &error(&text('form_esubdom', $in{'subdom'}));
 	}
-my $subhead = $aliasdom || $parentdom;
-$subhead = &domain_in($aliasdom || $parentdom) if ($subhead);
+my $subhead = $aliasdom || $parentdom ? &domain_in($aliasdom || $parentdom) : "";
 &ui_print_header($subhead, $aliasdom ? $text{'form_title3'} :
 			   $subdom ? $text{'form_title4'} :
 			   $parentdom ? $text{'form_title2'} :

--- a/domain_form.cgi
+++ b/domain_form.cgi
@@ -495,13 +495,16 @@ foreach $f (@dom_features) {
 		next;
 		}
 
-	local $txt = $parentdom ? $text{'form_sub'.$f} : undef;
-	$txt ||= $text{'form_'.$f};
+	my $ftxt = $aliasdom ? $text{'form_alias'.$f} :
+		   $parentdom ? $text{'form_sub'.$f} : undef;
+	my $fhelp = $f;
+	$fhelp = $f."_alias" if ($aliasdom && $ftxt);
+	$ftxt ||= $text{'form_'.$f};
 	push(@grid_order_initial, $f);
 	push(@grid, &ui_checkbox($f, 1, "",
 		$config{$f} == 1 && $in{'nofeat'} ne $f,
 		&feature_check_chained_javascript($f)).
-		    " <b>".&hlink($txt, $f)."</b>");
+		    " <b>".&hlink($ftxt, $fhelp)."</b>");
 	}
 
 # Show checkboxes for plugins

--- a/domain_form.cgi
+++ b/domain_form.cgi
@@ -498,7 +498,8 @@ foreach $f (@dom_features) {
 	local $txt = $parentdom ? $text{'form_sub'.$f} : undef;
 	$txt ||= $text{'form_'.$f};
 	push(@grid_order_initial, $f);
-	push(@grid, &ui_checkbox($f, 1, "", $config{$f} == 1,
+	push(@grid, &ui_checkbox($f, 1, "",
+		$config{$f} == 1 && $in{'nofeat'} ne $f,
 		&feature_check_chained_javascript($f)).
 		    " <b>".&hlink($txt, $f)."</b>");
 	}

--- a/domain_form.cgi
+++ b/domain_form.cgi
@@ -103,7 +103,6 @@ if (!$tdleft && $tdreason == 3) {
 print &ui_form_start("domain_setup.cgi", "post");
 print &ui_hidden("parentuser", $parentuser),"\n";
 print &ui_hidden("to", $in{'to'}),"\n";
-print &ui_hidden("aliasmail", $in{'aliasmail'}),"\n";
 print &ui_hidden("subdom", $in{'subdom'}),"\n";
 print &ui_hidden_table_start($text{'form_header'}, "width=100%", 2,
 			     "basic", 1);

--- a/domain_form.cgi
+++ b/domain_form.cgi
@@ -81,15 +81,15 @@ if ($in{'subdom'}) {
 	$subdom = &get_domain($in{'subdom'});
 	$subdom || &error(&text('form_esubdom', $in{'subdom'}));
 	}
-
-&ui_print_header(undef, $aliasdom ? $text{'form_title3'} :
-			$subdom ? $text{'form_title4'} :
-			$parentdom ? $text{'form_title2'} :
-				     $text{'form_title'}, "",
-			$aliasdom ? "create_alias" :
-			$subdom ? "create_subdom" :
-			$parentdom ? "create_subserver" :
-				  "create_form");
+my $subhead = $aliasdom || $parentdom;
+$subhead = &domain_in($aliasdom || $parentdom) if ($subhead);
+&ui_print_header($subhead, $aliasdom ? $text{'form_title3'} :
+			   $subdom ? $text{'form_title4'} :
+			   $parentdom ? $text{'form_title2'} :
+				        $text{'form_title'}, "",
+			   $aliasdom ? "create_alias" :
+			   $subdom ? "create_subdom" :
+			   $parentdom ? "create_subserver" : "create_form");
 # Show user friendly info
 my ($tdleft, $tdreason, $tdmax) = &count_domains("topdoms");
 if (!$tdleft && $tdreason == 3) {

--- a/domain_setup.cgi
+++ b/domain_setup.cgi
@@ -407,8 +407,7 @@ if ($config{'mysql'} && &can_edit_templates() && !$aliasdom && !$parentdom) {
 # Special magic - if the dir feature is enabled by default and this is an alias
 # domain, don't set it
 foreach my $f (@features, &list_feature_plugins()) {
-	next if ($f eq 'dir' && $config{$f} == 3 && $aliasdom &&
-                 $tmpl->{'aliascopy'} && !$dom{'aliasmail'});
+	next if ($f eq 'dir' && $aliasdom);
 	$dom{$f} = &can_use_feature($f) && int($in{$f});
 	}
 

--- a/domain_setup.cgi
+++ b/domain_setup.cgi
@@ -334,7 +334,7 @@ $pclash && &error(&text('setup_eprefix3', $prefix, $pclash->{'dom'}));
 		( 'pass', $parentdom->{'pass'} ) :
 		( 'pass', $pass ),
 	 'alias', $aliasdom ? $aliasdom->{'id'} : undef,
-	 'aliasmail', $in{'aliasmail'},
+	 'aliasmail', $in{'mail'},
 	 'subdom', $subdom ? $subdom->{'id'} : undef,
 	 'subprefix', $subprefix,
 	 'uid', $uid,

--- a/edit_domain.cgi
+++ b/edit_domain.cgi
@@ -369,20 +369,23 @@ if (!$d->{'disabled'}) {
 			next;
 			}
 
-		local $txt = $parentdom ? $text{'edit_sub'.$f} : undef;
-		$txt ||= $text{'edit_'.$f};
+		my $ftxt = $aliasdom ? $text{'form_alias'.$f} :
+			   $parentdom ? $text{'edit_sub'.$f} : undef;
+		my $fhelp = $f;
+		$fhelp = $f."_alias" if ($aliasdom && $ftxt);
+		$ftxt ||= $text{'edit_'.$f};
 		if (!&can_use_feature($f)) {
 			push(@grid_order_initial, $f);
 			push(@grid, &ui_checkbox($f."_dis", 1, undef,
 						$d->{$f}, undef, 1).
 				    &ui_hidden($f, $d->{$f}).
-				    " <b>".&hlink($txt, $f)."</b>");
+				    " <b>".&hlink($ftxt, $fhelp)."</b>");
 			}
 		else {
 			push(@grid_order_initial, $f);
 			push(@grid, &ui_checkbox($f, 1, "", $d->{$f},
 					&feature_check_chained_javascript($f)).
-				    " <b>".&hlink($txt, $f)."</b>");
+				    " <b>".&hlink($ftxt, $fhelp)."</b>");
 			}
 		}
 

--- a/help/mail_alias.html
+++ b/help/mail_alias.html
@@ -1,0 +1,4 @@
+<header>Accept mail for alias?</header>
+
+If enabled, the server alias will be configured to receive emails for the parent
+domain. <p>

--- a/help/mail_alias.html
+++ b/help/mail_alias.html
@@ -1,4 +1,4 @@
 <header>Accept mail for alias?</header>
 
 If enabled, the server alias will be configured to receive emails for the parent
-domain. <p>
+domain.

--- a/lang/en
+++ b/lang/en
@@ -324,6 +324,7 @@ form_group=Group for administration user
 form_crgroup=Same as group for mail users
 form_exgroup=Existing group
 form_mail=Mail for domain?
+form_aliasmail=Mail for alias?
 form_unix=Server administrator?
 form_dir=Home directory?
 form_web=Apache website?

--- a/lang/en
+++ b/lang/en
@@ -291,7 +291,7 @@ index_global_eg=e.g.
 
 form_title=Create Virtual Server
 form_title2=Create Sub-Server
-form_title3=Create Alias Server
+form_title3=Create Server Alias
 form_title4=Create Virtual Sub-Domain
 form_ecannot=You are not allowed to create virtual servers
 form_enomore=You are not allowed to create any more virtual servers of any type
@@ -1175,7 +1175,7 @@ fstart_eup=Already running
 
 edit_title=Edit Virtual Server
 edit_title2=Edit Virtual Sub-Server
-edit_title3=Edit Alias Server
+edit_title3=Edit Server Alias
 edit_title4=Edit Virtual Sub-Domain
 edit_ecannot=You are not allowed to edit this virtual server
 edit_ewebappcannot=You are not allowed to manage web applications
@@ -1300,7 +1300,7 @@ edit_renamedesc=Display a form for changing the domain name for this virtual ser
 edit_cert=SSL Certificate
 edit_catcert=Setup SSL Certificate
 edit_certdesc=Display a page for requesting a new SSL certificate for this virtual server, and installing a signed certificate from a CA.
-edit_alias=Create Alias Server
+edit_alias=Create Server Alias
 edit_aliasdesc=Add a virtual server that is just an alias for this existing server, so that it can be accessed using a different domain name.
 edit_subserv=Create Sub-Server
 edit_subservdesc=Add a new virtual server that is owned by the same administrator as this domain.

--- a/lang/en
+++ b/lang/en
@@ -290,12 +290,11 @@ index_keyinvalid=The SSL key file $2 for $1 is invalid : $3
 index_global_eg=e.g.
 
 form_title=Create Virtual Server
-form_title2=Create Virtual Sub-Server
+form_title2=Create Sub-Server
 form_title3=Create Alias Server
 form_title4=Create Virtual Sub-Domain
 form_ecannot=You are not allowed to create virtual servers
 form_enomore=You are not allowed to create any more virtual servers of any type
-form_genericmode=New virtual server type:
 form_generic_master=Top-level server
 form_generic_subserver=Sub-server
 form_generic_subserverof=Sub-server of $1

--- a/lang/en
+++ b/lang/en
@@ -291,7 +291,7 @@ index_global_eg=e.g.
 
 form_title=Create Virtual Server
 form_title2=Create Sub-Server
-form_title3=Create Server Alias
+form_title3=Create Alias Server
 form_title4=Create Virtual Sub-Domain
 form_ecannot=You are not allowed to create virtual servers
 form_enomore=You are not allowed to create any more virtual servers of any type
@@ -1175,7 +1175,7 @@ fstart_eup=Already running
 
 edit_title=Edit Virtual Server
 edit_title2=Edit Virtual Sub-Server
-edit_title3=Edit Server Alias
+edit_title3=Edit Alias Server
 edit_title4=Edit Virtual Sub-Domain
 edit_ecannot=You are not allowed to edit this virtual server
 edit_ewebappcannot=You are not allowed to manage web applications
@@ -1300,7 +1300,7 @@ edit_renamedesc=Display a form for changing the domain name for this virtual ser
 edit_cert=SSL Certificate
 edit_catcert=Setup SSL Certificate
 edit_certdesc=Display a page for requesting a new SSL certificate for this virtual server, and installing a signed certificate from a CA.
-edit_alias=Create Server Alias
+edit_alias=Create Alias Server
 edit_aliasdesc=Add a virtual server that is just an alias for this existing server, so that it can be accessed using a different domain name.
 edit_subserv=Create Sub-Server
 edit_subservdesc=Add a new virtual server that is owned by the same administrator as this domain.

--- a/save_domain.cgi
+++ b/save_domain.cgi
@@ -354,6 +354,9 @@ else {
 		}
 	}
 
+# Update alias domain mail-related flag
+$d->{'aliasmail'} = $d->{'mail'} if ($d->{'alias'});
+
 # Update the parent user
 &refresh_webmin_user($d);
 

--- a/virtual-server-lib-funcs.pl
+++ b/virtual-server-lib-funcs.pl
@@ -13976,9 +13976,19 @@ local @rv;
 # Always start with edit/view link
 my $canconfig = &can_config_domain($d);
 local $vm = "/$module_name";
+my $edit_title = $text{'edit_title'};
+my $view_title = $text{'view_title'};
+if ($d->{'parent'} && !$d->{'alias'}) {
+	$edit_title = $text{'edit_title2'};
+	$view_title = $text{'view_title2'};
+	}
+elsif ($d->{'parent'} && $d->{'alias'}) {
+	$edit_title = $text{'edit_title3'};
+	$view_title = $text{'view_title3'}
+	}
 push(@rv, { 'url' => $canconfig ? "$vm/edit_domain.cgi?dom=$d->{'id'}"
 				: "$vm/view_domain.cgi?dom=$d->{'id'}",
-	    'title' => $canconfig ? $text{'edit_title'} : $text{'view_title'},
+	    'title' => $canconfig ? $edit_title : $view_title,
 	    'cat' => 'objects',
 	    'icon' => $canconfig ? 'edit' : 'view' });
 

--- a/webmin_menu.pl
+++ b/webmin_menu.pl
@@ -129,19 +129,18 @@ else {
 
 # Create sub-server and/or alias links
 if (&can_create_master_servers() || &can_create_sub_servers()) {
-	my $gparent = &get_domain($did);
-	if (&can_create_sub_servers() && $gparent && !$gparent->{'parent'}) {
+	if (&can_create_sub_servers() && $d && !$d->{'parent'}) {
 		push(@rv, { "type" => "item",
 			    "desc" => $text{'form_title2'},
 			    "link" => "/$module_name/domain_form.cgi?".
-			              "add1=1&parentuser1=$gparent->{'user'}",
+			              "add1=1&parentuser1=$d->{'user'}",
 			  });
 		}
-	if (ref($gparent) && !$gparent->{'alias'}) {
+	if (ref($d) && !$d->{'alias'}) {
 		push(@rv, { "type" => "item",
 			    "desc" => $text{'form_title3'},
 			    "link" => "/$module_name".
-			        "/domain_form.cgi?to=$gparent->{'id'}&".
+			        "/domain_form.cgi?to=$d->{'id'}&".
 				"nofeat=mail",
 			  });
 		}

--- a/webmin_menu.pl
+++ b/webmin_menu.pl
@@ -80,6 +80,18 @@ $d ||= &get_domain_by("user", $remote_user, "parent", "");
 $d ||= $doms[0];
 $did ||= ($d ? $d->{'id'} : undef);
 
+# Create top-level domain link
+push(@rv, { 'format' => 'new' });
+if (&can_create_master_servers() || &can_create_sub_servers()) {
+	# Domain creation item
+	push(@rv, { "type" => "item",
+		    "desc" => $text{'left_generic'},
+		    "format" => "link-new",
+		    "link" => "/$module_name/domain_form.cgi",
+		  });
+	push(@rv, { 'type' => 'hr' });
+	}
+
 if (@doms > $config{'display_max'} && $config{'display_max'}) {
 	# Domain text box
 	my $dfield = { 'type' => 'input',
@@ -115,20 +127,22 @@ else {
 				       : $text{'left_nodoms'} });
 	}
 
-# Domain creation item
+# Create sub-server and/or alias links
 if (&can_create_master_servers() || &can_create_sub_servers()) {
-	($rdleft, $rdreason, $rdmax) = &count_domains("realdoms");
-	($adleft, $adreason, $admax) = &count_domains("aliasdoms");
-	if ($rdleft || $adleft) {
-		push(@rv, { 'type' => 'item',
-			    'desc' => $text{'left_generic'},
-			    'link' => '/'.$module_name.
-			     '/domain_form.cgi?generic=1&amp;gparent='.$did,
+	my $gparent = &get_domain($did);
+	if (&can_create_sub_servers() && $gparent && !$gparent->{'parent'}) {
+		push(@rv, { "type" => "item",
+			    "desc" => $text{'form_title2'},
+			    "link" => "/$module_name/domain_form.cgi?".
+			              "add1=1&parentuser1=$gparent->{'user'}",
 			  });
 		}
-	else {
-		push(@rv, { 'type' => 'html',
-			    'html' => "<b>".$text{'left_nomore'}."</b>",
+	if (ref($gparent) && !$gparent->{'alias'}) {
+		push(@rv, { "type" => "item",
+			    "desc" => $text{'form_title3'},
+			    "link" => "/$module_name".
+			        "/domain_form.cgi?to=$gparent->{'id'}&".
+			        "aliasmail=".($config{'mail'} ? 1 : 0),
 			  });
 		}
 	}

--- a/webmin_menu.pl
+++ b/webmin_menu.pl
@@ -142,7 +142,7 @@ if (&can_create_master_servers() || &can_create_sub_servers()) {
 			    "desc" => $text{'form_title3'},
 			    "link" => "/$module_name".
 			        "/domain_form.cgi?to=$gparent->{'id'}&".
-			        "aliasmail=".($config{'mail'} ? 1 : 0),
+				"nofeat=mail",
 			  });
 		}
 	}


### PR DESCRIPTION
Hello Jamie!

As we discussed a while back in the chat, here’s the PR that adds support for the new menu layout. This update also addresses issues with labels for virtual servers, sub-servers, and alias servers.

The mail feature for alias domains is now called “Mail for alias” and has its own help tip, since there’s no way to edit mail settings for the domain—I wanted to keep things clear.

Also, let’s discuss whether a home directory is really necessary for an alias with its own mail, and if auto-replies work as intended or are needed at all?

Below are some examples of the reworked menu layout (supported in current Webmin 2.302), based on Joe’s suggestions and numerous user suggestions:

**Create top-level domain menu and form**

<img width="1424" alt="image" src="https://github.com/user-attachments/assets/91ab4d42-caca-4175-9eba-392395807a25" />

**Create sub-server domain menu and form**

<img width="1424" alt="image" src="https://github.com/user-attachments/assets/109527d1-b38f-4d7e-8c58-ddd62f9219c3" />

**Create alias in top-level domain menu and form**

<img width="1423" alt="image" src="https://github.com/user-attachments/assets/32cef51a-7c95-4750-ad89-45045e2c62fd" />

**Edit sub-domain menu and form**

<img width="1421" alt="image" src="https://github.com/user-attachments/assets/d41cb970-e5c4-495b-85e6-604c1c3d5c34" />


**Edit alias server menu and form**

<img width="1425" alt="image" src="https://github.com/user-attachments/assets/05352adc-7bbb-4080-8916-ee6689847eda" />
