### PR TITLE
Fix Webmin serving wrong SSL cert on shared IPs after cert renewal

### DIFF
--- a/feature-ssl.pl
+++ b/feature-ssl.pl
@@ -1738,12 +1738,17 @@ local %miniserv;
 &$getfunc(\%miniserv);
 local @ipkeys = &webmin::get_ipkeys(\%miniserv);
 local @ips;
-if ($d->{'virt'}) {
-	push(@ips, $d->{'ip'});
-	}
-if ($d->{'virt6'}) {
-	push(@ips, $d->{'ip6'});
-	}
+# Skip adding IPs to the ipkey entry - use domain names only for SNI.
+# Including IPs causes miniserv to create per-IP SSL contexts that
+# bypass the SNI callback, serving the wrong cert on shared IPs.
+# Domain names alone are sufficient for SNI matching.
+# Ref: https://github.com/virtualmin/virtualmin-gpl/issues/1134
+#if ($d->{'virt'}) {
+#	push(@ips, $d->{'ip'});
+#	}
+#if ($d->{'virt6'}) {
+#	push(@ips, $d->{'ip6'});
+#	}
 push(@ips, @dnames);
 my $chain = &get_website_ssl_file($d, 'ca');
 push(@ipkeys, { 'ips' => \@ips,


### PR DESCRIPTION
## Summary

Cert renewals for domains with dedicated IPs add the IP address to `ipcert` entries in `miniserv.conf`, causing Webmin to serve the wrong SSL certificate on shared IPs.

Split from #1227 per Jamie's request. This PR covers Webmin/miniserv only; Dovecot fix is in #1228.

## Root Cause

`setup_ipkeys()` adds `$d->{'ip'}` to the ipkeys array alongside domain names. Miniserv.pl creates per-IP SSL contexts for these entries but only registers the SNI callback on the default (`*`) context. When a client connects to a shared IP, miniserv uses the per-IP context directly and the SNI callback never fires, so hostname-based cert selection doesn't work. The client gets whichever domain's cert was last assigned to that IP (non-deterministic hash ordering).

## Fix

Skip adding IPs to ipkey entries. Use domain names only. The SNI callback on the default context handles hostname matching correctly for all domains.

Original code commented out, not deleted.

## Testing

Tested on Ubuntu 22.04 with Webmin 2.641. Ran `virtualmin generate-letsencrypt-cert --domain <domain> --renew` multiple times. Verified:
- No IP-based `ipcert` entries in `miniserv.conf` after renewal
- Webmin serves correct cert for each domain via SNI
- Tested with `openssl s_client -connect <shared-ip>:9595 -servername <hostname>`

Related: #1134