### PR TITLE
Fix to normalize apex record shorthand

### DIFF
--- a/functional-test.pl
+++ b/functional-test.pl
@@ -818,6 +818,10 @@ $domains_tests = [
 	  'args' => [ [ 'domain', $test_domain ],
 		      [ 'add-record-with-ttl', 'ttltest A 3600 5.6.7.8' ] ],
 	},
+	{ 'command' => 'modify-dns.pl',
+	  'args' => [ [ 'domain', $test_domain ],
+		      [ 'add-record', '@ TXT apex test record' ] ],
+	},
 
 	# Verify that it worked
 	{ 'command' => 'host -t A testing.'.$test_domain,
@@ -825,6 +829,9 @@ $domains_tests = [
 	},
 	{ 'command' => 'host -t A ttltest.'.$test_domain,
 	  'grep' => '5.6.7.8',
+	},
+	{ 'command' => 'dig TXT '.$test_domain,
+	  'grep' => 'apex test record',
 	},
 
 	# Modify one of the records
@@ -849,6 +856,11 @@ $domains_tests = [
 		      [ 'remove-record', 'ttltest A 5.6.7.8' ] ],
 	  'sleep' => 1,
 	},
+	{ 'command' => 'modify-dns.pl',
+	  'args' => [ [ 'domain', $test_domain ],
+		      [ 'remove-record', '@ TXT apex test record' ] ],
+	  'sleep' => 1,
+	},
 
 	# Make sure they are gone
 	{ 'command' => 'host -t A testing.'.$test_domain,
@@ -856,6 +868,9 @@ $domains_tests = [
 	},
 	{ 'command' => 'host -t A ttltest.'.$test_domain,
 	  'fail' => 1,
+	},
+	{ 'command' => 'dig TXT '.$test_domain,
+	  'antigrep' => 'apex test record',
 	},
 
 	# Disable SPF, then re-enable

--- a/modify-dns.pl
+++ b/modify-dns.pl
@@ -603,9 +603,7 @@ foreach $d (@doms) {
 		local @alld;
 		foreach my $rn (@delrecs) {
 			my ($name, $type, @values) = @$rn;
-			if ($name !~ /\.$/) {
-				$name .= ".".$d->{'dom'}.".";
-				}
+			$name = &expand_dns_record($name, $d);
 			local @d = grep { $_->{'name'} eq $name &&
 					 lc($_->{'type'}) eq lc($type) } @$recs;
 			if (@values) {
@@ -651,9 +649,7 @@ foreach $d (@doms) {
 					&usage("Invalid IPv6 address ".$v.
 					       " in --add-record");
 				}
-			if ($name !~ /\.$/ && $name ne "\@") {
-				$name .= ".".$d->{'dom'}.".";
-				}
+			$name = &expand_dns_record($name, $d);
 			my $r = { 'name' => $name,
 				  'type' => $type,
 				  'ttl' => $ttl,
@@ -688,12 +684,8 @@ foreach $d (@doms) {
 			}
 		foreach my $rn (@uprecs) {
 			my ($oldname, $oldtype, $name, $type, $ttl, $values, $proxied) = @$rn;
-			if ($oldname !~ /\.$/ && $oldname ne "\@") {
-				$oldname .= ".".$d->{'dom'}.".";
-				}
-			if ($name !~ /\.$/ && $name ne "\@") {
-				$name .= ".".$d->{'dom'}.".";
-				}
+			$oldname = &expand_dns_record($oldname, $d);
+			$name = &expand_dns_record($name, $d);
 			my ($r) = grep { $_->{'name'} eq $oldname &&
 					 $_->{'type'} eq $oldtype } @$recs;
 			if (!$r) {


### PR DESCRIPTION
Hey Jamie,

This PR addresses what appears to be a bug discussed [here](https://forum.virtualmin.com/t/change-ns-host-soa-in-all-domains/137313/2?u=ilia). It normalizes `@` DNS record names in the `modify-dns` add, remove, and update ops.

It also adds a regression test for adding and removing apex records via the CLI.