### PR TITLE
Fix milter-greylist mail rate-limit bypasses

### DIFF
--- a/install_ratelimit.cgi
+++ b/install_ratelimit.cgi
@@ -30,18 +30,7 @@ if (!$before && $ok) {
 			&save_ratelimit_directive($conf, $c, undef);
 			}
 		}
-	($nospf) = grep { $_->{'name'} eq 'nospf' } @$conf;
-	if (!$nospf) {
-		&save_ratelimit_directive($conf, undef,
-			{ 'name' => 'nospf',
-			  'values' => [] });
-		}
-	($noauth) = grep { $_->{'name'} eq 'noauth' } @$conf;
-	if (!$noauth) {
-		&save_ratelimit_directive($conf, undef,
-			{ 'name' => 'noauth',
-			  'values' => [] });
-		}
+	&normalize_ratelimit_config($conf);
 	&flush_file_lines();
 	&unlock_file(&get_ratelimit_config_file());
 	&$second_print($text{'setup_done'});

--- a/postinstall.pl
+++ b/postinstall.pl
@@ -491,15 +491,34 @@ if ($warn) {
 	print STDERR &get_virtualmin_url()," to fix them.\n";
 	}
 
-# Fix rate limiting noauth setting
-if (!&check_ratelimit() && &is_ratelimit_enabled()) {
+# Fix rate limiting milter-greylist settings
+if (!&check_ratelimit()) {
 	my $conf = &get_ratelimit_config();
-	($noauth) = grep { $_->{'name'} eq 'noauth' } @$conf;
-	if (!$noauth) {
-		&save_ratelimit_directive($conf, undef,
-			{ 'name' => 'noauth',
-			  'values' => [] });
-		&flush_file_lines(&get_ratelimit_config_file());
+	my $has_limits;
+	foreach my $c (@$conf) {
+		if ($c->{'name'} eq 'ratelimit' &&
+		    &is_virtualmin_ratelimit_name($c->{'values'}->[0])) {
+			$has_limits = 1;
+			last;
+			}
+		for(my $i=0; $i<@{$c->{'values'}}-1; $i++) {
+			# ACLs can reference Virtualmin rate-limit classes even
+			# if the class line is missing or has been moved by hand.
+			if ($c->{'values'}->[$i] eq 'ratelimit' &&
+			    &is_virtualmin_ratelimit_name($c->{'values'}->[$i+1])) {
+				$has_limits = 1;
+				last;
+				}
+			}
+		last if ($has_limits);
+		}
+	if ($has_limits) {
+		&lock_file(&get_ratelimit_config_file());
+		$conf = &get_ratelimit_config();
+		if (&normalize_ratelimit_config($conf)) {
+			&flush_file_lines(&get_ratelimit_config_file());
+			}
+		&unlock_file(&get_ratelimit_config_file());
 		}
 	}
 

--- a/ratelimit-lib.pl
+++ b/ratelimit-lib.pl
@@ -393,6 +393,8 @@ return 1;
 sub enable_ratelimit
 {
 # Build stop and start commands (needed when installed from source)
+my $cfile = &get_ratelimit_config_file();
+&lock_file($cfile);
 my $conf = &get_ratelimit_config();
 my ($pidfile) = grep { $_->{'name'} eq 'pidfile' } @$conf;
 if (!$pidfile) {
@@ -403,11 +405,12 @@ if (!$pidfile) {
 	&flush_file_lines($pidfile->{'file'});
 	}
 if (&normalize_ratelimit_config($conf)) {
-	&flush_file_lines(&get_ratelimit_config_file());
+	&flush_file_lines($cfile);
 	}
+&unlock_file($cfile);
 my $stopcmd = "kill `cat $pidfile->{'value'}` && sleep 5";
 my $startcmd = &has_command("milter-greylist").
-	       " -f ".&get_ratelimit_config_file();
+	       " -f ".$cfile;
 
 # Enable at boot
 &foreign_require("init");
@@ -434,8 +437,11 @@ if (&get_ratelimit_type() eq 'debian' && -r $dfile) {
 # Pick a socket file under the mail server's chroot
 &$first_print($text{'ratelimit_socket'});
 my $chroot = &get_mailserver_chroot();
+&lock_file($cfile);
+$conf = &get_ratelimit_config();
 my ($oldsocket) = grep { $_->{'name'} eq 'socket' } @$conf;
 if (!$oldsocket) {
+	&unlock_file($cfile);
 	&$second_print($text{'ratelimit_esocket'});
 	return 0;
 	}
@@ -490,6 +496,7 @@ if ($socket && $socket->{'values'}->[1] ne '666') {
 	&save_ratelimit_directive($conf, $socket, $socket);
 	&flush_file_lines($socket->{'file'});
 	}
+&unlock_file($cfile);
 
 &$second_print($text{'setup_done'});
 

--- a/ratelimit-lib.pl
+++ b/ratelimit-lib.pl
@@ -218,6 +218,34 @@ $name =~ s/^['"]|['"]$//g;
 return $name eq 'virtualmin_limit' || $name =~ /^domain_\d+$/;
 }
 
+# is_ratelimit_acl_directive(&directive)
+# Returns 1 for milter-greylist ACL directives
+sub is_ratelimit_acl_directive
+{
+my ($c) = @_;
+return $c->{'name'} eq 'racl' || $c->{'name'} eq 'acl';
+}
+
+# is_virtualmin_ratelimit_acl(&directive)
+# Returns 1 for blacklist ACLs that apply a Virtualmin rate-limit class
+sub is_virtualmin_ratelimit_acl
+{
+my ($c) = @_;
+return &is_ratelimit_acl_directive($c) &&
+       $c->{'values'}->[0] eq 'blacklist' &&
+       $c->{'values'}->[3] eq 'ratelimit' &&
+       &is_virtualmin_ratelimit_name($c->{'values'}->[4]);
+}
+
+# virtualmin_ratelimit_acl_from(&directive)
+# Returns the from regexp matched by a Virtualmin rate-limit ACL
+sub virtualmin_ratelimit_acl_from
+{
+my ($c) = @_;
+return undef if (!&is_virtualmin_ratelimit_acl($c));
+return $c->{'values'}->[1] eq 'from' ? $c->{'values'}->[2] : undef;
+}
+
 # normalize_ratelimit_config([&config])
 # Ensures milter-greylist does not bypass Virtualmin rate limits
 sub normalize_ratelimit_config
@@ -248,35 +276,30 @@ foreach my $name (@controls) {
 # otherwise milter-greylist accepts the message before checking quotas.
 my %rate_froms;
 foreach my $c (@$conf) {
-	if (($c->{'name'} eq 'racl' || $c->{'name'} eq 'acl') &&
-	    $c->{'values'}->[0] eq 'blacklist' &&
-	    $c->{'values'}->[1] eq 'from' &&
-	    $c->{'values'}->[3] eq 'ratelimit' &&
-	    &is_virtualmin_ratelimit_name($c->{'values'}->[4])) {
-		$rate_froms{$c->{'values'}->[2]} = 1;
+	my $from = &virtualmin_ratelimit_acl_from($c);
+	if (defined($from)) {
+		$rate_froms{$from} = 1;
 		}
 	}
-my @rate = grep {
-	$_->{'name'} eq 'ratelimit' ?
-		&is_virtualmin_ratelimit_name($_->{'values'}->[0]) :
-	($_->{'name'} eq 'racl' || $_->{'name'} eq 'acl') &&
-		(
-		$_->{'values'}->[0] eq 'blacklist' &&
-		$_->{'values'}->[3] eq 'ratelimit' &&
-		&is_virtualmin_ratelimit_name($_->{'values'}->[4]) ||
-		$_->{'values'}->[0] eq 'whitelist' &&
-		$_->{'values'}->[1] eq 'from' &&
-		$rate_froms{$_->{'values'}->[2]}
-		);
-	} @$conf;
+my @rate;
 my $before;
 foreach my $c (@$conf) {
-	next if ($c->{'name'} ne 'racl' && $c->{'name'} ne 'acl');
-	next if ($c->{'values'}->[0] ne 'whitelist');
-	next if ($c->{'values'}->[1] eq 'from' &&
-		 $rate_froms{$c->{'values'}->[2]});
-	$before = $c;
-	last;
+	if ($c->{'name'} eq 'ratelimit' &&
+	    &is_virtualmin_ratelimit_name($c->{'values'}->[0])) {
+		push(@rate, $c);
+		next;
+		}
+	next if (!&is_ratelimit_acl_directive($c));
+	if (&is_virtualmin_ratelimit_acl($c) ||
+	    ($c->{'values'}->[0] eq 'whitelist' &&
+	     $c->{'values'}->[1] eq 'from' &&
+	     $rate_froms{$c->{'values'}->[2]})) {
+		push(@rate, $c);
+		next;
+		}
+	if (!$before && $c->{'values'}->[0] eq 'whitelist') {
+		$before = $c;
+		}
 	}
 if ($before && grep { $_->{'line'} > $before->{'line'} } @rate) {
 	my @newrate = map {

--- a/ratelimit-lib.pl
+++ b/ratelimit-lib.pl
@@ -208,6 +208,94 @@ if ($rlines) {
 	}
 }
 
+# is_virtualmin_ratelimit_name(name)
+# Returns 1 for rate-limit classes managed by Virtualmin
+sub is_virtualmin_ratelimit_name
+{
+my ($name) = @_;
+return 0 if (!defined($name));
+$name =~ s/^['"]|['"]$//g;
+return $name eq 'virtualmin_limit' || $name =~ /^domain_\d+$/;
+}
+
+# normalize_ratelimit_config([&config])
+# Ensures milter-greylist does not bypass Virtualmin rate limits
+sub normalize_ratelimit_config
+{
+my ($conf) = @_;
+$conf ||= &get_ratelimit_config();
+my $changed = 0;
+
+# milter-greylist otherwise bypasses authenticated users and SPF-valid senders
+# before the rate-limit ACLs have a chance to run.
+my @controls = ( 'noauth', 'nospf' );
+my %has_control = map { $_->{'name'}, 1 }
+		  grep { $_->{'name'} eq 'noauth' ||
+			 $_->{'name'} eq 'nospf' } @$conf;
+my ($control_before) = grep { $_->{'name'} eq 'ratelimit' ||
+			      $_->{'name'} eq 'racl' ||
+			      $_->{'name'} eq 'acl' } @$conf;
+foreach my $name (@controls) {
+	if (!$has_control{$name}) {
+		my $new = { 'name' => $name, 'values' => [] };
+		&save_ratelimit_directive($conf, undef, $new,
+					  $control_before);
+		$changed++;
+		}
+	}
+
+# Keep rate-limit ACLs before ordinary whitelists such as "my network",
+# otherwise milter-greylist accepts the message before checking quotas.
+my %rate_froms;
+foreach my $c (@$conf) {
+	if (($c->{'name'} eq 'racl' || $c->{'name'} eq 'acl') &&
+	    $c->{'values'}->[0] eq 'blacklist' &&
+	    $c->{'values'}->[1] eq 'from' &&
+	    $c->{'values'}->[3] eq 'ratelimit' &&
+	    &is_virtualmin_ratelimit_name($c->{'values'}->[4])) {
+		$rate_froms{$c->{'values'}->[2]} = 1;
+		}
+	}
+my @rate = grep {
+	$_->{'name'} eq 'ratelimit' ?
+		&is_virtualmin_ratelimit_name($_->{'values'}->[0]) :
+	($_->{'name'} eq 'racl' || $_->{'name'} eq 'acl') &&
+		(
+		$_->{'values'}->[0] eq 'blacklist' &&
+		$_->{'values'}->[3] eq 'ratelimit' &&
+		&is_virtualmin_ratelimit_name($_->{'values'}->[4]) ||
+		$_->{'values'}->[0] eq 'whitelist' &&
+		$_->{'values'}->[1] eq 'from' &&
+		$rate_froms{$_->{'values'}->[2]}
+		);
+	} @$conf;
+my $before;
+foreach my $c (@$conf) {
+	next if ($c->{'name'} ne 'racl' && $c->{'name'} ne 'acl');
+	next if ($c->{'values'}->[0] ne 'whitelist');
+	next if ($c->{'values'}->[1] eq 'from' &&
+		 $rate_froms{$c->{'values'}->[2]});
+	$before = $c;
+	last;
+	}
+if ($before && grep { $_->{'line'} > $before->{'line'} } @rate) {
+	my @newrate = map {
+		my $new = { 'name' => $_->{'name'},
+			    'values' => [ @{$_->{'values'}} ] };
+		$new->{'members'} = [ @{$_->{'members'}} ] if ($_->{'members'});
+		$new;
+		} @rate;
+	foreach my $c (reverse @rate) {
+		&save_ratelimit_directive($conf, $c, undef);
+		}
+	foreach my $c (@newrate) {
+		&save_ratelimit_directive($conf, undef, $c, $before);
+		}
+	$changed++;
+	}
+return $changed;
+}
+
 # make_ratelimit_lines(&directive)
 # Returns an array of lines for some directive
 sub make_ratelimit_lines
@@ -242,10 +330,11 @@ return $out =~ /milter-greylist-([0-9\.]+)/ ? $1 : undef;
 # milter-greylist socket file must be relative to this.
 sub get_mailserver_chroot
 {
+&require_mail() if (!defined($mail_system));
 if ($mail_system == 0) {
 	&foreign_require("postfix");
 	my $postfix_conf = &postfix::get_master_config();
-	my ($postsmtpchroot) = grep { $_->{'name'} = 'smtp' && $_->{'chroot'} eq 'y' } @{$postfix_conf};		
+	my ($postsmtpchroot) = grep { $_->{'name'} eq 'smtp' && $_->{'chroot'} eq 'y' } @{$postfix_conf};
 	if ($postsmtpchroot) {
 		return "/var/spool/postfix";
 		}
@@ -312,6 +401,9 @@ if (!$pidfile) {
 		     'values' => [ '"/var/run/milter-greylist.pid"' ] };
 	&save_ratelimit_directive($conf, undef, $pidfile);
 	&flush_file_lines($pidfile->{'file'});
+	}
+if (&normalize_ratelimit_config($conf)) {
+	&flush_file_lines(&get_ratelimit_config_file());
 	}
 my $stopcmd = "kill `cat $pidfile->{'value'}` && sleep 5";
 my $startcmd = &has_command("milter-greylist").

--- a/save_ratelimit.cgi
+++ b/save_ratelimit.cgi
@@ -78,6 +78,7 @@ foreach my $rwhite (@rwhites) {
 		}
 	}
 
+&normalize_ratelimit_config($conf);
 &flush_file_lines();
 &unlock_file(&get_ratelimit_config_file());
 &webmin_log($action, "ratelimit");

--- a/virtual-server-lib-funcs.pl
+++ b/virtual-server-lib-funcs.pl
@@ -6944,6 +6944,8 @@ if (&check_ratelimit() eq '') {
 			my ($socket) = grep { $_->{'name'} eq 'socket' }
 					    @$conf;
 			&save_ratelimit_directive($conf, $socket, $oldsocket);
+			&normalize_ratelimit_config($conf);
+			&flush_file_lines(&get_ratelimit_config_file());
 			&$outdent_print();
                         &$second_print($text{'setup_done'});
 			}

--- a/virtual-server-lib-funcs.pl
+++ b/virtual-server-lib-funcs.pl
@@ -6935,17 +6935,21 @@ if (&check_ratelimit() eq '') {
 			# Enable on this system, and copy config file
 			&$indent_print();
 			&enable_ratelimit();
+			my $cfile = &get_ratelimit_config_file();
+			&lock_file($cfile);
 			my $conf = &get_ratelimit_config();
 			my ($oldsocket) = grep { $_->{'name'} eq 'socket' }
 					       @$conf;
 			&copy_source_dest($file."_ratelimitconfig",
-					  &get_ratelimit_config_file());
-			my $conf = &get_ratelimit_config();
+					  $cfile);
+			&unflush_file_lines($cfile);
+			$conf = &get_ratelimit_config();
 			my ($socket) = grep { $_->{'name'} eq 'socket' }
 					    @$conf;
 			&save_ratelimit_directive($conf, $socket, $oldsocket);
 			&normalize_ratelimit_config($conf);
-			&flush_file_lines(&get_ratelimit_config_file());
+			&flush_file_lines($cfile);
+			&unlock_file($cfile);
 			&$outdent_print();
                         &$second_print($text{'setup_done'});
 			}


### PR DESCRIPTION
Hello, Jamie!

This PR normalizes Virtualmin milter-greylist rate-limit configs so quota ACLs run before broad whitelists like `my network`, and ensure noauth/nospf are present so authenticated and SPF-pass senders are still metered.

And, also fixes the Postfix chroot detection typo (`=` instead of `eq`), guard `get_mailserver_chroot` against an undef `$mail_system` when called from `postinstall.pl`, and flush the lines cache after the socket swap on the backup restore path.

https://forum.virtualmin.com/t/tutorial-fix-mail-rate-limiting-not-working-on-ubuntu-24-04-postfix-chroot-milter-greylist-config-order/137303?u=ilia

