### PR TITLE
Add ability to exclude some backup features to avoid overhead

### DIFF
--- a/backup.cgi
+++ b/backup.cgi
@@ -117,6 +117,7 @@ elsif ($cbmode == 3 && $in{'dest_mode'} == 0) {
 
 if ($in{'feature_all'}) {
 	@do_features = ( &get_available_backup_features(), &list_backup_plugins() );
+	&prune_all_features_for_backup(\@do_features);
 	}
 else {
 	@do_features = split(/\0/, $in{'feature'});

--- a/backup.pl
+++ b/backup.pl
@@ -117,6 +117,7 @@ if ($sched->{'key'} && defined(&get_backup_key)) {
 if ($sched->{'feature_all'}) {
 	@do_features = ( &get_available_backup_features(),
 			 &list_backup_plugins() );
+	&prune_all_features_for_backup(\@do_features);
 	}
 else {
 	@do_features = split(/\s+/, $sched->{'features'});

--- a/backups-lib.pl
+++ b/backups-lib.pl
@@ -7347,5 +7347,17 @@ return $log->{'user'} eq $remote_user ||
        $log->{'ownrestore'};
 }
 
+# prune_all_features_for_backup(&features)
+# Remove features whose plugin does not support backup for all features
+sub prune_all_features_for_backup
+{
+my ($features) = @_;
+my %rm = map { $_, 1 }
+	 grep { &plugin_defined($_, 'feature_backup_no_all_features') &&
+		&plugin_call($_, 'feature_backup_no_all_features')
+	 } &list_backup_plugins();
+@$features = grep { !$rm{$_} } @$features;
+}
+
 1;
 

--- a/virtual_feature_api.pl
+++ b/virtual_feature_api.pl
@@ -223,6 +223,13 @@ sub feature_always_links
 {
 }
 
+# feature_backup_no_all_features()
+# Returns 1 if this feature should be excluded from scheduled backups by default
+# when all features are selected to avoid overhead since features could overlap
+sub feature_backup_no_all_features
+{
+}
+
 # feature_backup(&domain, file, &opts, homeformat?, differential?, as-owner,
 #                &all-opts, &destinations)
 # Called to backup this feature for the domain to the given file. Must return 1
@@ -248,7 +255,7 @@ sub feature_always_postbackup
 {
 }
 
-# feature_backup_opts(&opts)
+# feature_backup_opts(&opts, [disabled])
 # Returns HTML for selecting options for a backup of this feature
 sub feature_backup_opts
 {


### PR DESCRIPTION
Hello Jamie!

As [discussed here](https://github.com/virtualmin/virtualmin-gpl/issues/1106#issuecomment-3289502635)—it's been tested and implemented.

Now if the scheduled backup has all features enabled, it will never back up a plugin that has `feature_backup_no_all_features` sub defined to avoid overhead.

On the UI, it will nicely and clearly show those features as grayed-out (disabled). Also, the backup logic will ignore that feature if all features mode is enabled.

I was thinking of just making a patch but made a PR in case you have some questions.