### PR TITLE
A bug hunter example for Webmin modules

### DIFF
--- a/virtual-server-lib-funcs.pl
+++ b/virtual-server-lib-funcs.pl
@@ -12583,6 +12583,17 @@ if ($config{'dns'}) {
 		}
 	}
 
+# Hunt message from a log file that need attention to show to the user
+if (defined &list_logs_messages) {
+	my $file;
+	my $log = { file => $file,      # if empty, check default miniserv.error
+		    msg  => [
+			'SSL certificate parsing using Perl failed',
+		    ] };
+	my @msgs = &list_logs_messages($log);
+	push(@rv, \@msgs);
+	}
+
 return @rv;
 }
 


### PR DESCRIPTION
Hey Jamie,

A while ago, I created a function called `read_file_contents_limit` that can read a file partially. We can use it to find specific error messages in a log and display them on the dashboard in a dismissible alert message, asking the user to report them to us.

This is one way to test a new feature to make sure it works as expected for all users.

A default file to check for logged messages would be `miniserv.error` and each Webmin module would be able to configure its own sets of error messages to check.

But the main logic will be in Webmin.