### PR TITLE
Fix to increase TXT record split boundary from 80 to 255 characters

### DIFF
--- a/feature-dns.pl
+++ b/feature-dns.pl
@@ -1243,7 +1243,7 @@ else {
 }
 
 # split_long_txt_record(string, [no-brackets])
-# Split a TXT record at 80 char boundaries
+# Split a TXT record at 255 char boundaries
 sub split_long_txt_record
 {
 local ($str, $nobrackets) = @_;
@@ -1251,8 +1251,8 @@ $str =~ s/^"//;
 $str =~ s/"$//;
 local @rv;
 while($str) {
-	local $first = substr($str, 0, 80);
-	$str = substr($str, 80);
+	local $first = substr($str, 0, 255);
+	$str = substr($str, 255);
 	push(@rv, $first);
 	}
 return @rv == 1 ? '"'.$rv[0].'"' :


### PR DESCRIPTION
Hello Jamie!

This change updates the `split_long_txt_record` function to use a 255-character boundary instead of the previous 80-character limit for DNS TXT records.

The 255-character limit aligns just fine with [DNS standards](https://www.rfc-editor.org/rfc/rfc1035#section-2.3.4), which allows up to 255 characters per TXT string.

The current 80-character limit is problematic, especially with SPF records, resulting in unnecessary splits and reduced readability, for example:

```
debian12-pro.virtualmin.dev.	86400	IN	TXT	( "v=spf1 a mx a:debian12-pro.virtualmin.dev ip4:10.211.55.20 ip4:1.2.3.4 ip6" ":fdb2:2c26:f4e4:0:21c:42ff:fea2:f273 ?all" )
```