### PR TITLE
[FIX] Database postgress support: remove postgresql, is no longer supported. 

### DIFF
--- a/scripts/tikiwiki.pl
+++ b/scripts/tikiwiki.pl
@@ -46,14 +46,14 @@ sub script_tikiwiki_php_modules
 {
 local ($d, $ver, $phpver, $opts) = @_;
 local ($dbtype, $dbname) = split(/_/, $opts->{'db'}, 2);
-local @rv = $dbtype eq "mysql" ? ("mysql") : ("pgsql");
+local @rv = $dbtype eq "mysql" ? ("mysql") : return undef;
 push(@rv, "xml", "intl", "zip", "gd", "mbstring");
 return @rv;
 }
 
 sub script_tikiwiki_dbs
 {
-return ("mysql", "postgres");
+return ("mysql");
 }
 
 sub script_tikiwiki_php_fullver
@@ -97,7 +97,7 @@ if ($upgrade) {
 	}
 else {
 	# Show editable install options
-	local @dbs = &domain_databases($d, [ "mysql", "postgres" ]);
+	local @dbs = &domain_databases($d, [ "mysql" ]);
 	$rv .= &ui_table_row("Database for TikiWiki tables",
 		     &ui_database_select("db", undef, \@dbs, $d, "tikiwiki"));
 	$rv .= &ui_table_row("Install sub-directory under <tt>$hdir</tt>",
@@ -253,8 +253,8 @@ else {
 
 sub script_tikiwiki_db_conn_desc
 {
-my $db_conn_desc = 
-    { 'db/local.php' => 
+my $db_conn_desc =
+    { 'db/local.php' =>
         {
            'dbpass' =>
            {

--- a/scripts/tikiwiki.pl
+++ b/scripts/tikiwiki.pl
@@ -44,11 +44,7 @@ return ( 5 );
 
 sub script_tikiwiki_php_modules
 {
-local ($d, $ver, $phpver, $opts) = @_;
-local ($dbtype, $dbname) = split(/_/, $opts->{'db'}, 2);
-local @rv = $dbtype eq "mysql" ? ("mysql") : return undef;
-push(@rv, "xml", "intl", "zip", "gd", "mbstring");
-return @rv;
+return ("mysql", "xml", "intl", "zip", "gd", "mbstring");
 }
 
 sub script_tikiwiki_dbs
@@ -253,8 +249,8 @@ else {
 
 sub script_tikiwiki_db_conn_desc
 {
-my $db_conn_desc =
-    { 'db/local.php' =>
+my $db_conn_desc = 
+    { 'db/local.php' => 
         {
            'dbpass' =>
            {


### PR DESCRIPTION
Post was used on older version of tiki, and they are no longer supported.
Based on [tiki documentation](https://tiki.org/TikiPostgres), postgress is no longer supported.
