### PR TITLE
Fix Dovecot SSL conflicts on cert renewal for domains with dedicated IPs

### DIFF
--- a/feature-ssl.pl
+++ b/feature-ssl.pl
@@ -2464,11 +2464,18 @@ my $chain = &get_website_ssl_file($d, "ca");
 my $nochange = 0;
 
 my @ips;
-if ($d->{'virt'}) {
-	# Domain has it's own IPv4, and maybe v6
-	push(@ips, $d->{'ip'});
-	push(@ips, "[".$d->{'ip6'}."]") if ($d->{'virt6'} && $d->{'ip6'});
-	}
+# Skipping local IP block creation - always use local_name (SNI) instead.
+# local IP blocks conflict with local_name entries and Dovecot cannot
+# resolve both for the same connection (config error: "Conflict in
+# setting ssl_cert"). Since Dovecot 2+ supports SNI via local_name,
+# that is the correct mechanism for all domains regardless of whether
+# they have a dedicated IP.
+# Ref: https://github.com/virtualmin/virtualmin-gpl/issues/1134
+#if ($d->{'virt'}) {
+#	# Domain has it's own IPv4, and maybe v6
+#	push(@ips, $d->{'ip'});
+#	push(@ips, "[".$d->{'ip6'}."]") if ($d->{'virt6'} && $d->{'ip6'});
+#	}
 my ($cname, $cvalue) = &get_dovecot_ssl_dir("cert", $d->{'ssl_combined'});
 my ($kname, $kvalue) = &get_dovecot_ssl_dir("key", $d->{'ssl_key'});
 foreach my $ip (@ips) {
@@ -2567,7 +2574,8 @@ foreach my $ip (@ips) {
 		}
 	}
 
-if (!$d->{'virt'}) {
+if (1) {
+	# Always use local_name (SNI) for all domains, including those with dedicated IPs
 	# Domain has no IP, but Dovecot supports SNI in version 2
 	my @loc = grep { $_->{'name'} eq 'local_name' &&
 			 $_->{'section'} } @$conf;


### PR DESCRIPTION
## Summary

Cert renewals for domains with dedicated IPs create conflicting `local IP` blocks in dovecot.conf, breaking all IMAP/POP3 TLS connections.

Split from #1227 per Jamie's request. This PR covers Dovecot only; Webmin/miniserv fix is in a separate PR.

## Root Cause

`sync_dovecot_ssl_cert()` creates `local IP` blocks when `$d->{'virt'}` is true. If `local_name` entries also exist for the same domain (from migration, older Virtualmin version, or mixed config), Dovecot fails with `Conflict in setting ssl_cert`. All TLS connections fail silently.

## Fix

Always use `local_name` (SNI) instead of `local IP` blocks. Since Dovecot 2+ supports SNI via `local_name`, IP-based entries are unnecessary and cause conflicts on servers with multiple domains sharing an IP.

Two changes:
1. Skip populating `@ips` when domain has a dedicated IP (prevents `local IP` block creation)
2. Always enter the `local_name` code path (remove `!\->{'virt'}` guard)

Original code commented out, not deleted.

## Testing

Tested on Ubuntu 22.04 with Webmin 2.641 and Dovecot 2.3.16. Ran `virtualmin generate-letsencrypt-cert --domain <domain> --renew` multiple times. Verified:
- No `local IP` blocks created in dovecot.conf
- `local_name` blocks created correctly for all domains (24 blocks)
- No Dovecot config errors (`doveconf -n`)
- IMAPS (993) and POP3S (995) serving correct LE certs
- Full test script with 7 automated checks, all pass

Fixes #1134