### PR TITLE
Fix Dovecot SSL conflict: remove local_name entries before creating local IP blocks

### DIFF
--- a/feature-ssl.pl
+++ b/feature-ssl.pl
@@ -2491,6 +2491,26 @@ foreach my $ip (@ips) {
 		}
 
 	if ($enable) {
+		# Remove any conflicting local_name blocks for this
+		# domain before creating the local IP block. Dedicated-IP
+		# domains should use local {} not local_name {}.
+		# Ref: https://github.com/virtualmin/virtualmin-gpl/issues/1134
+		my @lnloc = grep { $_->{'name'} eq 'local_name' &&
+				   $_->{'section'} } @$conf;
+		my @doms = ( $d, &get_domain_by("alias", $d->{'id'}) );
+		my @conflicting = grep {
+			&hostname_under_domain(\@doms, $_->{'value'})
+			} @lnloc;
+		foreach my $cl (@conflicting) {
+			&dovecot::delete_section($conf, $cl);
+			@$conf = grep { $_ ne $cl } @$conf;
+			@$conf = grep {
+				$_->{'sectionname'} ne $cl->{'name'} ||
+				$_->{'sectionvalue'} ne $cl->{'value'}
+				} @$conf;
+			&flush_file_lines($cl->{'file'});
+			}
+
 		# Needs a cert for the IP
 		if (!$l) {
 			$l = { 'name' => 'local',


### PR DESCRIPTION
When a dedicated-IP domain has both `local {}` and `local_name {}` entries in dovecot.conf, Dovecot fails with "Conflict in setting ssl_cert" and all IMAP/POP3 TLS connections fail silently. This can happen when `local_name` entries exist from a previous configuration state (migration, IP change, or older Virtualmin version).

**Fix:** In `sync_dovecot_ssl_cert()`, before creating or updating a `local IP` block for a dedicated-IP domain, check for and remove any conflicting `local_name` entries for that domain's hostnames. Uses the same `hostname_under_domain()` and `delete_section()` patterns already used elsewhere in the function.

This preserves the intended architecture: dedicated-IP domains use `local {}`, shared-IP domains use `local_name {}`. Only the conflict case is addressed.

Tested with `virtualmin generate-letsencrypt-cert --renew` on a server with dedicated-IP domains. After renewal: `local IP` blocks created, conflicting `local_name` entries removed, zero Dovecot config errors, correct certs served on IMAPS and POP3S, subdomain `local_name` entries for shared-IP subdomains preserved.

Fixes #1134

If there are any further concerns, please do not hesitate to let me know.