### PR TITLE
Fix selected differential backup chain state handling

### DIFF
--- a/backup-domain.pl
+++ b/backup-domain.pl
@@ -228,6 +228,8 @@ while(@ARGV > 0) {
 	elsif ($a eq "--incremental-of" || $a eq "--differential-of") {
 		&has_incremental_tar() || &usage("The tar command on this system does not support differential backups");
 		$increment = shift(@ARGV);
+		$increment eq "1" &&
+			&usage("The legacy scheduled backup with ID 1 cannot be used as a selected full backup");
 		($isched) = grep { $_->{'id'} eq $increment } &list_scheduled_backups();
 		$isched || &usage("No scheduled backup with ID $increment exists");
 		$isched->{'increment'} == 0 ||

--- a/backup_form.cgi
+++ b/backup_form.cgi
@@ -343,7 +343,7 @@ if (&has_incremental_tar()) {
 	my @iopts = ( [ 0, $text{'backup_increment0'}."<br>" ],
 		      [ 1, $text{'backup_increment1'}."<br>" ],
 		      [ 2, $text{'backup_increment2'}."<br>" ] );
-	my @fullscheds = grep { !$_->{'increment'} } @scheds;
+	my @fullscheds = grep { !$_->{'increment'} && $_->{'id'} ne '1' } @scheds;
 	if (($in{'sched'} || $in{'new'}) && @fullscheds) {
 		# May be incremental of a specific full backup
 		my @sopts;

--- a/backup_sched.cgi
+++ b/backup_sched.cgi
@@ -181,7 +181,8 @@ else {
 	$sched->{'email_doms'} = $in{'email_doms'};
 	$sched->{'errors'} = $in{'errors'};
 	if ($in{'increment'} == 3) {
-		my @fullscheds = grep { !$_->{'increment'} } @scheds;
+		$in{'incrementof'} eq '1' && &error($text{'backup_eincrement1'});
+		my @fullscheds = grep { !$_->{'increment'} && $_->{'id'} ne '1' } @scheds;
 		my ($isched) = grep { $_->{'id'} eq $in{'incrementof'} } @fullscheds;
 		$isched || &error($text{'backup_eincrement'});
 		$sched->{'increment'} = $in{'incrementof'};

--- a/backups-lib.pl
+++ b/backups-lib.pl
@@ -804,9 +804,6 @@ local $ok = 1;
 local @donedoms;
 local ($okcount, $errcount) = (0, 0);
 local @errdoms;
-my %fullstateok;
-my $selected_full = $increment == 0 &&
-		    defined($id) && $id =~ /^\d+$/ && $id >= 3;
 local %donefeatures;				# Map from domain name->features
 local @cleanuphomes;				# Temporary homes
 local %donedoms;				# Map from domain name->hash
@@ -1032,8 +1029,6 @@ DOMAIN: foreach $d (sort { $a->{'dom'} cmp $b->{'dom'} } @$doms) {
 	if ($onebyone && $homefmt && $dok && $anyremote) {
 		# Transfer this domain now
 		local $df = "$d->{'dom'}.$hfsuffix";
-		$fullstateok{$d->{'id'}} = 1
-			if ($selected_full && $anylocal && $d->{'id'});
 		&$cbfunc($d, 1, "$dest/$df") if ($cbfunc);
 		local $tstart = time();
 		local $binfo = { $d->{'dom'} =>
@@ -1212,8 +1207,6 @@ DOMAIN: foreach $d (sort { $a->{'dom'} cmp $b->{'dom'} } @$doms) {
 				}
 			else {
 				&$second_print($text{'setup_done'});
-				$fullstateok{$d->{'id'}} = 1
-					if ($selected_full && $d->{'id'});
 				local @tst = stat("$dest/$df");
 				if ($mode != 0 && !$done_transferred_sz++) {
 					$transferred_sz += $tst[7];
@@ -1528,17 +1521,6 @@ else {
 	}
 $sz += $transferred_sz;
 
-my %archiveerrids = map { $_->{'id'}, 1 }
-		    grep { $_->{'id'} } @errdoms;
-my $mark_fullstate_ok = sub {
-	return if (!$selected_full);
-	foreach my $sd (@_) {
-		next if (!$sd || !$sd->{'id'} || $archiveerrids{$sd->{'id'}});
-		$fullstateok{$sd->{'id'}} = 1;
-		}
-	};
-&$mark_fullstate_ok(@donedoms) if ($ok && $anylocal);
-
 foreach my $desturl (@$desturls) {
 	local ($mode, $user, $pass, $server, $path, $port) =
 		&parse_backup_url($desturl);
@@ -1622,7 +1604,6 @@ foreach my $desturl (@$desturls) {
 			}
 		&unlink_file($infotemp);
 		&unlink_file($domtemp);
-		&$mark_fullstate_ok(@donedoms) if (!$err);
 		&$second_print($text{'setup_done'}) if ($ok);
 		}
 	elsif ($ok && ($mode == 2 || $mode == 13) && (@destfiles || !$dirfmt)) {
@@ -1707,7 +1688,6 @@ foreach my $desturl (@$desturls) {
 			}
 		&unlink_file($infotemp);
 		&unlink_file($domtemp);
-		&$mark_fullstate_ok(@donedoms) if (!$err);
 		&$second_print($text{'setup_done'}) if ($ok);
 		}
 	elsif ($ok && $mode == 3 && (@destfiles || !$dirfmt)) {
@@ -1762,7 +1742,6 @@ foreach my $desturl (@$desturls) {
 							 $tstart, time());
 				}
 			}
-		&$mark_fullstate_ok(@donedoms) if (!$err);
 		&$second_print($text{'setup_done'}) if ($ok);
 		}
 	elsif ($ok && $mode == 6 && (@destfiles || !$dirfmt)) {
@@ -1830,7 +1809,6 @@ foreach my $desturl (@$desturls) {
 			}
 		&unlink_file($infotemp);
 		&unlink_file($domtemp);
-		&$mark_fullstate_ok(@donedoms) if (!$err);
 		&$second_print($text{'setup_done'}) if ($ok);
 		}
 	elsif ($ok && ($mode == 7 || $mode == 8 || $mode == 10 ||
@@ -1908,7 +1886,6 @@ foreach my $desturl (@$desturls) {
 			}
 		&unlink_file($infotemp);
 		&unlink_file($domtemp);
-		&$mark_fullstate_ok(@donedoms) if (!$err);
 		&$second_print($text{'setup_done'}) if ($ok);
 		}
 	elsif ($ok && $mode == 9 && (@destfiles || !$dirfmt)) {
@@ -1994,7 +1971,6 @@ foreach my $desturl (@$desturls) {
 			}
 		&unlink_file($infotemp);
 		&unlink_file($domtemp);
-		&$mark_fullstate_ok(@donedoms) if (!$err);
 		&$second_print($text{'setup_done'}) if ($ok);
 		}
 	elsif ($ok && $mode == 0 && (@destfiles || !$dirfmt) &&
@@ -2105,42 +2081,23 @@ if ($ok) {
 		}
 	}
 
-# Keep selected full-backup differential state only for domains whose full
-# backup reached at least one durable destination.
-if ($increment == 0 && &has_incremental_tar()) {
-	if ($selected_full) {
-		my %donestate;
-		foreach my $d (@$doms) {
-			next if (!$d->{'id'} || $donestate{$d->{'id'}}++);
-			my $ifile = &get_incremental_file($d, $increment, $id);
-			if ($fullstateok{$d->{'id'}}) {
-				my $ifiledef = &get_incremental_file($d);
-				if ($ifile && $ifiledef && $ifile ne $ifiledef &&
-				    -r $ifile) {
-					&copy_source_dest($ifile, $ifiledef);
-					}
-				}
-			else {
-				&unlink_file($ifile);
-				}
-			}
+	# Release lock on dest file
+	foreach my $lockfile (@lockfiles) {
+		&unlock_file($lockfile);
 		}
-	else {
+
+	# For any domains that failed and were full backups, clear the differential
+	# file so that future differential backups aren't diffs against it
+	if ($increment == 0 && &has_incremental_tar()) {
 		foreach my $d (@errdoms) {
 			if ($d->{'id'}) {
 				&unlink_file(&get_incremental_file($d, $increment, $id));
 				}
 			}
 		}
-	}
 
-# Release lock on dest file
-foreach my $lockfile (@lockfiles) {
-	&unlock_file($lockfile);
+	return ($ok, $sz, \@errdoms);
 	}
-
-return ($ok, $sz, \@errdoms);
-}
 
 # get_incremental_file(&domain, increment-mode, backup-id)
 # Returns the path to the incremental file for a backup

--- a/backups-lib.pl
+++ b/backups-lib.pl
@@ -2113,7 +2113,10 @@ elsif ($mode == 0 && $id && $id ne "1") {
 	# This full backup gets its own snapshot only if a differential
 	# schedule actually references it.
 	my @incrs = grep { $_->{'increment'} == $id } &list_scheduled_backups();
-	return "$incremental_backups_dir/$id/$d->{'id'}" if (@incrs);
+	if (@incrs) {
+		# Yes, so it gets its own incremental file
+		return "$incremental_backups_dir/$id/$d->{'id'}";
+		}
 	}
 return "$incremental_backups_dir/$d->{'id'}";
 }

--- a/backups-lib.pl
+++ b/backups-lib.pl
@@ -2085,7 +2085,8 @@ if ($ok) {
 # is known. A failed upload can happen after tar has already advanced the
 # snapshot files, so failed full backups must not become a future baseline.
 if ($increment == 0 && &has_incremental_tar()) {
-	my %errids = map { $_->{'id'} ? ($_->{'id'}, 1) : () } @errdoms;
+	my %errids = map { $_->{'id'}, 1 }
+		     grep { $_->{'id'} } @errdoms;
 	if ($ok) {
 		foreach my $d (@$doms) {
 			next if (!$d->{'id'} || $errids{$d->{'id'}});

--- a/backups-lib.pl
+++ b/backups-lib.pl
@@ -2081,23 +2081,23 @@ if ($ok) {
 		}
 	}
 
-	# Release lock on dest file
-	foreach my $lockfile (@lockfiles) {
-		&unlock_file($lockfile);
-		}
+# Release lock on dest file
+foreach my $lockfile (@lockfiles) {
+	&unlock_file($lockfile);
+	}
 
-	# For any domains that failed and were full backups, clear the differential
-	# file so that future differential backups aren't diffs against it
-	if ($increment == 0 && &has_incremental_tar()) {
-		foreach my $d (@errdoms) {
-			if ($d->{'id'}) {
-				&unlink_file(&get_incremental_file($d, $increment, $id));
-				}
+# For any domains that failed and were full backups, clear the differential
+# file so that future differential backups aren't diffs against it
+if ($increment == 0 && &has_incremental_tar()) {
+	foreach my $d (@errdoms) {
+		if ($d->{'id'}) {
+			&unlink_file(&get_incremental_file($d, $increment, $id));
 			}
 		}
-
-	return ($ok, $sz, \@errdoms);
 	}
+
+return ($ok, $sz, \@errdoms);
+}
 
 # get_incremental_file(&domain, increment-mode, backup-id)
 # Returns the path to the incremental file for a backup
@@ -2109,10 +2109,11 @@ if ($mode >= 3) {
 	# Incremental against a specific backup
 	return "$incremental_backups_dir/$mode/$d->{'id'}";
 	}
-elsif ($mode == 0 && $id =~ /^\d+$/ && $id >= 3) {
-	# This is a scheduled full backup. Keep its own snapshot even before
-	# any differential schedule references it, so future chains can use it.
-	return "$incremental_backups_dir/$id/$d->{'id'}";
+elsif ($mode == 0 && $id && $id ne "1") {
+	# This full backup gets its own snapshot only if a differential
+	# schedule actually references it.
+	my @incrs = grep { $_->{'increment'} == $id } &list_scheduled_backups();
+	return "$incremental_backups_dir/$id/$d->{'id'}" if (@incrs);
 	}
 return "$incremental_backups_dir/$d->{'id'}";
 }

--- a/backups-lib.pl
+++ b/backups-lib.pl
@@ -2125,13 +2125,10 @@ if ($mode >= 3) {
 	# Incremental against a specific backup
 	return "$incremental_backups_dir/$mode/$d->{'id'}";
 	}
-elsif ($mode == 0 && $id) {
-	# This is a full backup, but are there other incrementals referencing it?
-	my @incrs = grep { $_->{'increment'} == $id } &list_scheduled_backups();
-	if (@incrs) {
-		# Yes, so it gets its own incremental file
-		return "$incremental_backups_dir/$id/$d->{'id'}";
-		}
+elsif ($mode == 0 && $id =~ /^\d+$/ && $id >= 3) {
+	# This is a scheduled full backup. Keep its own snapshot even before
+	# any differential schedule references it, so future chains can use it.
+	return "$incremental_backups_dir/$id/$d->{'id'}";
 	}
 return "$incremental_backups_dir/$d->{'id'}";
 }

--- a/backups-lib.pl
+++ b/backups-lib.pl
@@ -2081,19 +2081,35 @@ if ($ok) {
 		}
 	}
 
-# Release lock on dest file
-foreach my $lockfile (@lockfiles) {
-	&unlock_file($lockfile);
-	}
-
-# For any domains that failed and were full backups, clear the differential
-# file so that future differential backups aren't diffs against it
+# Update full-backup differential state only after the complete backup result
+# is known. A failed upload can happen after tar has already advanced the
+# snapshot files, so failed full backups must not become a future baseline.
 if ($increment == 0 && &has_incremental_tar()) {
-	foreach my $d (@errdoms) {
+	my %errids = map { $_->{'id'} ? ($_->{'id'}, 1) : () } @errdoms;
+	if ($ok) {
+		foreach my $d (@$doms) {
+			next if (!$d->{'id'} || $errids{$d->{'id'}});
+			my $ifile = &get_incremental_file($d, $increment, $id);
+			my $ifiledef = &get_incremental_file($d);
+			if ($ifile && $ifiledef && $ifile ne $ifiledef &&
+			    -r $ifile) {
+				&copy_source_dest($ifile, $ifiledef);
+				}
+			}
+		}
+	my @cleardoms = $ok ? @errdoms : @$doms;
+	my %donecleardom;
+	foreach my $d (@cleardoms) {
 		if ($d->{'id'}) {
+			next if ($donecleardom{$d->{'id'}}++);
 			&unlink_file(&get_incremental_file($d, $increment, $id));
 			}
 		}
+	}
+
+# Release lock on dest file
+foreach my $lockfile (@lockfiles) {
+	&unlock_file($lockfile);
 	}
 
 return ($ok, $sz, \@errdoms);

--- a/backups-lib.pl
+++ b/backups-lib.pl
@@ -804,6 +804,9 @@ local $ok = 1;
 local @donedoms;
 local ($okcount, $errcount) = (0, 0);
 local @errdoms;
+my %fullstateok;
+my $selected_full = $increment == 0 &&
+		    defined($id) && $id =~ /^\d+$/ && $id >= 3;
 local %donefeatures;				# Map from domain name->features
 local @cleanuphomes;				# Temporary homes
 local %donedoms;				# Map from domain name->hash
@@ -1029,6 +1032,8 @@ DOMAIN: foreach $d (sort { $a->{'dom'} cmp $b->{'dom'} } @$doms) {
 	if ($onebyone && $homefmt && $dok && $anyremote) {
 		# Transfer this domain now
 		local $df = "$d->{'dom'}.$hfsuffix";
+		$fullstateok{$d->{'id'}} = 1
+			if ($selected_full && $anylocal && $d->{'id'});
 		&$cbfunc($d, 1, "$dest/$df") if ($cbfunc);
 		local $tstart = time();
 		local $binfo = { $d->{'dom'} =>
@@ -1207,6 +1212,8 @@ DOMAIN: foreach $d (sort { $a->{'dom'} cmp $b->{'dom'} } @$doms) {
 				}
 			else {
 				&$second_print($text{'setup_done'});
+				$fullstateok{$d->{'id'}} = 1
+					if ($selected_full && $d->{'id'});
 				local @tst = stat("$dest/$df");
 				if ($mode != 0 && !$done_transferred_sz++) {
 					$transferred_sz += $tst[7];
@@ -1521,6 +1528,17 @@ else {
 	}
 $sz += $transferred_sz;
 
+my %archiveerrids = map { $_->{'id'}, 1 }
+		    grep { $_->{'id'} } @errdoms;
+my $mark_fullstate_ok = sub {
+	return if (!$selected_full);
+	foreach my $sd (@_) {
+		next if (!$sd || !$sd->{'id'} || $archiveerrids{$sd->{'id'}});
+		$fullstateok{$sd->{'id'}} = 1;
+		}
+	};
+&$mark_fullstate_ok(@donedoms) if ($ok && $anylocal);
+
 foreach my $desturl (@$desturls) {
 	local ($mode, $user, $pass, $server, $path, $port) =
 		&parse_backup_url($desturl);
@@ -1604,6 +1622,7 @@ foreach my $desturl (@$desturls) {
 			}
 		&unlink_file($infotemp);
 		&unlink_file($domtemp);
+		&$mark_fullstate_ok(@donedoms) if (!$err);
 		&$second_print($text{'setup_done'}) if ($ok);
 		}
 	elsif ($ok && ($mode == 2 || $mode == 13) && (@destfiles || !$dirfmt)) {
@@ -1688,6 +1707,7 @@ foreach my $desturl (@$desturls) {
 			}
 		&unlink_file($infotemp);
 		&unlink_file($domtemp);
+		&$mark_fullstate_ok(@donedoms) if (!$err);
 		&$second_print($text{'setup_done'}) if ($ok);
 		}
 	elsif ($ok && $mode == 3 && (@destfiles || !$dirfmt)) {
@@ -1742,6 +1762,7 @@ foreach my $desturl (@$desturls) {
 							 $tstart, time());
 				}
 			}
+		&$mark_fullstate_ok(@donedoms) if (!$err);
 		&$second_print($text{'setup_done'}) if ($ok);
 		}
 	elsif ($ok && $mode == 6 && (@destfiles || !$dirfmt)) {
@@ -1809,6 +1830,7 @@ foreach my $desturl (@$desturls) {
 			}
 		&unlink_file($infotemp);
 		&unlink_file($domtemp);
+		&$mark_fullstate_ok(@donedoms) if (!$err);
 		&$second_print($text{'setup_done'}) if ($ok);
 		}
 	elsif ($ok && ($mode == 7 || $mode == 8 || $mode == 10 ||
@@ -1886,6 +1908,7 @@ foreach my $desturl (@$desturls) {
 			}
 		&unlink_file($infotemp);
 		&unlink_file($domtemp);
+		&$mark_fullstate_ok(@donedoms) if (!$err);
 		&$second_print($text{'setup_done'}) if ($ok);
 		}
 	elsif ($ok && $mode == 9 && (@destfiles || !$dirfmt)) {
@@ -1971,6 +1994,7 @@ foreach my $desturl (@$desturls) {
 			}
 		&unlink_file($infotemp);
 		&unlink_file($domtemp);
+		&$mark_fullstate_ok(@donedoms) if (!$err);
 		&$second_print($text{'setup_done'}) if ($ok);
 		}
 	elsif ($ok && $mode == 0 && (@destfiles || !$dirfmt) &&
@@ -2081,29 +2105,31 @@ if ($ok) {
 		}
 	}
 
-# Update full-backup differential state only after the complete backup result
-# is known. A failed upload can happen after tar has already advanced the
-# snapshot files, so failed full backups must not become a future baseline.
+# Keep selected full-backup differential state only for domains whose full
+# backup reached at least one durable destination.
 if ($increment == 0 && &has_incremental_tar()) {
-	my %errids = map { $_->{'id'}, 1 }
-		     grep { $_->{'id'} } @errdoms;
-	if ($ok) {
+	if ($selected_full) {
+		my %donestate;
 		foreach my $d (@$doms) {
-			next if (!$d->{'id'} || $errids{$d->{'id'}});
+			next if (!$d->{'id'} || $donestate{$d->{'id'}}++);
 			my $ifile = &get_incremental_file($d, $increment, $id);
-			my $ifiledef = &get_incremental_file($d);
-			if ($ifile && $ifiledef && $ifile ne $ifiledef &&
-			    -r $ifile) {
-				&copy_source_dest($ifile, $ifiledef);
+			if ($fullstateok{$d->{'id'}}) {
+				my $ifiledef = &get_incremental_file($d);
+				if ($ifile && $ifiledef && $ifile ne $ifiledef &&
+				    -r $ifile) {
+					&copy_source_dest($ifile, $ifiledef);
+					}
+				}
+			else {
+				&unlink_file($ifile);
 				}
 			}
 		}
-	my @cleardoms = $ok ? @errdoms : @$doms;
-	my %donecleardom;
-	foreach my $d (@cleardoms) {
-		if ($d->{'id'}) {
-			next if ($donecleardom{$d->{'id'}}++);
-			&unlink_file(&get_incremental_file($d, $increment, $id));
+	else {
+		foreach my $d (@errdoms) {
+			if ($d->{'id'}) {
+				&unlink_file(&get_incremental_file($d, $increment, $id));
+				}
 			}
 		}
 	}

--- a/create-scheduled-backup.pl
+++ b/create-scheduled-backup.pl
@@ -222,6 +222,8 @@ while(@ARGV > 0) {
 	elsif ($a eq "--incremental-of" || $a eq "--differential-of") {
 		&has_incremental_tar() || &usage("The tar command on this system does not support differential backups");
 		$increment = shift(@ARGV);
+		$increment eq "1" &&
+			&usage("The legacy scheduled backup with ID 1 cannot be used as a selected full backup");
 		($isched) = grep { $_->{'id'} eq $increment } &list_scheduled_backups();
 		$isched || &usage("No scheduled backup with ID $increment exists");
 		$isched->{'increment'} == 0 ||

--- a/feature-dir.pl
+++ b/feature-dir.pl
@@ -575,9 +575,10 @@ foreach my $x (@xlist) {
 &close_tempfile(XTEMP);
 
 # Work out differential flags
-my ($iargs, $iflag, $ifile, $ifilecopy);
+my ($iargs, $iflag, $ifile, $ifilecopy, $ifiledef);
 if (&has_incremental_tar() && $increment != 2) {
 	$ifile = &get_incremental_file($d, $increment, $id);
+	$ifiledef = &get_incremental_file($d);
 	my $idir = $ifile =~ /^(.*)\/[^\/]+$/ ? $1 : undef;
 	&make_dir($idir, 0711, 1);
 	if (!$increment) {
@@ -670,6 +671,13 @@ if ($ex || !-s $destfile) {
 	return 0;
 	}
 else {
+	if ($ifile && $increment == 0 && $ifile ne $ifiledef) {
+		# This was a full backup but was using a per-backup incremental
+		# file. Copy that over the default incremental file so that
+		# other future non-chained incremental backups are relative to
+		# this latest backup.
+		&copy_source_dest($ifile, $ifiledef);
+		}
 	&$second_print($text{'setup_done'});
 	return 1;
 	}

--- a/feature-dir.pl
+++ b/feature-dir.pl
@@ -588,7 +588,11 @@ if (&has_incremental_tar() && $increment != 2) {
 		# Add a flag file indicating that this was an differential,
 		# and take a copy of the file so we can put it back as before
 		# the backup (as tar modifies it)
-		if (-r $ifile) {
+		if ($increment >= 3 && !-s $ifile) {
+			&$second_print(&text('backup_dirtarnobase', $increment));
+			return 0;
+			}
+		elsif (-r $ifile) {
 			$iflag = "$d->{'home'}/.incremental";
 			&open_tempfile_as_domain_user(
 				$d, IFLAG, ">$iflag", 0, 1);

--- a/feature-dir.pl
+++ b/feature-dir.pl
@@ -659,12 +659,6 @@ if (-r $ifile) {
 	&set_ownership_permissions($d->{'uid'}, $d->{'gid'},
 				   0700, $ifile);
 	}
-if ($ifile && $increment == 0 && $ifile ne $ifiledef) {
-	# This was a full backup but was using a per-backup incremental file.
-	# Copy that over the default incremental file so that other future
-	# non-chained incremental backups are relative to this latest backup.
-	&copy_source_dest($ifile, $ifiledef);
-	}
 if ($ex || !-s $destfile) {
 	&unlink_file($destfile);
 	&$second_print(&text($cmd =~ /^\S*zip/ ? 'backup_dirzipfailed'
@@ -673,6 +667,13 @@ if ($ex || !-s $destfile) {
 	return 0;
 	}
 else {
+	if ($ifile && $increment == 0 && $ifile ne $ifiledef) {
+		# This was a full backup but was using a per-backup incremental
+		# file. Copy that over the default incremental file so that
+		# other future non-chained incremental backups are relative to
+		# this latest backup.
+		&copy_source_dest($ifile, $ifiledef);
+		}
 	&$second_print($text{'setup_done'});
 	return 1;
 	}

--- a/feature-dir.pl
+++ b/feature-dir.pl
@@ -575,10 +575,9 @@ foreach my $x (@xlist) {
 &close_tempfile(XTEMP);
 
 # Work out differential flags
-my ($iargs, $iflag, $ifile, $ifilecopy, $ifiledef);
+my ($iargs, $iflag, $ifile, $ifilecopy);
 if (&has_incremental_tar() && $increment != 2) {
 	$ifile = &get_incremental_file($d, $increment, $id);
-	$ifiledef = &get_incremental_file($d);
 	my $idir = $ifile =~ /^(.*)\/[^\/]+$/ ? $1 : undef;
 	&make_dir($idir, 0711, 1);
 	if (!$increment) {
@@ -667,13 +666,6 @@ if ($ex || !-s $destfile) {
 	return 0;
 	}
 else {
-	if ($ifile && $increment == 0 && $ifile ne $ifiledef) {
-		# This was a full backup but was using a per-backup incremental
-		# file. Copy that over the default incremental file so that
-		# other future non-chained incremental backups are relative to
-		# this latest backup.
-		&copy_source_dest($ifile, $ifiledef);
-		}
 	&$second_print($text{'setup_done'});
 	return 1;
 	}

--- a/lang/en
+++ b/lang/en
@@ -2550,6 +2550,7 @@ backup_increment1=Differential - changes since full backup
 backup_increment2=Neither - all files, and don't update the state
 backup_increment3=Differential - changes since backup $1
 backup_eincrement=Invalid full backup for differential
+backup_eincrement1=The legacy scheduled backup with ID 1 cannot be used as a selected full backup
 backup_compression=Backup compression format
 backup_compression0=<tt>tar+gzip</tt>
 backup_compression1=<tt>tar+bzip2</tt>

--- a/lang/en
+++ b/lang/en
@@ -2788,6 +2788,7 @@ backup_eownrestore=Only signed backups can be restored by virtual server owners
 backup_dirtar=Creating TAR file of home directory ..
 backup_dirtarinc=Creating differential TAR file of home directory ..
 backup_dirtarfailed=.. TAR failed : $1
+backup_dirtarnobase=.. differential backup failed : no full backup state found for backup ID $1
 backup_dirzipfailed=.. ZIP failed : $1
 backup_dirzip=Creating ZIP file of home directory ..
 backup_virtualmincp=Copying virtual server configuration ..


### PR DESCRIPTION
Hello Jamie!

This fixes several edge cases in selected full-backup differential chains considering your latest changes to _master_!

Previously, full backup snapshot state could be advanced before the full backup was actually usable, or selected differential schedules could be configured against baselines that could not be represented or did not exist.

What changed (you can see more details in each linked commit):

- Only advance the default differential snapshot after a chained full backup archive is successfully created.
- Move full-backup snapshot promotion to the final backup result path, so state is advanced only after all destinations succeed.
- Clear new full-backup snapshot state when the backup fails, including failures after tar has already updated state, such as remote upload failures.
- Keep destination locks held until snapshot state has been updated.
- Disallow using legacy scheduled backup ID `1` as a selected full-backup baseline, because `increment == 1` already represents legacy differential mode.
- Always keep per-schedule snapshot state for scheduled full backups so selected differential chains can be created later.
- Fail selected differentials clearly when the chosen full-backup snapshot is missing, instead of silently creating a misleading backup from the wrong baseline.