### PR TITLE
[FIX] Install Instance: add missing command to lock installer after the installation.

### DIFF
--- a/scripts/tikiwiki.pl
+++ b/scripts/tikiwiki.pl
@@ -346,6 +346,9 @@ if ($upgrade) {
 }
 push @steps, ["Rebuild index ", "index:rebuild"];
 
+unless ($upgrade) {
+	push @steps, ["Lock the installer ", "installer:lock "];
+}
 foreach my $step (@steps) {
 	my ($description, $command) = @$step;
 	print "$description<br>";


### PR DESCRIPTION
After the auto-installation we face on the admin panel and message to inform that the lock file is missing to lock the installer to be run.
<img width="878" height="208" alt="image" src="https://github.com/user-attachments/assets/8807e1b9-c291-453d-88af-9345ec62893e" />
