### PR TITLE
Add Systemd user units support for domain owners

### DIFF
--- a/config
+++ b/config
@@ -22,6 +22,7 @@ avail_passwd=1
 avail_proc=2
 avail_cron=1
 avail_at=1
+avail_systemd=0
 avail_telnet=0
 avail_custom=0
 avail_updown=0

--- a/config-freebsd
+++ b/config-freebsd
@@ -22,6 +22,7 @@ avail_passwd=1
 avail_proc=2
 avail_cron=1
 avail_at=1
+avail_systemd=0
 avail_telnet=0
 avail_custom=0
 avail_updown=0

--- a/feature-webmin.pl
+++ b/feature-webmin.pl
@@ -670,6 +670,15 @@ if ($mods{'cron'} && !$noextra && $d->{'unix'} && !$chroot) {
 	push(@mods, "cron");
 	}
 
+if ($mods{'systemd'} && !$noextra && &foreign_check("systemd")) {
+	# Can manage supported systemd user units owned by the domain owner
+	&foreign_require("systemd");
+	my %acl = &systemd::systemd_user_unit_acl($d->{'user'});
+	&save_module_acl_logged(\%acl, $wuser->{'name'}, "systemd")
+		if (!$hasmods{'systemd'});
+	push(@mods, "systemd");
+	}
+
 if ($mods{'at'} && !$noextra && $d->{'unix'} && !$chroot) {
 	# Can only manage his at jobs
 	my %acl = ( 'noconfig' => 1,

--- a/feature-webmin.pl
+++ b/feature-webmin.pl
@@ -673,7 +673,7 @@ if ($mods{'cron'} && !$noextra && $d->{'unix'} && !$chroot) {
 if ($mods{'systemd'} && !$noextra && &foreign_check("systemd")) {
 	# Can manage supported systemd user units owned by the domain owner
 	&foreign_require("systemd");
-	my %acl = &systemd::systemd_user_unit_acl($d->{'user'});
+	my %acl = &systemd::systemd_safe_user_unit_acl($d->{'user'});
 	&save_module_acl_logged(\%acl, $wuser->{'name'}, "systemd")
 		if (!$hasmods{'systemd'});
 	push(@mods, "systemd");

--- a/help/config_avail_systemd.html
+++ b/help/config_avail_systemd.html
@@ -1,0 +1,6 @@
+<header>Systemd User Units (domain owner's units)</header>
+This option specifies whether the domain owner account can use the Systemd
+Webmin module to manage systemd user units owned by the domain's Unix user.
+When enabled, access is limited to that user's systemd manager and does not
+grant control over system-wide units.
+<footer>

--- a/virtual-server-lib-funcs.pl
+++ b/virtual-server-lib-funcs.pl
@@ -17886,6 +17886,9 @@ local @rv = (
 	    [ 0, 'No' ] ] ],
         [ 'cron', 'Scheduled Cron Jobs (user\'s Cron jobs)' ],
         [ 'at', 'Scheduled Commands (user\'s commands)' ],
+        &foreign_check("systemd") ?
+		( [ 'systemd', 'Systemd User Units (domain owner\'s units)' ] ) :
+		( ),
         [ 'telnet', 'SSH Login' ],
         [ 'xterm', 'Terminal' ],
         [ 'updown', 'Upload and Download (as user)',


### PR DESCRIPTION
Hey Jamie!

This PR adds Virtualmin integration for [the new](https://github.com/webmin/webmin/pull/2760) Webmin Systemd Services and Units module.

It adds a Systemd User Units option to the Administrator's Webmin modules template section. When enabled for a domain, Virtualmin grants the domain owner scoped access to their own systemd user units using the Systemd module's `systemd_user_unit_acl()` helper.

The integration is guarded with `foreign_check("systemd")`, so nothing changes or fails when the Systemd module is not installed. ACL policy remains owned by the Systemd module instead of being duplicated in Virtualmin.

