### PR TITLE
Fix Dovecot `local_name` insertion order

### DIFF
--- a/feature-ssl.pl
+++ b/feature-ssl.pl
@@ -2403,6 +2403,23 @@ else {
 	}
 }
 
+# dovecot_local_name_cmp(name1, name2)
+# Returns -1 if name1 should be before name2 for Dovecot SNI matching,
+# 1 if it should be after, or 0 if their relative order does not matter.
+sub dovecot_local_name_cmp
+{
+my ($a, $b) = @_;
+$a = lc($a);
+$b = lc($b);
+$a =~ s/\.$//;
+$b =~ s/\.$//;
+my $aw = $a =~ s/^\*\.// ? 1 : 0;
+my $bw = $b =~ s/^\*\.// ? 1 : 0;
+return -1 if ($aw && !$bw && $b =~ /^[^\.]+\.\Q$a\E$/);
+return 1 if ($bw && !$aw && $a =~ /^[^\.]+\.\Q$b\E$/);
+return 0;
+}
+
 # sync_dovecot_ssl_cert(&domain, [enable-or-disable])
 # If supported, configure Dovecot to use this domain's SSL cert for its IP
 sub sync_dovecot_ssl_cert
@@ -2562,8 +2579,6 @@ if (!$d->{'virt'}) {
 		}
 	else {
 		# May need to add or update
-		my $pdname = $d->{'dom'};
-		$pdname =~ s/^[^\.]+\.//;
 		foreach my $n (@dnames) {
 			my ($l) = grep { $_->{'value'} eq $n } @loc;
 			if ($l) {
@@ -2585,11 +2600,16 @@ if (!$d->{'virt'}) {
 						  'value' => $kvalue, },
 						],
 					  'file' => $cfile };
-				my ($plocal) = grep { $_->{'value'} eq $pdname } @loc;
+				my ($plocal) = grep {
+					&dovecot_local_name_cmp(
+						$n, $_->{'value'}) < 0
+					} @loc;
 				&dovecot::create_section($conf, $l, undef,
 							 $plocal);
 				push(@$conf, $l);
 				&flush_file_lines($l->{'file'}, undef, 1);
+				@loc = grep { $_->{'name'} eq 'local_name' &&
+					      $_->{'section'} } @$conf;
 				}
 			}
 		# Find old entries to remove

--- a/functional-test.pl
+++ b/functional-test.pl
@@ -7865,20 +7865,6 @@ $sslserv_tests = [
 		      [ 'service', 'dovecot' ] ],
 	},
 
-	# Check that parent wildcard is before the child host
-	{ 'command' => 'cat '.&dovecot::get_config_file(),
-	  'grep' => [ 'local_name \\*\\.'.$test_domain,
-		      'local_name '.$test_ssl_subdomain,
-		    ],
-	},
-	{ 'command' => "perl -ne 'if (/local_name \\\\Q*.$test_domain\\\\E\\\\b/) ".
-		       "{ \$w = \$.; } ".
-		       "if (/local_name \\\\Q$test_ssl_subdomain\\\\E\\\\b/) ".
-		       "{ \$s = \$.; } ".
-		       "END { exit(!(\$w && \$s && \$w < \$s)); }' ".
-		       &dovecot::get_config_file(),
-	},
-
 	# Validate that child Dovecot SNI prefers the specific host cert
 	{ 'command' => 'test-imap.pl',
 	  'args' => [ [ 'user', $test_ssl_subdomain_user ],

--- a/functional-test.pl
+++ b/functional-test.pl
@@ -7601,13 +7601,13 @@ $sslserv_tests = [
 		      @create_args, ],
         },
 
-	# Create an alias as well
+	# Create an alias with mail and SSL as well
 	{ 'command' => 'create-domain.pl',
 	  'args' => [ [ 'domain', $test_subdomain ],
 		      [ 'alias', $test_domain ],
 		      [ 'prefix', 'example2' ],
 		      [ 'desc', 'Test alias-domain' ],
-		      [ 'dir' ], [ $web ], [ 'dns' ], [ 'mail' ],
+		      [ 'dir' ], [ $web ], [ 'dns' ], [ 'mail' ], [ $ssl ],
 		      @create_args, ],
 	},
 
@@ -7746,6 +7746,8 @@ $sslserv_tests = [
 	{ 'command' => 'cat '.&dovecot::get_config_file(),
 	  'grep' => [ 'local_name '.$test_domain,
 		      'local_name \\*\\.'.$test_domain,
+		      'local_name '.$test_subdomain,
+		      'local_name \\*\\.'.$test_subdomain,
 		    ],
 	},
 
@@ -7835,6 +7837,68 @@ $sslserv_tests = [
 	  'antigrep' => [ 'O=Test 2 SSL domain', 'CN=(\\*\\.)?'.$test_domain ],
 	},
 
+	# Create a child domain on the shared IP with a different cert
+	{ 'command' => 'create-domain.pl',
+	  'args' => [ [ 'domain', $test_ssl_subdomain ],
+		      [ 'desc', 'Test SSL subdomain' ],
+		      [ 'pass', 'smeg' ],
+		      [ 'parent', $test_domain ],
+		      [ 'dir' ], [ 'unix' ], [ $web ], [ 'dns' ], [ 'mail' ],
+		      [ $ssl ],
+		      [ 'parent-ip' ],
+		      [ 'break-ssl-cert' ],
+		      [ 'content' => 'Test SSL subdomain home page' ],
+		      @create_args, ],
+	},
+
+	# Give the child its own distinct SSL cert
+	{ 'command' => 'generate-cert.pl',
+	  'args' => [ [ 'domain' => $test_ssl_subdomain ],
+		      [ 'self' ],
+		      [ 'o', 'Test 3 SSL subdomain' ] ],
+	},
+
+	# Install a Dovecot cert for the child domain too
+	{ 'command' => 'install-service-cert.pl',
+	  'args' => [ [ 'domain', $test_ssl_subdomain ],
+		      [ 'add-domain' ],
+		      [ 'service', 'dovecot' ] ],
+	},
+
+	# Check that parent wildcard is before the child host
+	{ 'command' => 'cat '.&dovecot::get_config_file(),
+	  'grep' => [ 'local_name \\*\\.'.$test_domain,
+		      'local_name '.$test_ssl_subdomain,
+		    ],
+	},
+	{ 'command' => "perl -ne 'if (/local_name \\\\Q*.$test_domain\\\\E\\\\b/) ".
+		       "{ \$w = \$.; } ".
+		       "if (/local_name \\\\Q$test_ssl_subdomain\\\\E\\\\b/) ".
+		       "{ \$s = \$.; } ".
+		       "END { exit(!(\$w && \$s && \$w < \$s)); }' ".
+		       &dovecot::get_config_file(),
+	},
+
+	# Validate that child Dovecot SNI prefers the specific host cert
+	{ 'command' => 'test-imap.pl',
+	  'args' => [ [ 'user', $test_ssl_subdomain_user ],
+		      [ 'pass', 'smeg' ],
+		      [ 'server', $test_ssl_subdomain ],
+		      [ 'ssl' ] ],
+	},
+	{ 'command' => 'openssl s_client -host mail.'.$test_ssl_subdomain.
+		       ' -servername '.$test_ssl_subdomain.
+		       ' -port 993 </dev/null',
+	  'grep' => [ 'O=Test 3 SSL subdomain',
+		      'CN=(\\*\\.)?'.$test_ssl_subdomain ],
+	},
+
+	# Remove the child domain again before the remaining service-cert tests
+	{ 'command' => 'delete-domain.pl',
+	  'args' => [ [ 'domain', $test_ssl_subdomain ] ],
+	  'cleanup' => 1,
+	},
+
 	# Turn off per-service certs
 	{ 'command' => 'install-service-cert.pl',
 	  'args' => [ [ 'domain', $test_domain ],
@@ -7849,6 +7913,8 @@ $sslserv_tests = [
 	{ 'command' => 'cat '.&dovecot::get_config_file(),
 	  'antigrep' => [ 'local_name '.$test_domain,
 		          'local_name \\*\\.'.$test_domain,
+		          'local_name '.$test_subdomain,
+		          'local_name \\*\\.'.$test_subdomain,
 		        ],
 	},
 


### PR DESCRIPTION
Hi, Jamie!

As [discussed earlier](https://github.com/virtualmin/virtualmin-gpl/commit/94211df1411d8310b6864d4914cf9aed7c64e741#commitcomment-184911306), this PR simply places newly created Dovecot SSL SNI `local_name` blocks before overlapping exact host blocks when needed, without reordering existing configs.
