### PR TITLE
Fix to separate lookup URLs to correctly get external IPv4 and IPv6 addresses

### DIFF
--- a/dynip-lib.pl
+++ b/dynip-lib.pl
@@ -92,7 +92,8 @@ if ((my $dig = &has_command("dig")) &&
 if ($error || !$out) {
 	$error = undef;
 	my $url = $config{'ip_lookup_url'} || 
-		"http://software.virtualmin.com/cgi-bin/ip.cgi";
+		"http://v4.software.virtualmin.com/cgi-bin/ip.cgi ".
+		"http://v6.software.virtualmin.com/cgi-bin/ip.cgi";
 	my ($url4, $url6) = split(/\s+/, $url, 2);
 	$url6 ||= $url4;
 	$url = $type == 4 ? $url4 : $url6;


### PR DESCRIPTION
Hello Jamie,

This fixes an issue we discussed in the chat, to clearly get the correct IPv4 and IPv6 using different URLs.

It should be merged when Joe sets this up.