### PR TITLE
Fix to properly update IMAP user password

### DIFF
--- a/api-create-domain-lib.pl
+++ b/api-create-domain-lib.pl
@@ -1008,6 +1008,14 @@ elsif ($sshmode == 2) {
 		}
 	}
 
+# Update the IMAP password
+my %u;
+$u{'user'} = $dom{'user'};
+$u{'home'} = $dom{'home'};
+$u{'plainpass'} = $pass;
+&set_usermin_imap_password(\%u);
+
+# Run post actions
 &run_post_actions_silently();
 &unlock_domain_name($domain);
 return \%dom;

--- a/create-domain.pl
+++ b/create-domain.pl
@@ -1086,6 +1086,14 @@ elsif ($sshmode == 2) {
 		}
 	}
 
+# Update the IMAP password
+my %u;
+$u{'user'} = $dom{'user'};
+$u{'home'} = $dom{'home'};
+$u{'plainpass'} = $pass;
+&set_usermin_imap_password(\%u);
+
+# Log the API call and run post actions
 &virtualmin_api_log(\@OLDARGV, \%dom, $dom{'hashpass'} ? [ "pass" ] : [ ]);
 &run_post_actions_silently();
 &unlock_domain_name($domain);

--- a/modify-domain.pl
+++ b/modify-domain.pl
@@ -496,6 +496,14 @@ if (defined($pass)) {
 		$d->{'pass'} = $pass;
 		$d->{'pass_set'} = 1;
 		&generate_domain_password_hashes($d, 0);
+
+		# Update password for IMAP domain owner user
+		next if ($d->{'parent'});
+		my %u;
+		$u{'user'} = $d->{'user'};
+		$u{'home'} = $d->{'home'};
+		$u{'plainpass'} = $pass;
+		&set_usermin_imap_password(\%u);
 		}
 	}
 if (defined($email)) {

--- a/virtual-server-lib-funcs.pl
+++ b/virtual-server-lib-funcs.pl
@@ -2052,9 +2052,7 @@ if (defined(&clear_lookup_domain_cache) && $d) {
 	}
 
 # Set the user's Usermin IMAP password
-if (($user->{'email'} || @{$user->{'extraemail'}}) &&
-    $user->{'plainpass'} && $olduser->{'plainpass'} &&
-    $user->{'plainpass'} ne $olduser->{'plainpass'}) {
+if (($user->{'email'} || @{$user->{'extraemail'}}) && $user->{'plainpass'}) {
 	&set_usermin_imap_password($user);
 	}
 
@@ -2366,8 +2364,9 @@ sub set_usermin_imap_password
 {
 local ($user) = @_;
 return 0 if (!$user->{'home'});
-return 0 if (!$user->{'plainpass'});
-
+my $plainpass = $user->{'plainpass'};
+$plainpass = $in{'passwd'} if (!defined $plainpass); # fetch for domain owner
+return 0 if (!$plainpass);
 # Make sure Usermin is installed, and the mailbox module is setup for IMAP
 return 0 if (!&foreign_check("usermin"));
 &foreign_require("usermin");
@@ -2392,7 +2391,7 @@ if (-d "$user->{'home'}/.usermin/mailbox") {
 	else {
 		$inbox{'user'} = $user->{'user'};
 		}
-	$inbox{'pass'} = $user->{'plainpass'};
+	$inbox{'pass'} = $plainpass;
 	$inbox{'nologout'} = 1;
 	eval {
 		# Ignore errors here, in case user is over quota

--- a/virtual-server-lib-funcs.pl
+++ b/virtual-server-lib-funcs.pl
@@ -2366,6 +2366,7 @@ local ($user) = @_;
 return 0 if (!$user->{'home'});
 my $plainpass = $user->{'plainpass'};
 $plainpass = $in{'passwd'} if (!defined $plainpass); # fetch for domain owner
+$plainpass = $in{'vpass'} if (!defined $plainpass); # fetch for new virtual server
 return 0 if (!$plainpass);
 # Make sure Usermin is installed, and the mailbox module is setup for IMAP
 return 0 if (!&foreign_check("usermin"));


### PR DESCRIPTION
Hey Jamie,

This PR fixes a problem when neither domain owner nor mailbox user IMAP credentials weren't updated correctly.

For domain owner it takes a simple route and checks with submitted data.

For mailbox user it does what it should do, and always updates it because old user will never have `plainpass` set with hashing enabled.

I'm submitting PR instead of patching because I think you may want to discuss current implementation for domain owner.