### PR TITLE
Add ability to check the other SSL providers issuer

### DIFF
--- a/feature-mail.pl
+++ b/feature-mail.pl
@@ -6885,7 +6885,7 @@ if (!&copy_alias_records($d)) {
 	}
 
 my $need_cert_host = !&has_mta_sts_cert($d) &&
-		     (&is_letsencrypt_cert($d) || $d->{'letsencrypt_last_id'});
+		     (&is_acme_cert($d) || $d->{'letsencrypt_last_id'});
 
 # Setup the webserver to serve mta-sts sub-domain
 my $mta_host = "mta-sts.".$d->{'dom'};

--- a/feature-ssl.pl
+++ b/feature-ssl.pl
@@ -419,7 +419,7 @@ if ($d->{'dom'} ne $oldd->{'dom'} && &self_signed_cert($d) &&
 
 if ($d->{'dom'} ne $oldd->{'dom'} &&
     !$d->{'ssl_same'} &&
-    &is_letsencrypt_cert($d) &&
+    &is_acme_cert($d) &&
     !&check_domain_certificate($d->{'dom'}, $d)) {
 	# Domain name has changed ... re-request let's encrypt cert
 	&$first_print($text{'save_ssl12'});
@@ -2952,9 +2952,9 @@ push(@rv, @{$info->{'alt'}}) if ($info->{'alt'});
 return @rv;
 }
 
-# is_letsencrypt_cert(&info|&domain)
-# Returns 1 if a cert info looks like it comes from Let's Encrypt
-sub is_letsencrypt_cert
+# is_acme_cert(&info|&domain)
+# Returns 1 if a cert info looks like it comes from supported ACME provider
+sub is_acme_cert
 {
 my ($info) = @_;
 if ($info->{'dom'} && $info->{'id'}) {
@@ -3001,7 +3001,7 @@ foreach my $d (&list_domains()) {
 	my $expiry = &parse_notafter_date($info->{'notafter'});
 
 	# Is the current cert even from an SSL provider?
-	next if (!&is_letsencrypt_cert($info));
+	next if (!&is_acme_cert($info));
 
 	# Figure out when the cert was last renewed. This is the max of the
 	# date in the cert and the time recorded in Virtualmin
@@ -3239,7 +3239,7 @@ my @caa = grep { $_->{'type'} eq 'CAA' } @$recs;
 my $lets = $letsencrypt_cert;
 if (!$lets) {
 	my $info = &cert_info($d);
-	$lets = &is_letsencrypt_cert($info) ? 1 : 0;
+	$lets = &is_acme_cert($info) ? 1 : 0;
 	}
 # Need delay for DNS propagation
 if (!@caa && $lets) {
@@ -3413,7 +3413,7 @@ $size ||= $tmpl->{'ssl_key_size'};
 my $phd = &public_html_dir($d);
 my $actype = $ctype =~ /^ec/ ? "ecdsa" : "rsa";
 my $dcinfo = &cert_info($d);
-my $dclets = &is_letsencrypt_cert($d);
+my $dclets = &is_acme_cert($d);
 my $dcalgo = $dcinfo->{'algo'};
 my $dctype = $dcalgo =~ /^ec/ ? "ecdsa" : "rsa";
 my $actype_reuse = $actype eq $dctype ? 1 : 0;

--- a/feature-ssl.pl
+++ b/feature-ssl.pl
@@ -2962,10 +2962,10 @@ if ($info->{'dom'} && $info->{'id'}) {
 	$info = &cert_info($info);
 	}
 
-# Check all provider names (if list fn exists)
+# Check all issuer names (if the list sub exists)
 my @patterns = ("Let's\\s+Encrypt");
 if (defined &list_known_acme_providers) {
-	push(@patterns, map { quotemeta($_->{'name'}) }
+	push(@patterns, map { quotemeta($_->{'issuer'}) }
 		&list_known_acme_providers());
 	}
 

--- a/virtual-server-lib-funcs.pl
+++ b/virtual-server-lib-funcs.pl
@@ -8592,7 +8592,7 @@ if ($dom->{'alias'} && &domain_has_website($dom)) {
 	    &domain_has_website($target) &&
 	    &domain_has_ssl_cert($target) &&
 	    ($tinfo = &cert_info($target)) &&
-	    &is_letsencrypt_cert($tinfo) &&
+	    &is_acme_cert($tinfo) &&
 	    !&check_domain_certificate($dom->{'dom'}, $tinfo)) {
 		&$first_print(&text('setup_letsaliases',
 				    &show_domain_name($target),
@@ -12293,7 +12293,7 @@ if ($small) {
 		}
 	$alert_text .= &ui_form_start($formlink);
 	$alert_text .= &ui_hidden("mode", $msg eq 'licence_smallself' ?
-					'create' : &is_letsencrypt_cert($small) ?
+					'create' : &is_acme_cert($small) ?
 							'lets' : 'csr');
 	$alert_text .= &ui_submit($msg eq 'licence_smallself' ?
 				$text{'licence_newcert'} :


### PR DESCRIPTION
Hey Jamie!

As we discussed [here](https://github.com/virtualmin/virtualmin-gpl/commit/b1508fc4a9cb51ff629cca307cdb65546a5d36cb#commitcomment-161442283), this patch resolves the issue of auto-renewals not working for ZeroSSL and other SSL providers but LE.

I have also tested this patch—after uploading it to my production server, the ZeroSSL certificate was renewed within a few minutes.

The patch to make SSL providers' names available in a function is [here](https://github.com/virtualmin/virtualmin-pro/commit/c9646544aa34774262e80f0ca2aa2692fe3708a5).
