### PR TITLE
[FIX] Check supported PHP version for selected tiki.

### DIFF
--- a/scripts/tikiwiki.pl
+++ b/scripts/tikiwiki.pl
@@ -56,11 +56,14 @@ sub script_tikiwiki_dbs
 return ("mysql", "postgres");
 }
 
+# script_tikiwiki_php_fullver(&domain, version, &sinfo)
+# Returns the PHP version to use for this script, or undef if it is not supported
 sub script_tikiwiki_php_fullver
 {
 local ($d, $ver, $sinfo) = @_;
-return &compare_versions($ver, 13) < 0 ? undef :
-       &compare_versions($ver, 22) >= 0 ? 7.4 : 5.5;
+return &compare_versions($ver, 17) <= 0 ? undef :
+       &compare_versions($ver, 22) <= 0 ? "7.2" :
+       &compare_versions($ver, 25) <= 0 ? "7.4" : "8.1";
 }
 
 sub script_tikiwiki_can_upgrade


### PR DESCRIPTION
## PHP version issue
While trying to install a new instance via the installer, we notice few things:
* You can select any version while being on an unsupported version of PHP, but the script installer will process with the installation of your instance, then discover after that you should update your PHP version. 
* No possible way to know which version is supported before the installation process.

## Solution
So, knowing that from version 26 it requires PHP 8.1, it require to update version verification.

Related PR: #1066