### PR TITLE
Fix to factor out PHP-FPM start-stop function to work with other webservers

### DIFF
--- a/feature-web.pl
+++ b/feature-web.pl
@@ -2525,34 +2525,6 @@ else {
 		    'longdesc' => $text{'index_astartdesc'},
 		    'links' => \@links });
 	}
-foreach my $fpm (&list_php_fpm_configs()) {
-	&foreign_require("init");
-	next if (!$fpm->{'init'});
-	next if (!defined(&init::status_action));
-	my $st = &init::status_action($fpm->{'init'});
-	next if ($st < 0);
-	if ($st) {
-		# Running, show buttons to stop and restart
-		push(@rv, { 'status' => 1,
-			    'feature' => 'fpm',
-			    'id' => $fpm->{'version'},
-			    'name' => &text('index_fpmname', $fpm->{'version'}),
-			    'desc' => $text{'index_fpmstop'},
-			    'restartdesc' => $text{'index_fpmrestart'},
-			    'longdesc' => &text('index_fpmstopdesc',
-						$fpm->{'version'}) });
-		}
-	else {
-		# Down, show button to start
-		push(@rv, { 'status' => 0,
-			    'feature' => 'fpm',
-			    'id' => $fpm->{'version'},
-			    'name' => &text('index_fpmname', $fpm->{'version'}),
-			    'desc' => $text{'index_fpmstart'},
-			    'longdesc' => &text('index_fpmstartdesc',
-						$fpm->{'version'}) });
-		}
-	}
 return @rv;
 }
 

--- a/php-lib.pl
+++ b/php-lib.pl
@@ -3376,5 +3376,42 @@ return "&nbsp;&nbsp;" .
 			undef, "target=_blank data-placement=\"$placement\"");
 }
 
+# startstop_phpfpm()
+# Returns a hash containing the current status of the PHP-FPM services and short
+# and long descriptions for the action to switch statuses
+sub startstop_phpfpm
+{
+my @rv;
+foreach my $fpm (&list_php_fpm_configs()) {
+	&foreign_require("init");
+	next if (!$fpm->{'init'});
+	next if (!defined(&init::status_action));
+	my $st = &init::status_action($fpm->{'init'});
+	next if ($st < 0);
+	if ($st) {
+		# Running, show buttons to stop and restart
+		push(@rv, { 'status' => 1,
+			    'feature' => 'fpm',
+			    'id' => $fpm->{'version'},
+			    'name' => &text('index_fpmname', $fpm->{'version'}),
+			    'desc' => $text{'index_fpmstop'},
+			    'restartdesc' => $text{'index_fpmrestart'},
+			    'longdesc' => &text('index_fpmstopdesc',
+					        $fpm->{'version'}) });
+		}
+	else {
+		# Down, show button to start
+		push(@rv, { 'status' => 0,
+			    'feature' => 'fpm',
+			    'id' => $fpm->{'version'},
+			    'name' => &text('index_fpmname', $fpm->{'version'}),
+			    'desc' => $text{'index_fpmstart'},
+			    'longdesc' => &text('index_fpmstartdesc',
+					        $fpm->{'version'}) });
+		}
+	}
+return @rv;
+}
+
 1;
 

--- a/restart-server.pl
+++ b/restart-server.pl
@@ -80,6 +80,18 @@ foreach my $f (@startstop_features) {
 			}
 		}
 	}
+foreach my $f (@startstop_always_features) {
+	my $sfunc = "startstop_".$f;
+	if (defined(&$sfunc)) {
+		foreach my $s (&$sfunc()) {
+			my $sf = $s->{'feature'} || $f;
+			if ($sf eq $sname) {
+				$found = 1;
+				}
+			push(@slist, $sf);
+			}
+		}
+	}
 foreach my $f (&list_startstop_plugins()) {
 	if ($f eq $sname) {
 		$found = 2;

--- a/virtual-server-lib-funcs.pl
+++ b/virtual-server-lib-funcs.pl
@@ -14507,6 +14507,15 @@ foreach my $f (@startstop_features) {
 			}
 		}
 	}
+foreach my $f (@startstop_always_features) {
+	local $sfunc = "startstop_".$f;
+	if (defined(&$sfunc)) {
+		foreach my $status (&$sfunc()) {
+			$status->{'feature'} ||= $f;
+			push(@rv, $status);
+			}
+		}
+	}
 foreach my $f (&list_startstop_plugins()) {
 	local $status = &plugin_call($f, "feature_startstop");
 	$status->{'feature'} ||= $f;

--- a/virtual-server-lib.pl
+++ b/virtual-server-lib.pl
@@ -109,6 +109,7 @@ foreach my $fname (@features, "virt", "virt6") {
 		     "directadmin" );
 @startstop_features = ("web", "dns", "mail", "ftp", "unix", "virus", "spam",
 		       "mysql", "postgres");
+@startstop_always_features = ("phpfpm");
 @bandwidth_features = ( @features, "backup", "restore" );
 @config_features = grep { $config{$_} } @features;
 @banned_usernames = ( 'root', 'resellers' );


### PR DESCRIPTION
Hey Jamie!

As [described here](https://forum.virtualmin.com/t/php-fpm-isnt-included-in-server-status-dashboard/133738/11?u=ilia) this PR adds independent support for PHP-FPM monitors.