### PR TITLE
Add hooks for feature plugins to inject users into the users listing

### DIFF
--- a/list_users.cgi
+++ b/list_users.cgi
@@ -59,6 +59,13 @@ if ($mleft != 0) {
 			}
 		}
 	}
+# Include user creation links from feature plugins
+foreach my $f (&list_feature_plugins()) {
+	if ($d->{$f} && &plugin_defined($f, "users_create_links")) {
+		my @plinks = &plugin_call($f, "users_create_links", $d);
+		push(@links, @plinks) if @plinks;
+		}
+	}
 push(@links, [ "mass_ucreate_form.cgi?dom=$in{'dom'}",
 	       $text{'users_batch2'}, "right" ]);
 

--- a/virtual-server-lib-funcs.pl
+++ b/virtual-server-lib-funcs.pl
@@ -1127,6 +1127,16 @@ if ($includeextra && &domain_has_website($d) &&
 	push(@users, &list_extra_web_users($d));
 	}
 
+# Include users from feature plugins that define list_plugin_users
+if ($includeextra) {
+	foreach my $f (&list_feature_plugins()) {
+		if ($d->{$f} && &plugin_defined($f, "list_plugin_users")) {
+			my @pu = &plugin_call($f, "list_plugin_users", $d);
+			push(@users, @pu) if @pu;
+			}
+		}
+	}
+
 # Add any secondary groups in the template
 local @sgroups = &allowed_secondary_groups($d);
 if (@sgroups) {
@@ -5723,10 +5733,17 @@ foreach $u (@$users) {
 	    $u->{'webowner'} && $u->{'pass'} =~ /^(\!|\*)/ ? $pop3_dis :
 	    $u->{'webowner'} ? $pop3 :
 	    $u->{'pass'} =~ /^(\!|\*)/ ? $pop3_dis : $pop3);
-	my $col_val = "<a href='edit_user.cgi?dom=$did$filetype&amp;".
-		      "user=".&urlize($u->{'user'})."'>$col_text</a>";
-	if (!$virtualmin_pro && $u->{'extra'}) {
+	my $col_val;
+	if ($u->{'edit_url'}) {
+		$col_val = "<a href='".&html_escape($u->{'edit_url'}).
+			   "'>$col_text</a>";
+		}
+	elsif (!$virtualmin_pro && $u->{'extra'}) {
 		$col_val = $col_text;
+		}
+	else {
+		$col_val = "<a href='edit_user.cgi?dom=$did$filetype&amp;".
+			      "user=".&urlize($u->{'user'})."'>$col_text</a>";
 		}
 	push(@cols, "$col_val\n");
 	push(@cols, &html_escape($u->{'user'}));


### PR DESCRIPTION
## Problem

Feature plugins that manage external user stores (remote mail relay accounts,
LDAP users, etc.) have no way to display their users in the standard domain
users listing or provide creation links. The only option today is a separate
plugin-specific page, which is inconsistent and harder for admins to discover.

## Changes

This PR adds three small hooks to Virtualmin core, following the existing
`plugin_call`/`plugin_defined` pattern already used for database users
(`list_domain_users` line 1096) and web users (`list_extra_web_users` line 1127):

### 1. `list_plugin_users` hook in `list_domain_users()`

Feature plugins can define a `list_plugin_users(&domain)` function that returns
user hashes. These are merged into the standard users listing, just like
`list_extra_web_users` does for `virtualmin-htpasswd`.

```perl
# Include users from feature plugins that define list_plugin_users
if ($includeextra) {
    foreach my $f (&list_feature_plugins()) {
        if ($d->{$f} && &plugin_defined($f, "list_plugin_users")) {
            my @pu = &plugin_call($f, "list_plugin_users", $d);
            push(@users, @pu) if @pu;
        }
    }
}
```

### 2. `edit_url` support in `users_table()`

If a user hash contains an `edit_url` key, that URL is used for the user's
name link instead of the hardcoded `edit_user.cgi`. This lets plugin users
link to their own edit pages. Existing GPL behavior (plain text for extra
users) and Pro behavior (edit_user.cgi links) are preserved unchanged.

### 3. `users_create_links` hook in `list_users.cgi`

Feature plugins can define a `users_create_links(&domain)` function that
returns link arrays (same format as the existing `@links` entries). These
are placed outside the `$mleft` mailbox quota guard since plugin users
don't count against the hosting plan's mailbox limit.

## Backward compatibility

All three changes are **complete no-ops** when no feature plugins define the
hooks. The existing behavior for standard users, database users, and web
users is entirely unchanged.

## Motivation

The immediate use case is [virtualmin-remote-mail](https://github.com/tecto/virtualmin-remote-mail),
a feature plugin that manages mail relay accounts for domains using an
external mail provider. With these hooks, remote mail users appear in the
standard users table alongside regular mailbox users, and admins can create
them from the same page.

The hooks are generic enough that any feature plugin managing external user
stores (LDAP directories, external authentication backends, etc.) could use
them.