### PR TITLE
Prep for testing, add compile.t

### DIFF
--- a/backup.pl
+++ b/backup.pl
@@ -2,6 +2,9 @@
 # Do a scheduled virtual server backup
 
 package virtual_server;
+
+unless (caller) {
+
 $main::no_acl_check++;
 require './virtual-server-lib.pl';
 $host = &get_system_hostname();
@@ -337,6 +340,8 @@ if ($sched->{'email_doms'} && $has_mailboxes &&
 	    { 'doms' => [ map { $_->{'dom'} } @doms ],
 	      'failed' => !$ok,
 	      'sched' => $id, });
+
+} # end of unless (caller)
 
 # Override print functions to capture output
 sub first_save_print

--- a/backup.pl
+++ b/backup.pl
@@ -3,7 +3,7 @@
 
 package virtual_server;
 
-unless (caller) {
+unless ($ENV{VIRTUALMIN_NO_MAIN}) {
 
 $main::no_acl_check++;
 require './virtual-server-lib.pl';
@@ -341,7 +341,7 @@ if ($sched->{'email_doms'} && $has_mailboxes &&
 	      'failed' => !$ok,
 	      'sched' => $id, });
 
-} # end of unless (caller)
+} # end of unless ($ENV{VIRTUALMIN_NO_MAIN})
 
 # Override print functions to capture output
 sub first_save_print

--- a/bwgraph.cgi
+++ b/bwgraph.cgi
@@ -2,6 +2,8 @@
 # bwgraph.cgi
 # Show current bandwidth usage graphs
 
+unless (caller) {
+
 require './virtual-server-lib.pl';
 &ReadParse();
 
@@ -403,6 +405,8 @@ if (&can_edit_templates() && $in{'dom'}) {
 	}
 push(@rets, "", $text{'index_return'});
 &ui_print_footer(@rets);
+
+} # end of unless (caller)
 
 # usage_colours(&domain, &usage)
 sub usage_colours

--- a/check-scripts.pl
+++ b/check-scripts.pl
@@ -12,7 +12,7 @@ be called.
 
 package virtual_server;
 
-unless (caller) {
+unless ($ENV{VIRTUALMIN_NO_MAIN}) {
 
 if (!$module_name) {
 	$main::no_acl_check++;
@@ -249,7 +249,7 @@ if (@errs) {
 		}
 	}
 
-} # end of unless (caller)
+} # end of unless ($ENV{VIRTUALMIN_NO_MAIN})
 
 sub patch_file
 {

--- a/check-scripts.pl
+++ b/check-scripts.pl
@@ -11,6 +11,9 @@ be called.
 =cut
 
 package virtual_server;
+
+unless (caller) {
+
 if (!$module_name) {
 	$main::no_acl_check++;
 	$ENV{'WEBMIN_CONFIG'} ||= "/etc/webmin";
@@ -245,6 +248,8 @@ if (@errs) {
 					   $body);
 		}
 	}
+
+} # end of unless (caller)
 
 sub patch_file
 {

--- a/downgrade-licence.pl
+++ b/downgrade-licence.pl
@@ -11,6 +11,9 @@ accounts, switches repositories, and reverts the license to GPL.
 =cut
 
 package virtual_server;
+
+unless (caller) {
+
 if (!$module_name) {
 	$main::no_acl_check++;
 	$ENV{'WEBMIN_CONFIG'} ||= "/etc/webmin";
@@ -166,6 +169,8 @@ if ($gpl_downgrading_failed_status) {
 else {
 	&$first_print($text{'downgrade_gpl_all_done'});
 	}
+
+} # end of unless (caller)
 
 # lock_all_resellers()
 # Lock all reseller accounts

--- a/downgrade-licence.pl
+++ b/downgrade-licence.pl
@@ -12,7 +12,7 @@ accounts, switches repositories, and reverts the license to GPL.
 
 package virtual_server;
 
-unless (caller) {
+unless ($ENV{VIRTUALMIN_NO_MAIN}) {
 
 if (!$module_name) {
 	$main::no_acl_check++;
@@ -170,7 +170,7 @@ else {
 	&$first_print($text{'downgrade_gpl_all_done'});
 	}
 
-} # end of unless (caller)
+} # end of unless ($ENV{VIRTUALMIN_NO_MAIN})
 
 # lock_all_resellers()
 # Lock all reseller accounts

--- a/functional-test.pl
+++ b/functional-test.pl
@@ -3,7 +3,7 @@
 
 package virtual_server;
 
-unless (caller) {
+unless ($ENV{VIRTUALMIN_NO_MAIN}) {
 
 if (!$module_name) {
 	$main::no_acl_check++;
@@ -13323,7 +13323,7 @@ if ($total_failed) {
 	}
 exit($total_failed);
 
-} # end of unless (caller)
+} # end of unless ($ENV{VIRTUALMIN_NO_MAIN})
 
 sub run_test
 {

--- a/functional-test.pl
+++ b/functional-test.pl
@@ -2,6 +2,9 @@
 # Runs all Virtualmin tests
 
 package virtual_server;
+
+unless (caller) {
+
 if (!$module_name) {
 	$main::no_acl_check++;
 	$ENV{'WEBMIN_CONFIG'} ||= "/etc/webmin";
@@ -13319,6 +13322,8 @@ if ($total_failed) {
 	print "!!!!!!!!!!!!! FAILURES : ",join(" ", @failed_tests,),"\n";
 	}
 exit($total_failed);
+
+} # end of unless (caller)
 
 sub run_test
 {

--- a/info.pl
+++ b/info.pl
@@ -26,7 +26,7 @@ to sections of the full output, for example:
 
 package virtual_server;
 
-unless (caller) {
+unless ($ENV{VIRTUALMIN_NO_MAIN}) {
 
 if (!$module_name) {
 	$main::no_acl_check++;
@@ -93,7 +93,7 @@ foreach my $k (keys %$info) {
 	}
 &recursive_info_dump($info, "");
 
-} # end of unless (caller)
+} # end of unless ($ENV{VIRTUALMIN_NO_MAIN})
 
 sub recursive_info_dump
 {

--- a/info.pl
+++ b/info.pl
@@ -25,6 +25,9 @@ to sections of the full output, for example:
 =cut
 
 package virtual_server;
+
+unless (caller) {
+
 if (!$module_name) {
 	$main::no_acl_check++;
 	$ENV{'WEBMIN_CONFIG'} ||= "/etc/webmin";
@@ -89,6 +92,8 @@ foreach my $k (keys %$info) {
 	delete($info->{$k}) if (!&info_search_match($k));
 	}
 &recursive_info_dump($info, "");
+
+} # end of unless (caller)
 
 sub recursive_info_dump
 {

--- a/link.cgi
+++ b/link.cgi
@@ -321,6 +321,8 @@ if (!$$injected_ref) {
 return $chunk;
 }
 
+unless (caller) {
+
 &init_config();
 delete($ENV{'HTTP_REFERER'});
 $| = 1;
@@ -368,4 +370,6 @@ else {
 		}
 	}
 &close_http_connection($con);
+
+} # end of unless (caller)
 

--- a/list-config-revisions.pl
+++ b/list-config-revisions.pl
@@ -72,11 +72,11 @@ Specifies which Git repository to use. Defaults to F</etc/.git/>.
 package virtual_server;
 
 # File-scope lexicals shared between the main body and the subs below.
-# Kept outside the `unless (caller)` guard so subs see them when the
+# Kept outside the VIRTUALMIN_NO_MAIN guard so subs see them when the
 # script is `require`d for testing without the main body running.
 my ($etcdir, $depth, $git_repo);
 
-unless (caller) {
+unless ($ENV{VIRTUALMIN_NO_MAIN}) {
 
 # If not loaded by Webmin, do standard Virtualmin environment prep
 if (!$module_name) {
@@ -169,7 +169,7 @@ else {
 &do_list(\@source_paths, $depth, $git_repo);
 exit(0);
 
-} # end of unless (caller)
+} # end of unless ($ENV{VIRTUALMIN_NO_MAIN})
 
 # usage(msg)
 # Print usage message and exit

--- a/list-config-revisions.pl
+++ b/list-config-revisions.pl
@@ -71,6 +71,13 @@ Specifies which Git repository to use. Defaults to F</etc/.git/>.
 
 package virtual_server;
 
+# File-scope lexicals shared between the main body and the subs below.
+# Kept outside the `unless (caller)` guard so subs see them when the
+# script is `require`d for testing without the main body running.
+my ($etcdir, $depth, $git_repo);
+
+unless (caller) {
+
 # If not loaded by Webmin, do standard Virtualmin environment prep
 if (!$module_name) {
 	$main::no_acl_check++;
@@ -88,7 +95,7 @@ if (!$module_name) {
 	}
 
 # Get /etc from environment
-my $etcdir = $ENV{'WEBMIN_CONFIG'};
+$etcdir = $ENV{'WEBMIN_CONFIG'};
 $etcdir =~ s/\/[^\/]+$//;
 
 # Disable HTML output
@@ -97,10 +104,10 @@ $etcdir =~ s/\/[^\/]+$//;
 # Parse command-line args
 &parse_common_cli_flags(\@ARGV);
 
-my $depth = 1;
+$depth = 1;
 my @module_files;
 my $module;
-my $git_repo = "$etcdir/.git";
+$git_repo = "$etcdir/.git";
 
 while(@ARGV > 0) {
 	my $a = shift(@ARGV);
@@ -161,6 +168,8 @@ else {
 # Main logic
 &do_list(\@source_paths, $depth, $git_repo);
 exit(0);
+
+} # end of unless (caller)
 
 # usage(msg)
 # Print usage message and exit

--- a/lookup-domain-daemon.pl
+++ b/lookup-domain-daemon.pl
@@ -23,7 +23,7 @@ package virtual_server;
 use POSIX;
 use Socket;
 
-unless (caller) {
+unless ($ENV{VIRTUALMIN_NO_MAIN}) {
 
 $main::no_acl_check++;
 $ENV{'WEBMIN_CONFIG'} ||= "/etc/webmin";
@@ -139,7 +139,7 @@ while(1) {
 		}
 	}
 
-} # end of unless (caller)
+} # end of unless ($ENV{VIRTUALMIN_NO_MAIN})
 
 sub handle_one_request
 {

--- a/lookup-domain-daemon.pl
+++ b/lookup-domain-daemon.pl
@@ -20,6 +20,11 @@ typically started by C</etc/init.d/lookup-domain>.
 =cut
 
 package virtual_server;
+use POSIX;
+use Socket;
+
+unless (caller) {
+
 $main::no_acl_check++;
 $ENV{'WEBMIN_CONFIG'} ||= "/etc/webmin";
 $ENV{'WEBMIN_VAR'} ||= "/var/webmin";
@@ -33,8 +38,6 @@ $0 = "$pwd/lookup-domain-daemon.pl";
 $no_virtualmin_plugins = 1;
 require './virtual-server-lib.pl';
 $< == 0 || die "lookup-domain-daemon.pl must be run as root";
-use POSIX;
-use Socket;
 
 # Parse command line
 $port = $config{'lookup_domain_port'} || $lookup_domain_port;
@@ -135,6 +138,8 @@ while(1) {
 		@childpids = grep { kill(0, $_) } @childpids;
 		}
 	}
+
+} # end of unless (caller)
 
 sub handle_one_request
 {

--- a/quotas.pl
+++ b/quotas.pl
@@ -3,6 +3,9 @@
 # the admin for those that are over.
 
 package virtual_server;
+
+unless (caller) {
+
 $main::no_acl_check++;
 $no_virtualmin_plugins = 1;
 require './virtual-server-lib.pl';
@@ -110,6 +113,8 @@ if ($config{'quota_email'}) {
 		&send_user_quota_email(\@umsgs, $config{'quota_email'});
 		}
 	}
+
+} # end of unless (caller)
 
 # send_domain_quota_email(&message, address)
 # Converts a list of domain over-quota notifications into a message, and send it

--- a/quotas.pl
+++ b/quotas.pl
@@ -4,7 +4,7 @@
 
 package virtual_server;
 
-unless (caller) {
+unless ($ENV{VIRTUALMIN_NO_MAIN}) {
 
 $main::no_acl_check++;
 $no_virtualmin_plugins = 1;
@@ -114,7 +114,7 @@ if ($config{'quota_email'}) {
 		}
 	}
 
-} # end of unless (caller)
+} # end of unless ($ENV{VIRTUALMIN_NO_MAIN})
 
 # send_domain_quota_email(&message, address)
 # Converts a list of domain over-quota notifications into a message, and send it

--- a/restore-config-revision.pl
+++ b/restore-config-revision.pl
@@ -93,6 +93,13 @@ Specifies which Git repository to use. Defaults to F</etc/.git/>.
 
 package virtual_server;
 
+# File-scope lexicals shared between the main body and the subs below.
+# Kept outside the `unless (caller)` guard so subs see them when the
+# script is `require`d for testing without the main body running.
+my ($etcdir, $target_dir, $dry_run, $depth, $git_repo);
+
+unless (caller) {
+
 # If not loaded by Webmin, do standard Virtualmin environment prep
 if (!$module_name) {
 	$main::no_acl_check++;
@@ -110,7 +117,7 @@ if (!$module_name) {
 	}
 
 # Get /etc from environment
-my $etcdir = $ENV{'WEBMIN_CONFIG'};
+$etcdir = $ENV{'WEBMIN_CONFIG'};
 $etcdir =~ s/\/[^\/]+$//;
 
 # Disable HTML output
@@ -119,12 +126,10 @@ $etcdir =~ s/\/[^\/]+$//;
 # Parse command-line args
 &parse_common_cli_flags(\@ARGV);
 
-my $target_dir;
-my $dry_run;
-my $depth = 1;
+$depth = 1;
 my @module_files;
 my $module;
-my $git_repo = "$etcdir/.git";
+$git_repo = "$etcdir/.git";
 
 while(@ARGV > 0) {
 	my $a = shift(@ARGV);
@@ -198,6 +203,8 @@ else {
 # Main logic
 &do_restore(\@source_paths, $depth, $git_repo, $target_dir, $dry_run);
 exit(0);
+
+} # end of unless (caller)
 
 # usage(msg)
 # Print usage message and exit

--- a/restore-config-revision.pl
+++ b/restore-config-revision.pl
@@ -93,10 +93,10 @@ Specifies which Git repository to use. Defaults to F</etc/.git/>.
 
 package virtual_server;
 
-# File-scope lexicals shared between the main body and the subs below.
-# Kept outside the VIRTUALMIN_NO_MAIN guard so subs see them when the
+# File-scope lexical shared between the main body and the subs below.
+# Kept outside the VIRTUALMIN_NO_MAIN guard so subs see it when the
 # script is `require`d for testing without the main body running.
-my ($etcdir, $target_dir, $dry_run, $depth, $git_repo);
+my ($etcdir);
 
 unless ($ENV{VIRTUALMIN_NO_MAIN}) {
 

--- a/restore-config-revision.pl
+++ b/restore-config-revision.pl
@@ -94,11 +94,11 @@ Specifies which Git repository to use. Defaults to F</etc/.git/>.
 package virtual_server;
 
 # File-scope lexicals shared between the main body and the subs below.
-# Kept outside the `unless (caller)` guard so subs see them when the
+# Kept outside the VIRTUALMIN_NO_MAIN guard so subs see them when the
 # script is `require`d for testing without the main body running.
 my ($etcdir, $target_dir, $dry_run, $depth, $git_repo);
 
-unless (caller) {
+unless ($ENV{VIRTUALMIN_NO_MAIN}) {
 
 # If not loaded by Webmin, do standard Virtualmin environment prep
 if (!$module_name) {
@@ -204,7 +204,7 @@ else {
 &do_restore(\@source_paths, $depth, $git_repo, $target_dir, $dry_run);
 exit(0);
 
-} # end of unless (caller)
+} # end of unless ($ENV{VIRTUALMIN_NO_MAIN})
 
 # usage(msg)
 # Print usage message and exit

--- a/spamtrap.pl
+++ b/spamtrap.pl
@@ -4,7 +4,7 @@
 
 package virtual_server;
 
-unless (caller) {
+unless ($ENV{VIRTUALMIN_NO_MAIN}) {
 
 $main::no_acl_check++;
 $no_virtualmin_plugins = 1;
@@ -249,7 +249,7 @@ foreach $d (&list_domains()) {
 	&clear_index_file($hamf->{'file'});
 	}
 
-} # end of unless (caller)
+} # end of unless ($ENV{VIRTUALMIN_NO_MAIN})
 
 # find_user_by_email(email, &users, &aliases)
 sub find_user_by_email

--- a/spamtrap.pl
+++ b/spamtrap.pl
@@ -3,6 +3,9 @@
 # domains with spam emailed.
 
 package virtual_server;
+
+unless (caller) {
+
 $main::no_acl_check++;
 $no_virtualmin_plugins = 1;
 require './virtual-server-lib.pl';
@@ -245,6 +248,8 @@ foreach $d (&list_domains()) {
 	&clear_index_file($spamf->{'file'});
 	&clear_index_file($hamf->{'file'});
 	}
+
+} # end of unless (caller)
 
 # find_user_by_email(email, &users, &aliases)
 sub find_user_by_email

--- a/t/README.md
+++ b/t/README.md
@@ -128,7 +128,7 @@ remains inside the guard, so tests can mock the values themselves.
 ## Sub-stubbing in tests
 
 The canonical example lives in the Webmin repo:
-`webmin/t/miniserv-http_error.t`. The pattern:
+`webmin/t/miniserv.t`. The pattern:
 
 1. `require` the script. The `unless (caller)` guard skips its main body.
 2. Replace side-effecting subs (disk I/O, `backquote_command`, network,

--- a/t/README.md
+++ b/t/README.md
@@ -1,0 +1,136 @@
+# Virtualmin test suite
+
+This `t/` tree holds tests for virtualmin-gpl. Companion infrastructure
+lives in the Webmin repo (`webmin/t/`); the patterns here mirror it.
+
+`functional-test.pl` already provides significant integration testing, but
+likely needs some work to make it usable via `prove` and in CI.
+
+## Running tests
+
+```sh
+prove -lr t                                          # everything under t/
+prove t/compile.t                                    # one test file
+VIRTUALMIN_COMPILE_T_FILTER='^\./backup' prove t/compile.t   # one area
+```
+
+`prove` and `Test::More` are core; on RPM-based distros, install
+`perl-Test-Harness`.
+
+## What's here
+
+| File | What it checks |
+| --- | --- |
+| `compile.t` | Every `.pl` and `.cgi` parses cleanly (`perl -c`). Catches breakage from bulk refactors without exercising every page. ~1s for the full tree (537 files). |
+
+## The require-and-stub pattern
+
+Most Virtualmin scripts mix sub definitions with a main body that opens
+the Webmin config, reads `/etc/webmin/virtual-server/*`, talks to MySQL,
+or runs CLI work. To test individual subs in isolation we `require` the
+script as a library without running the main body.
+
+Virtualmin's idiom — script body runs at file scope, helper subs are
+defined alongside or below — calls for the **block-wrap** form:
+
+```perl
+#!/usr/local/bin/perl
+package virtual_server;
+require './virtual-server-lib.pl';   # use lines and requires stay outside
+
+unless (caller) {
+
+# main body: arg parsing, the actual work
+while(@ARGV > 0) { ... }
+...
+
+} # end of unless (caller)
+
+sub helper { ... }
+```
+
+The `!caller(0)` one-liner form used by Webmin's `bin/` tools (`exit
+main(\@ARGV) if !caller(0);`) doesn't fit here — Virtualmin scripts
+don't have a `sub main` convention.
+
+**Which scripts are wrapped.** The vast majority of `.pl` and `.cgi`
+files have no helper subs beyond `sub usage`, so wrapping them buys
+nothing — there is nothing to call from a test. The scripts currently
+wrapped are the ones with non-trivial helper subs we'd plausibly want to
+exercise in isolation:
+
+| File | Subs available to tests |
+| --- | --- |
+| `link.cgi` | preview/proxy logic: `parse_preview_request`, `open_target_connection`, `send_target_request`, `read_target_headers`, `read_browser_request_body`, `is_basic_auth_challenge`, `preflight_preview_request`, `print_preview_wrapper`, `rewrite_proxy_redirect`, `sanitize_proxy_headers`, `preview_blocker_markup`, `rewrite_html_chunk`, `require_local_preview_ip` |
+| `bwgraph.cgi` | `usage_colours`, `minimum_day`, `usage_for_days` |
+| `backup.pl` | `first_save_print`, `second_save_print`, `indent_save_print`, `outdent_save_print`, `backup_cbfunc` |
+| `functional-test.pl` | `run_test`, `run_test_command`, `postgresql_login_commands`, `convert_to_encrypted`, `convert_to_dnscloud`, `convert_to_location`, `convert_to_atmail` |
+| `quotas.pl` | `send_domain_quota_email`, `send_user_quota_email`, `send_single_user_quota_email`, `check_quota_threshold`, `check_quota_interval` |
+| `upload-api-docs.pl` | `convert_to_html`, `extract_html_title`, `unique`, `indexof` |
+| `check-scripts.pl` | `patch_file`, `ftp_size` |
+| `lookup-domain-daemon.pl` | `handle_one_request`, `send_response` |
+| `info.pl` | `recursive_info_dump`, `info_search_match` |
+| `restore-config-revision.pl` | `normalize_paths`, `do_restore` |
+| `list-config-revisions.pl` | `normalize_paths`, `do_list` |
+| `spamtrap.pl` | `find_user_by_email`, `parse_received_header`, `clear_index_file` |
+| `downgrade-licence.pl` (and the `downgrade-license.pl` symlink) | `lock_all_resellers`, `execute_command_error`, `revert_virtualmin_license_file` |
+
+Any future script that grows a testable sub should add the same guard at
+the same time.
+
+A few of the wrapped files (`restore-config-revision.pl`,
+`list-config-revisions.pl`) declare lexical `my` variables at file scope
+that the subs below reference (`$etcdir` for path normalization). Those
+declarations are pulled above the `unless (caller)` line so the subs
+still see them when the script is `require`d for testing. Initialization
+remains inside the guard, so tests can mock the values themselves.
+
+## Sub-stubbing in tests
+
+The canonical example lives in the Webmin repo:
+`webmin/t/miniserv-http_error.t`. The pattern:
+
+1. `require` the script. The `unless (caller)` guard skips its main body.
+2. Replace side-effecting subs (disk I/O, `backquote_command`, network,
+   logging) with capture-buffer overrides under `no warnings 'redefine'`.
+3. Populate package globals (`%config`, `%text`, `%access`, etc.)
+   directly instead of running `init_config()` and friends.
+4. Call the sub under test. Assert on contract — return values,
+   side-effect captures, structural properties — not on cosmetics like
+   exact wording or HTML class names.
+
+Tying tests to contract rather than rendering lets the UI evolve without
+breaking the test, while still catching real regressions.
+
+## Tiered coverage policy
+
+- **Tier 1 — security-critical paths.** ACL checks (`acl_security.pl`,
+  `can_*` predicates in `virtual-server-lib-funcs.pl`), backup
+  encryption/key handling, command execution wrappers, user/password
+  handling. Comprehensive contract tests as scripts come under audit.
+- **Tier 2 — active refactor surface.** New code, code changing in
+  response to ongoing audit. perlcritic and strict/warnings for all
+  code.
+- **Tier 3 — everything else.** Covered by `compile.t`. Don't chase line
+  coverage on stable parsers.
+
+The goal is not coverage-as-a-number. It's:
+
+- Every parser round-trips its serializer.
+- Every privilege boundary has a test.
+- Every external-command call has a mock-driven test for its output
+  parser.
+
+## Caveats
+
+- `VIRTUALMIN_COMPILE_T_STRICT=1` turns missing-CPAN-module skips into
+  failures. Use this in CI on a fully-provisioned image; leave it off on
+  dev boxes where optional deps may be missing.
+- `.pl` is also the Polish translation suffix. `compile.t` skips
+  `<file>.pl` when a sibling `<file>` (no extension) exists, so
+  `module.info.pl` and similar data files are excluded without a
+  hardcoded list.
+- Virtualmin scripts expect to be invoked from the module directory
+  with Webmin's environment (`WEBMIN_CONFIG`, `WEBMIN_VAR`). Tests that
+  go beyond `perl -c` will need to either set those up in a tmpdir or
+  stub the loaders.

--- a/t/README.md
+++ b/t/README.md
@@ -31,27 +31,67 @@ or runs CLI work. To test individual subs in isolation we `require` the
 script as a library without running the main body.
 
 Virtualmin's idiom — script body runs at file scope, helper subs are
-defined alongside or below — calls for the **block-wrap** form:
+defined alongside or below — calls for the **block-wrap** form. The
+guard differs between CLI `.pl` scripts and `.cgi` files:
 
 ```perl
 #!/usr/local/bin/perl
 package virtual_server;
-require './virtual-server-lib.pl';   # use lines and requires stay outside
 
-unless (caller) {
+unless ($ENV{VIRTUALMIN_NO_MAIN}) {   # CLI .pl files
 
 # main body: arg parsing, the actual work
+require './virtual-server-lib.pl';
 while(@ARGV > 0) { ... }
 ...
 
-} # end of unless (caller)
+} # end of guard
 
 sub helper { ... }
 ```
 
+```perl
+#!/usr/local/bin/perl
+# A .cgi file
+unless (caller) {                      # .cgi files only
+
+require './virtual-server-lib.pl';
+&ReadParse();
+...
+
+} # end of guard
+
+sub helper { ... }
+```
+
+**Why two guards.** Virtualmin's `execute_webmin_script` (in
+`json-lib.pl`) runs CLI scripts as `do $cmd` inside an `eval "..."`
+block in a forked child — this is the path Webmin Cron uses to run
+scheduled jobs like `backup.pl`. Under that path, `caller` is defined
+(the eval frame), so `unless (caller)` would wrongly skip the main body
+and the cron job would silently no-op. `$ENV{VIRTUALMIN_NO_MAIN}` is
+unaffected by `do` and is explicitly cleared by
+`execute_webmin_script`'s `clean_environment()` call, so production
+always runs the main body and only tests skip it.
+
+`.cgi` files are never loaded via `do`/`require` in production —
+miniserv fork+execs them — so `unless (caller)` is sufficient there and
+keeps the test mechanism identical to Webmin's.
+
 The `!caller(0)` one-liner form used by Webmin's `bin/` tools (`exit
-main(\@ARGV) if !caller(0);`) doesn't fit here — Virtualmin scripts
-don't have a `sub main` convention.
+main(\@ARGV) if !caller(0);`) doesn't fit either kind of file here —
+Virtualmin scripts don't have a `sub main` convention.
+
+**In tests**: set the env var (for CLI `.pl`) before `require`:
+
+```perl
+BEGIN { $ENV{VIRTUALMIN_NO_MAIN} = 1; }
+require './backup.pl';
+# now backup.pl's subs are defined; its main body did not run
+```
+
+For `.cgi` files, the bare `require` is enough — `caller` is defined
+inside a `.t` file and the guard skips the body.
 
 **Which scripts are wrapped.** The vast majority of `.pl` and `.cgi`
 files have no helper subs beyond `sub usage`, so wrapping them buys

--- a/t/compile.t
+++ b/t/compile.t
@@ -1,0 +1,77 @@
+#!/usr/bin/perl
+# Verify every .pl and .cgi in the tree parses (perl -c).
+#
+# Catches syntax and `use` breakage from bulk refactors without having
+# to load every page in a browser. The test is the first line of defence
+# for the "we changed thousands of files mechanically, did anything
+# break" question.
+#
+# Skipped:
+#   - $file.pl when a sibling $file (no .pl) exists. .pl is also the
+#     Polish translation suffix, so module.info.pl, config.info.pl, etc.
+#     are data files, not Perl.
+#   - Files that fail only because of a missing CPAN module. The file
+#     itself parses, but `use Foo::Bar` can't resolve at compile time.
+#     Treated as a skip so missing optional deps don't gate the suite.
+#     Set VIRTUALMIN_COMPILE_T_STRICT=1 to turn these into failures.
+#
+# Narrow with VIRTUALMIN_COMPILE_T_FILTER=<regex> when iterating on a
+# specific area.
+
+use strict;
+use warnings;
+use Test::More;
+use File::Find;
+use File::Basename qw(dirname);
+use File::Spec;
+use Cwd qw(abs_path);
+
+my $root = abs_path(File::Spec->catdir(dirname(__FILE__), '..'));
+chdir($root) or die "chdir($root): $!";
+
+my $filter = $ENV{VIRTUALMIN_COMPILE_T_FILTER};
+my $strict = $ENV{VIRTUALMIN_COMPILE_T_STRICT};
+
+my @files;
+find({
+	no_chdir => 1,
+	wanted => sub {
+		return if -d;
+		my $name = $File::Find::name;
+		return unless $name =~ /\.(pl|cgi)\z/;
+		# Skip the Polish translations that share the .pl suffix.
+		if ($name =~ m{(.+)\.pl\z}) {
+			my $base = $1;
+			return if -f "$base";
+			}
+		push(@files, $name);
+		},
+	}, '.');
+
+@files = sort @files;
+@files or BAIL_OUT("found no .pl/.cgi scripts under $root");
+
+if ($filter) {
+	@files = grep { /$filter/ } @files;
+	@files or do { diag("filter '$filter' matched zero files"); plan skip_all => "no files match filter"; };
+	}
+
+diag("compile-checking " . scalar(@files) . " files");
+
+for my $f (@files) {
+	my $rel = $f;
+	$rel =~ s{^\./}{};
+	my $out = qx{perl -I. -c -- "$rel" 2>&1};
+	if ($out =~ /\bsyntax OK\b/) {
+		pass("$rel compiles");
+		}
+	elsif (!$strict && $out =~ /Can't locate (\S+\.pm) in \@INC/) {
+		SKIP: { skip("$rel: missing optional CPAN module $1", 1); }
+		}
+	else {
+		fail("$rel compiles");
+		diag($out);
+		}
+	}
+
+done_testing();

--- a/upload-api-docs.pl
+++ b/upload-api-docs.pl
@@ -4,6 +4,8 @@
 
 use Pod::Simple::HTML;
 
+unless (caller) {
+
 $wiki_pages_host = "virtualmin.com";
 $wiki_pages_user = "virtualmin";
 $wiki_pages_dir = "/home/virtualmin/virtualmin-api";
@@ -191,6 +193,8 @@ if (!$noupload) {
 	print "Uploading to Wiki server $wiki_pages_host ..\n";
 	system("su $wiki_pages_su -c 'scp $tempdir/* $wiki_pages_user\@$wiki_pages_host:$wiki_pages_dir/'");
 	}
+
+} # end of unless (caller)
 
 # convert_to_html(pod-text)
 # Converts a POD-format text into HTML format, and returns that and

--- a/upload-api-docs.pl
+++ b/upload-api-docs.pl
@@ -4,7 +4,7 @@
 
 use Pod::Simple::HTML;
 
-unless (caller) {
+unless ($ENV{VIRTUALMIN_NO_MAIN}) {
 
 $wiki_pages_host = "virtualmin.com";
 $wiki_pages_user = "virtualmin";
@@ -194,7 +194,7 @@ if (!$noupload) {
 	system("su $wiki_pages_su -c 'scp $tempdir/* $wiki_pages_user\@$wiki_pages_host:$wiki_pages_dir/'");
 	}
 
-} # end of unless (caller)
+} # end of unless ($ENV{VIRTUALMIN_NO_MAIN})
 
 # convert_to_html(pod-text)
 # Converts a POD-format text into HTML format, and returns that and


### PR DESCRIPTION
Same prep for testing as [this PR](https://github.com/webmin/webmin/pull/2701) does for Webmin.

This one is hairier, as we have `execute_webmin_function` in `json-lib.pl` which does this:

```
	eval "
		\%pkg::ENV = \%ENV;
		package $pkg;
		do \$cmd;
		die \$@ if (\$@);
		";
	exit($@ ? 1 : 0);
```

To run scripts, which sets `caller` and also expects side effects. I can't figure out why it does it this way, but it's easy/safe to work around with an environment variable `VIRTUALMIN_NO_MAIN` that gets set in tests for the handful of effected files, which is checked instead of `caller`.

Also adds a `compile.t` test which just does `perl -c` across all Perl files, and a `t/README.md` documenting how to make tests and the special case we're doing for `execute_webmin_command`.