### PR TITLE
Fix extra DB user restore by passing hashed mysql password

### DIFF
--- a/virtual-server-lib-funcs.pl
+++ b/virtual-server-lib-funcs.pl
@@ -1188,13 +1188,14 @@ foreach my $dt (&unique(map { $_->{'type'} } &domain_databases($d))) {
 		if (&indexof($dt, &list_database_plugins()) < 0) {
 			# Create in core database
 			my $crfunc = "create_${dt}_database_user";
-			&$crfunc($d, \@dbs, $user->{'user'}, $user->{'pass'});
+			&$crfunc($d, \@dbs, $user->{'user'}, $user->{'pass'},
+				 $user->{'mysql_pass'});
 			}
 		elsif (&indexof($dt, &list_database_plugins()) >= 0) {
 			# Create in plugin database
 			&plugin_call($dt, "database_create_user",
 				     $d, \@dbs, $user->{'user'},
-				     $user->{'pass'});
+				     $user->{'pass'}, $user->{'mysql_pass'});
 			}
 		};
 	# Show error

--- a/virtual-server-lib-funcs.pl
+++ b/virtual-server-lib-funcs.pl
@@ -1189,13 +1189,13 @@ foreach my $dt (&unique(map { $_->{'type'} } &domain_databases($d))) {
 			# Create in core database
 			my $crfunc = "create_${dt}_database_user";
 			&$crfunc($d, \@dbs, $user->{'user'}, $user->{'pass'},
-				 $user->{'mysql_pass'});
+				 $user->{$dt.'_pass'});
 			}
 		elsif (&indexof($dt, &list_database_plugins()) >= 0) {
 			# Create in plugin database
 			&plugin_call($dt, "database_create_user",
 				     $d, \@dbs, $user->{'user'},
-				     $user->{'pass'}, $user->{'mysql_pass'});
+				     $user->{'pass'}, $user->{$dt.'_pass'});
 			}
 		};
 	# Show error


### PR DESCRIPTION
**Summary**
This PR fixes restore failures for extra MariaDB/MySQL users when only a hashed password is present in backup data.
More informations and logs : https://forum.virtualmin.com/t/backup-mariadb-user-restoration-issue/137492

**Issue**
In some restores, user creation failed with SQL like:
create user ... identified by password
because no password value was passed in that code path.

**Root cause**
The extra DB user restore flow only forwarded the plain password field.
When plain password is empty but mysql_pass is set, user creation received no usable password.

**Fix**
Forward mysql_pass as the encrypted password argument when restoring extra DB users:

- Core DB user creation call updated
- Plugin DB user creation call updated

**Impact**
Extra DB users now restore correctly in hashed-password scenarios, with no behavior change for plain-password restores.