### PR TITLE
Fix to replace lexical `local` declarations with `my`

### DIFF
--- a/admins-lib.pl
+++ b/admins-lib.pl
@@ -4,12 +4,12 @@
 # Returns a list of extra admins for some domain
 sub list_extra_admins
 {
-local ($d) = @_;
-local @rv;
+my ($d) = @_;
+my @rv;
 opendir(DIR, "$extra_admins_dir/$d->{'id'}");
 foreach my $f (readdir(DIR)) {
 	if ($f =~ /^(.*)\.admin$/) {
-		local %admin;
+		my %admin;
 		&read_file("$extra_admins_dir/$d->{'id'}/$f", \%admin);
 		$admin{'file'} = "$extra_admins_dir/$d->{'id'}/$f";
 		$admin{'origname'} ||= $admin{'name'};
@@ -24,7 +24,7 @@ return @rv;
 # Create an extra admin account for a domain
 sub create_extra_admin
 {
-local ($admin, $d) = @_;
+my ($admin, $d) = @_;
 mkdir($extra_admins_dir, 0700);
 mkdir("$extra_admins_dir/$d->{'id'}", 0700);
 $admin->{'file'} = "$extra_admins_dir/$d->{'id'}/$admin->{'name'}.admin";
@@ -40,7 +40,7 @@ $admin->{'file'} = "$extra_admins_dir/$d->{'id'}/$admin->{'name'}.admin";
 # Remove an extra admin account
 sub delete_extra_admin
 {
-local ($admin, $d) = @_;
+my ($admin, $d) = @_;
 unlink($admin->{'file'});
 &push_all_print();
 &set_all_null_print();
@@ -53,7 +53,7 @@ unlink($admin->{'file'});
 # Update an extra admin
 sub modify_extra_admin
 {
-local ($admin, $old, $d) = @_;
+my ($admin, $old, $d) = @_;
 if ($old->{'name'} ne $admin->{'name'}) {
 	unlink($old->{'file'});
 	$admin->{'file'} = "$extra_admins_dir/$d->{'id'}/$admin->{'name'}.admin";

--- a/backup-domain.pl
+++ b/backup-domain.pl
@@ -115,12 +115,12 @@ $asowner = 0;
 @allplans = &list_plans();
 @OLDARGV = @ARGV;
 while(@ARGV > 0) {
-	local $a = shift(@ARGV);
+	my $a = shift(@ARGV);
 	if ($a eq "--dest") {
 		push(@dests, shift(@ARGV));
 		}
 	elsif ($a eq "--feature") {
-		local $f = shift(@ARGV);
+		my $f = shift(@ARGV);
 		&is_enabled_backup_feature($f) ||
 			&usage("Feature $f is not enabled on this system");
 		push(@bfeats, $f);
@@ -152,7 +152,7 @@ while(@ARGV > 0) {
 		push(@bfeats, &list_backup_plugins());
 		}
 	elsif ($a eq "--except-feature") {
-		local $f = shift(@ARGV);
+		my $f = shift(@ARGV);
 		@bfeats = grep { $_ ne $f } @bfeats;
 		}
 	elsif ($a eq "--all-domains") {

--- a/backup.cgi
+++ b/backup.cgi
@@ -65,7 +65,7 @@ elsif ($in{'all'} == 2) {
 else {
 	# Only selected
 	foreach $did (split(/\s+/, $in{'doms'})) {
-		local $dinfo = &get_domain($did);
+		my $dinfo = &get_domain($did);
 		if ($dinfo && &can_backup_domain($dinfo, $acluser)) {
 			push(@doms, $dinfo);
 			if (!$dinfo->{'parent'} && $in{'parent'}) {
@@ -157,7 +157,7 @@ if (defined(&get_backup_key) && $in{'key'}) {
 
 # Parse option inputs
 foreach $f (@do_features) {
-	local $ofunc = "parse_backup_$f";
+	my $ofunc = "parse_backup_$f";
 	if (&indexof($f, &list_backup_plugins()) < 0 &&
 	    defined(&$ofunc)) {
 		$options{$f} = &$ofunc(\%in);

--- a/backup.pl
+++ b/backup.pl
@@ -15,7 +15,7 @@ $mode = 'sched';
 $id = 1;
 $backup_debug = 0;
 while(@ARGV > 0) {
-	local $a = shift(@ARGV);
+	my $a = shift(@ARGV);
 	if ($a eq "--id") {
 		$id = shift(@ARGV);
 		$id || &usage("Missing backup schedule ID");
@@ -60,7 +60,7 @@ elsif ($sched->{'all'} == 2) {
 else {
 	# Selected domains
 	foreach $d (split(/\s+/, $sched->{'doms'})) {
-		local $dinfo = &get_domain($d);
+		my $dinfo = &get_domain($d);
 		if ($dinfo) {
 			push(@doms, $dinfo);
 			if (!$dinfo->{'parent'} && $sched->{'parent'}) {
@@ -343,7 +343,7 @@ if ($sched->{'email_doms'} && $has_mailboxes &&
 # Override print functions to capture output
 sub first_save_print
 {
-local @msg = map { &html_tags_to_text(&entities_to_ascii($_)) } @_;
+my @msg = map { &html_tags_to_text(&entities_to_ascii($_)) } @_;
 $output .= $indent_text.join("", @msg)."\n";
 $domain_output{$current_id} .= $indent_text.join("", @msg)."\n"
 	if ($current_id);
@@ -351,7 +351,7 @@ print $indent_text.join("", @msg)."\n" if ($backup_debug);
 }
 sub second_save_print
 {
-local @msg = map { &html_tags_to_text(&entities_to_ascii($_)) } @_;
+my @msg = map { &html_tags_to_text(&entities_to_ascii($_)) } @_;
 $output .= $indent_text.join("", @msg)."\n\n";
 $domain_output{$current_id} .= $indent_text.join("", @msg)."\n\n"
 	if ($current_id);
@@ -369,7 +369,7 @@ $indent_text = substr($indent_text, 4);
 # Called during the backup process for each domain
 sub backup_cbfunc
 {
-local ($d, $step, $info) = @_;
+my ($d, $step, $info) = @_;
 if ($step == 0) {
 	$current_id = $d->{'id'};
 	}

--- a/backup_form.cgi
+++ b/backup_form.cgi
@@ -148,10 +148,10 @@ foreach $f (&get_available_backup_features()) {
 		$text{'backup_feature_'.$f} || $text{'feature_'.$f},
 		&indexof($f, @schedfeats) >= 0,
 		"onClick='form.feature_all[1].checked = true'")."\n";
-	local $ofunc = "show_backup_$f";
-	local %opts = map { split(/=/, $_) }
+	my $ofunc = "show_backup_$f";
+	my %opts = map { split(/=/, $_) }
 			 split(/,/, $sched->{'backup_opts_'.$f});
-	local $ohtml;
+	my $ohtml;
 	if (defined(&$ofunc) && ($ohtml = &$ofunc(\%opts)) && $ohtml) {
 		$ftable .= "<table><tr><td>\n";
 		$ftable .= ("&nbsp;" x 5);
@@ -180,7 +180,7 @@ foreach my $f (&list_backup_plugins()) {
 		"onClick='form.feature_all[1].checked = true' ".
 		"data-feature-noall='$noall'", $dis)."\n";
 	if (&plugin_defined($f, "feature_backup_opts")) {
-		local %opts = map { split(/=/, $_) }
+		my %opts = map { split(/=/, $_) }
 				 split(/,/, $sched->{'backup_opts_'.$f});
 		$ftable .= &plugin_call($f, "feature_backup_opts",
 					\%opts, $dis);

--- a/backup_sched.cgi
+++ b/backup_sched.cgi
@@ -117,7 +117,7 @@ else {
 
 	# Parse option inputs
 	foreach $f (@do_features) {
-		local $ofunc = "parse_backup_$f";
+		my $ofunc = "parse_backup_$f";
 		if (&indexof($f, &list_backup_plugins()) < 0 &&
 		    defined(&$ofunc)) {
 			$options{$f} = &$ofunc(\%in);

--- a/backups-lib.pl
+++ b/backups-lib.pl
@@ -4,11 +4,11 @@
 # Returns a list of all scheduled backups
 sub list_scheduled_backups
 {
-local @rv;
+my @rv;
 
 # Add old single schedule, from config file
 if ($config{'backup_dest'}) {
-	local %backup = ( 'id' => 1,
+	my %backup = ( 'id' => 1,
 			  'dest' => $config{'backup_dest'},
 			  'fmt' => $config{'backup_fmt'},
 			  'mkdir' => $config{'backup_mkdir'},
@@ -33,7 +33,7 @@ if ($config{'backup_dest'}) {
 			  'exclude' => $config{'backup_exclude'},
 			  'key' => $config{'backup_key'},
 			 );
-	local @bf;
+	my @bf;
 	foreach $f (&get_available_backup_features(), &list_backup_plugins()) {
 		push(@bf, $f) if ($config{'backup_feature_'.$f});
 		$backup{'opts_'.$f} = $config{'backup_opts_'.$f};
@@ -50,7 +50,7 @@ if ($config{'backup_dest'}) {
 opendir(BACKUPS, $scheduled_backups_dir);
 foreach my $b (readdir(BACKUPS)) {
 	if ($b ne "." && $b ne "..") {
-		local %backup;
+		my %backup;
 		&read_file("$scheduled_backups_dir/$b", \%backup);
 		$backup{'id'} = $b;
 		$backup{'file'} = "$scheduled_backups_dir/$b";
@@ -62,12 +62,12 @@ closedir(BACKUPS);
 
 # Merge in classic cron jobs to see which are enabled
 &foreign_require("cron");
-local @jobs = &cron::list_cron_jobs();
+my @jobs = &cron::list_cron_jobs();
 foreach my $j (@jobs) {
 	if ($j->{'user'} eq 'root' &&
 	    $j->{'command'} =~ /^\Q$backup_cron_cmd\E(\s+\-\-id\s+(\d+))?/) {
-		local $id = $2 || 1;
-		local ($backup) = grep { $_->{'id'} eq $id } @rv;
+		my $id = $2 || 1;
+		my ($backup) = grep { $_->{'id'} eq $id } @rv;
 		if ($backup) {
 			$backup->{'enabled'} = 1;
 			&copy_cron_sched_keys($j, $backup);
@@ -77,13 +77,13 @@ foreach my $j (@jobs) {
 
 # Also merge in webmincron jobs
 &foreign_require("webmincron");
-local @jobs = &webmincron::list_webmin_crons();
+my @jobs = &webmincron::list_webmin_crons();
 foreach my $j (@jobs) {
 	if ($j->{'module'} eq $module_name &&
 	    $j->{'func'} eq 'run_cron_script' &&
 	    $j->{'args'}->[0] eq 'backup.pl') {
-		local $id = $j->{'args'}->[1] =~ /--id\s+(\d+)/ ? $1 : 1;
-		local ($backup) = grep { $_->{'id'} eq $id } @rv;
+		my $id = $j->{'args'}->[1] =~ /--id\s+(\d+)/ ? $1 : 1;
+		my ($backup) = grep { $_->{'id'} eq $id } @rv;
 		if ($backup) {
 			$backup->{'enabled'} = 2;
 			&copy_cron_sched_keys($j, $backup);
@@ -107,8 +107,8 @@ return grep { !$_->{'plugged'} } &list_scheduled_backups();
 # Create or update a scheduled backup. Also creates any needed cron job.
 sub save_scheduled_backup
 {
-local ($backup) = @_;
-local $wasnew = !$backup->{'id'};
+my ($backup) = @_;
+my $wasnew = !$backup->{'id'};
 
 if ($backup->{'id'} == 1) {
 	# Update schedule in Virtualmin config
@@ -135,7 +135,7 @@ if ($backup->{'id'} == 1) {
 	$config{'backup_after'} = $backup->{'after'};
 	$config{'backup_exclude'} = $backup->{'exclude'};
 	$config{'backup_key'} = $backup->{'key'};
-	local @bf = split(/\s+/, $backup->{'features'});
+	my @bf = split(/\s+/, $backup->{'features'});
 	foreach $f (&get_available_backup_features(), &list_backup_plugins()) {
 		$config{'backup_feature_'.$f} = &indexof($f, @bf) >= 0 ? 1 : 0;
 		$config{'backup_opts_'.$f} = $backup->{'opts_'.$f};
@@ -165,11 +165,11 @@ else {
 
 # Update or delete cron job
 &foreign_require("cron");
-local $cmd = $backup_cron_cmd;
+my $cmd = $backup_cron_cmd;
 $cmd .= " --id $backup->{'id'}" if ($backup->{'id'} != 1);
-local $job;
+my $job;
 if (!$wasnew) {
-	local @jobs = &find_cron_script($cmd);
+	my @jobs = &find_cron_script($cmd);
 	if ($backup->{'id'} == 1) {
 		# The find_module_cron_job function will match
 		# backup.pl --id xxx when looking for backup.pl, so we have
@@ -216,14 +216,14 @@ elsif (!$backup->{'enabled'} && $job) {
 # Remove one existing backup, and its cron job.
 sub delete_scheduled_backup
 {
-local ($backup) = @_;
+my ($backup) = @_;
 $backup->{'id'} || &error("Missing backup ID!");
 $backup->{'id'} == 1 && &error("The default backup cannot be deleted!");
 &unlink_file($backup->{'file'});
 
 # Delete cron too
-local $cmd = $backup_cron_cmd." --id $backup->{'id'}";
-local @jobs = &find_cron_script($cmd);
+my $cmd = $backup_cron_cmd." --id $backup->{'id'}";
+my @jobs = &find_cron_script($cmd);
 if ($backup->{'id'} == 1) {
 	@jobs = grep { $_->{'command'} !~ /\-\-id/ } @jobs;
 	}
@@ -267,14 +267,14 @@ return $asd;
 # something went wrong.
 sub backup_domains
 {
-local ($desturls, $doms, $features, $dirfmt, $skip, $opts, $homefmt, $vbs,
+my ($desturls, $doms, $features, $dirfmt, $skip, $opts, $homefmt, $vbs,
        $mkdir, $onebyone, $asowner, $cbfunc, $increment, $onsched, $key,
        $kill, $compression, $nosign, $id) = @_;
 $opts->{'skip'} = $skip;
 $opts->{'id'} = $id;
 $desturls = [ $desturls ] if (!ref($desturls));
-local $backupdir;
-local $transferred_sz;
+my $backupdir;
+my $transferred_sz;
 
 # Work out the compression format
 if (!$dirfmt && !$homefmt) {
@@ -298,15 +298,15 @@ if ($compression == 3 && $increment) {
 	}
 
 # Check if the limit on running backups has been hit
-local $err = &check_backup_limits($asowner, $onsched, $desturl);
+my $err = &check_backup_limits($asowner, $onsched, $desturl);
 if ($err) {
 	&$first_print($err);
 	return (0, 0, $doms);
 	}
 
 # Work out who the backup is running as
-local $asd = $asowner ? &get_backup_as_domain($doms) : undef;
-local $asuser = $asd ? $asd->{'user'} : undef;
+my $asd = $asowner ? &get_backup_as_domain($doms) : undef;
+my $asuser = $asd ? $asd->{'user'} : undef;
 
 # Find the tar command
 if (!&get_tar_command()) {
@@ -325,12 +325,12 @@ if ($key && $compression == 3) {
 		  @$desturls;
 
 # See if we can actually connect to the remote server
-local $anyremote;
-local $anylocal;
-local $rsh;	# Rackspace cloud files handle
-local @okurls;
+my $anyremote;
+my $anylocal;
+my $rsh;	# Rackspace cloud files handle
+my @okurls;
 foreach my $desturl (@$desturls) {
-	local ($mode, $user, $pass, $server, $path, $port) =
+	my ($mode, $user, $pass, $server, $path, $port) =
 		&parse_backup_url($desturl);
 	if ($mode == 0) {
 		$desturl = $path;	# Canonicalize path
@@ -339,7 +339,7 @@ foreach my $desturl (@$desturls) {
 		&$first_print(&text('backup_edesturl', &nice_backup_url($desturl), $user));
 		return (0, 0, $doms);
 		}
-	local $starpass = "*" x length($pass);
+	my $starpass = "*" x length($pass);
 	if ($mode == 0 && $asd) {
 		# Always create virtualmin-backup directory
 		$mkdir = 1;
@@ -351,7 +351,7 @@ foreach my $desturl (@$desturls) {
 		my $ftpfunc = $mode == 14
 			? \&ftp_encrypted_onecommand
 			: \&ftp_onecommand;
-		local $ftperr;
+		my $ftperr;
 		&$ftpfunc($server, "PWD", \$ftperr, $user, $pass, $port);
 		if ($ftperr) {
 			$ftperr =~ s/\Q$pass\E/$starpass/g;
@@ -361,17 +361,17 @@ foreach my $desturl (@$desturls) {
 		if ($dirfmt) {
 			# Also create the destination directory and all parents
 			# (ignoring any error, as it may already exist)
-			local @makepath = split(/\//, $path);
-			local $prefix;
+			my @makepath = split(/\//, $path);
+			my $prefix;
 			if ($makepath[0] eq '') {
 				# Remove leading /
 				$prefix = '/';
 				shift(@makepath);
 				}
 			for(my $i=0; $i<@makepath; $i++) {
-				local $makepath = $prefix.
+				my $makepath = $prefix.
 						  join("/", @makepath[0..$i]);
-				local $mkdirerr;
+				my $mkdirerr;
 				&$ftpfunc($server, "MKD $makepath",
 					  \$mkdirerr, $user, $pass, $port);
 				$mkdirerr =~ s/\Q$pass\E/$starpass/g;
@@ -381,16 +381,16 @@ foreach my $desturl (@$desturls) {
 	elsif ($mode == 2) {
 		# Extract destination directory and filename
 		$path =~ /^(.*)\/([^\/]+)\/?$/;
-		local ($pathdir, $pathfile) = ($1, $2);
+		my ($pathdir, $pathfile) = ($1, $2);
 
 		# Try a dummy SCP
-		local $scperr;
-		local $qserver = &check_ip6address($server) ? "[$server]"
+		my $scperr;
+		my $qserver = &check_ip6address($server) ? "[$server]"
 							    : $server;
-		local $testuser = $user || "root";
-		local $testfile = "/tmp/virtualmin-copy-test.$testuser";
-		local $r = ($user ? "$user\@" : "").$qserver.":".$testfile;
-		local $temp = &transname();
+		my $testuser = $user || "root";
+		my $testfile = "/tmp/virtualmin-copy-test.$testuser";
+		my $r = ($user ? "$user\@" : "").$qserver.":".$testfile;
+		my $temp = &transname();
 		open(TEMP, ">$temp");
 		close(TEMP);
 		&scp_copy($temp, $r, $pass, \$scperr, $port, $asuser);
@@ -420,12 +420,12 @@ foreach my $desturl (@$desturls) {
 			}
 
 		# Clean up dummy file if possible
-		local $sshcmd = "ssh".($port ? " -p $port" : "")." ".
+		my $sshcmd = "ssh".($port ? " -p $port" : "")." ".
 				$config{'ssh_args'}." ".
 				($user ? quotemeta($user)."\@" : "").
 				quotemeta($qserver || $server);
-		local $rmcmd = $sshcmd." rm -f ".quotemeta($testfile);
-		local $rmerr;
+		my $rmcmd = $sshcmd." rm -f ".quotemeta($testfile);
+		my $rmerr;
 		&run_ssh_command($rmcmd, $pass, \$rmerr);
 
 		if ($dirfmt && $path ne "/") {
@@ -433,18 +433,18 @@ foreach my $desturl (@$desturls) {
 			# mkdir via ssh or scping an empty dir
 
 			# ssh mkdir first
-			local $mkcmd = $sshcmd." mkdir -p ".
+			my $mkcmd = $sshcmd." mkdir -p ".
 				       quotemeta($path);
-			local $err;
-			local $lsout = &run_ssh_command($mkcmd, $pass, \$err,
+			my $err;
+			my $lsout = &run_ssh_command($mkcmd, $pass, \$err,
 							$asuser);
 
 			if ($err) {
 				# Try scping an empty dir
-				local $empty = &transname($pathfile);
-				local $mkdirerr;
+				my $empty = &transname($pathfile);
+				my $mkdirerr;
 				&make_dir($empty, 0700);
-				local $r = ($user ? "$user\@" : "").
+				my $r = ($user ? "$user\@" : "").
 					   "$server:$pathdir";
 				&scp_copy($empty, $r, $pass, \$mkdirerr, $port,
 					  $asuser);
@@ -458,7 +458,7 @@ foreach my $desturl (@$desturls) {
 			&$first_print($text{'backup_es3nopath'});
 			next;
 			}
-		local $err = &init_s3_bucket($user, $pass, $server,
+		my $err = &init_s3_bucket($user, $pass, $server,
 					     $s3_upload_tries,
 					     $config{'s3_location'});
 		if ($err) {
@@ -477,7 +477,7 @@ foreach my $desturl (@$desturls) {
 			&$second_print($rsh);
 			next;
 			}
-		local $err = &rs_create_container($rsh, $server);
+		my $err = &rs_create_container($rsh, $server);
 		if ($err) {
 			&$second_print($err);
 			next;
@@ -486,14 +486,14 @@ foreach my $desturl (@$desturls) {
 		}
 	elsif ($mode == 7) {
 		# Connect to Google and create the bucket
-		local $buckets = &list_gcs_buckets();
+		my $buckets = &list_gcs_buckets();
 		if (!ref($buckets)) {
 			&$second_print($buckets);
 			next;
 			}
 		my ($already) = grep { $_->{'name'} eq $server } @$buckets;
 		if (!$already) {
-			local $err = &create_gcs_bucket(
+			my $err = &create_gcs_bucket(
 				$server, $config{'google_location'});
 			if ($err) {
 				&$second_print($err);
@@ -536,7 +536,7 @@ foreach my $desturl (@$desturls) {
 		}
 	elsif ($mode == 9) {
 		# Connect to the remote Webmin server
-		local $w = &dest_to_webmin($desturl);
+		my $w = &dest_to_webmin($desturl);
 		eval {
 			local $main::error_must_die = 1;
 			&remote_foreign_require($w, "webmin");
@@ -555,13 +555,13 @@ foreach my $desturl (@$desturls) {
 		}
 	elsif ($mode == 10) {
 		# Connect to Backblaze and create the bucket
-		local $already = &get_bb_bucket($server);
+		my $already = &get_bb_bucket($server);
 		if ($already && !ref($already)) {
 			&$second_print($already);
 			next;
 			}
 		if (!$already) {
-			local $err = &create_bb_bucket($server);
+			my $err = &create_bb_bucket($server);
 			if ($err) {
 				&$second_print($err);
 				next;
@@ -570,14 +570,14 @@ foreach my $desturl (@$desturls) {
 		}
 	elsif ($mode == 11) {
 		# Connect to Azure and create the container
-		local $containers = &list_azure_containers();
+		my $containers = &list_azure_containers();
 		if (!ref($containers)) {
 			&$second_print($containers);
 			next;
 			}
 		my ($already) = grep { $_->{'name'} eq $server } @$containers;
 		if (!$already) {
-			local $err = &create_azure_container($server);
+			my $err = &create_azure_container($server);
 			if ($err) {
 				&$second_print($err);
 				next;
@@ -597,7 +597,7 @@ foreach my $desturl (@$desturls) {
 			}
 		my $already = &get_drive_folder($server);
 		if (!ref($already)) {
-			local $err = &create_drive_folder($server);
+			my $err = &create_drive_folder($server);
 			if ($err) {
 				&$second_print($err);
 				next;
@@ -669,10 +669,10 @@ foreach my $desturl (@$desturls) {
 			}
 		if (!$dirfmt && $mkdir) {
 			# Create parent directories for a file backup
-			local $dirdest = $desturl;
+			my $dirdest = $desturl;
 			$dirdest =~ s/\/[^\/]+$//;
 			if ($dirdest && !-d $dirdest) {
-				local $derr = &make_backup_dir(
+				my $derr = &make_backup_dir(
 						$dirdest, 0700, 0, $asd);
 				if ($derr) {
 					&$second_print(&text('backup_emkdir',
@@ -720,13 +720,13 @@ if ($homefmt && !$dirfmt) {
 	}
 
 # Work out where to write the final tar files to
-local ($dest, @destfiles, %destfiles_map);
-local ($mode0, $user0, $pass0, $server0, $path0, $port0) =
+my ($dest, @destfiles, %destfiles_map);
+my ($mode0, $user0, $pass0, $server0, $path0, $port0) =
 	&parse_backup_url($desturls->[0]);
 if (!$anylocal) {
 	# Write archive to temporary file/dir first, for later upload
 	$path0 =~ /^(.*)\/([^\/]+)\/?$/;
-	local ($pathdir, $pathfile) = ($1, $2);
+	my ($pathdir, $pathfile) = ($1, $2);
 	$dest = &transname($$."-".$pathfile);
 	}
 else {
@@ -735,7 +735,7 @@ else {
 	}
 if ($dirfmt && !-d $dest) {
 	# If backing up to a directory that doesn't exist yet, create it
-	local $derr = &make_backup_dir($dest, 0700, 1, $asd);
+	my $derr = &make_backup_dir($dest, 0700, 1, $asd);
 	if ($derr) {
 		&$first_print(&text('backup_emkdir', "<tt>$dest</tt>", $derr));
 		return (0, 0, $doms);
@@ -749,8 +749,8 @@ elsif (!$dirfmt && $anyremote && $asd) {
 	}
 
 # For a home-format backup, the home has to be last
-local @backupfeatures = @$features;
-local $hfsuffix;
+my @backupfeatures = @$features;
+my $hfsuffix;
 if ($homefmt) {
 	@backupfeatures = ((grep { $_ ne "dir" } @$features), "dir");
 	$hfsuffix = &compression_to_suffix($compression);
@@ -758,16 +758,16 @@ if ($homefmt) {
 
 # Take a lock on the backup destination, to avoid concurrent backups to
 # the same dest
-local @lockfiles;
+my @lockfiles;
 foreach my $desturl (@$desturls) {
-	local $lockname = $desturl;
+	my $lockname = $desturl;
 	$lockname =~ s/\//_/g;
 	$lockname =~ s/\s/_/g;
 	if (!-d $backup_locks_dir) {
 		&make_dir($backup_locks_dir, 0700);
 		}
-	local $lockfile = $backup_locks_dir."/".$lockname;
-	local $lpid = &test_lock($lockfile);
+	my $lockfile = $backup_locks_dir."/".$lockname;
+	my $lpid = &test_lock($lockfile);
 	if ($kill == 2 && $lpid) {
 		# Destination is locked, wait for it to free up
 		&$first_print(&text('backup_waitlock', $lpid));
@@ -799,15 +799,15 @@ foreach my $desturl (@$desturls) {
 
 # Go through all the domains, and for each feature call the backup function
 # to add it to the backup directory
-local $d;
-local $ok = 1;
-local @donedoms;
-local ($okcount, $errcount) = (0, 0);
-local @errdoms;
-local %donefeatures;				# Map from domain name->features
-local @cleanuphomes;				# Temporary homes
-local %donedoms;				# Map from domain name->hash
-local $failalldoms;
+my $d;
+my $ok = 1;
+my @donedoms;
+my ($okcount, $errcount) = (0, 0);
+my @errdoms;
+my %donefeatures;				# Map from domain name->features
+my @cleanuphomes;				# Temporary homes
+my %donedoms;				# Map from domain name->hash
+my $failalldoms;
 my @bplugins;
 DOMAIN: foreach $d (sort { $a->{'dom'} cmp $b->{'dom'} } @$doms) {
 	# Force lock and re-read the domain in case it has changed
@@ -859,9 +859,9 @@ DOMAIN: foreach $d (sort { $a->{'dom'} cmp $b->{'dom'} } @$doms) {
 		$dok = 0;
 		goto DOMAINFAILED_NOQUOTAS;
 		}
-	local $f;
-	local $dok = 1;
-	local @donefeatures;
+	my $f;
+	my $dok = 1;
+	my @donefeatures;
 
 	# Run the before command
 	&set_domain_envs($dom, "BACKUP_DOMAIN");
@@ -901,7 +901,7 @@ DOMAIN: foreach $d (sort { $a->{'dom'} cmp $b->{'dom'} } @$doms) {
 	# don't fail
 	&disable_quotas($d);
 
-	local $lockdir;
+	my $lockdir;
 	if ($homefmt) {
 		# Backup for most features goes to a sub-dir of the home, which
 		# is then included in a tar of the home directory
@@ -909,7 +909,7 @@ DOMAIN: foreach $d (sort { $a->{'dom'} cmp $b->{'dom'} } @$doms) {
 		&lock_file($lockdir);
 		&execute_command("rm -rf ".quotemeta($backupdir));
 		&disable_quotas($asd) if ($asd);
-		local $derr = &make_backup_dir($backupdir, 0777, 0, $asd);
+		my $derr = &make_backup_dir($backupdir, 0777, 0, $asd);
 		&enable_quotas($asd) if ($asd);
 		if ($derr) {
 			&$second_print(&text('backup_ebackupdir',
@@ -1028,27 +1028,27 @@ DOMAIN: foreach $d (sort { $a->{'dom'} cmp $b->{'dom'} } @$doms) {
 
 	if ($onebyone && $homefmt && $dok && $anyremote) {
 		# Transfer this domain now
-		local $df = "$d->{'dom'}.$hfsuffix";
+		my $df = "$d->{'dom'}.$hfsuffix";
 		&$cbfunc($d, 1, "$dest/$df") if ($cbfunc);
-		local $tstart = time();
-		local $binfo = { $d->{'dom'} =>
+		my $tstart = time();
+		my $binfo = { $d->{'dom'} =>
 				 $donefeatures{$d->{'dom'}} };
-		local $bdom = { $d->{'dom'} => &clean_domain_passwords($d) };
-		local $infotemp = &transname();
+		my $bdom = { $d->{'dom'} => &clean_domain_passwords($d) };
+		my $infotemp = &transname();
 		&uncat_file($infotemp, &serialise_variable($binfo));
-		local $domtemp = &transname();
+		my $domtemp = &transname();
 		&uncat_file($domtemp, &serialise_variable($bdom));
-		local $done_transferred_sz = 0;
+		my $done_transferred_sz = 0;
 		foreach my $desturl (@$desturls) {
-			local ($mode, $user, $pass, $server, $path, $port) =
+			my ($mode, $user, $pass, $server, $path, $port) =
 				&parse_backup_url($desturl);
-			local $starpass = "*" x length($pass);
-			local $err;
+			my $starpass = "*" x length($pass);
+			my $err;
 			if ($mode == 0 && $path ne $path0) {
 				# Copy to another local directory
 				&$first_print(&text('backup_copy',
 						    "<tt>$path/$df</tt>"));
-				local $ok;
+				my $ok;
 				if ($asd) {
 					($ok, $err) = 
 					  &copy_source_dest_as_domain_user(
@@ -1084,7 +1084,7 @@ DOMAIN: foreach $d (sort { $a->{'dom'} cmp $b->{'dom'} } @$doms) {
 			elsif ($mode == 0 && $path eq $path0) {
 				# Just silently write out .info and .dom files
 				# for this directory
-				local $ok;
+				my $ok;
 				if ($asd) {
 					($ok, $err) = 
 					  &copy_source_dest_as_domain_user(
@@ -1144,7 +1144,7 @@ DOMAIN: foreach $d (sort { $a->{'dom'} cmp $b->{'dom'} } @$doms) {
 				# Via Webmin file transfer
 				&$first_print(&text('backup_upload9',
 						    "<tt>$server</tt>"));
-				local $w = &dest_to_webmin($desturl);
+				my $w = &dest_to_webmin($desturl);
 				eval {
 					local $main::error_must_die = 1;
 					&remote_finished();
@@ -1171,7 +1171,7 @@ DOMAIN: foreach $d (sort { $a->{'dom'} cmp $b->{'dom'} } @$doms) {
 			elsif ($mode == 6) {
 				# Via rackspace upload
 				&$first_print($text{'backup_upload6'});
-				local $dfpath = $path ? $path."/".$df : $df;
+				my $dfpath = $path ? $path."/".$df : $df;
 				$err = &rs_upload_object($rsh,
 					$server, $dfpath, "$dest/$df");
 				$err = &rs_upload_object($rsh, $server,
@@ -1207,7 +1207,7 @@ DOMAIN: foreach $d (sort { $a->{'dom'} cmp $b->{'dom'} } @$doms) {
 				}
 			else {
 				&$second_print($text{'setup_done'});
-				local @tst = stat("$dest/$df");
+				my @tst = stat("$dest/$df");
 				if ($mode != 0 && !$done_transferred_sz++) {
 					$transferred_sz += $tst[7];
 					}
@@ -1244,11 +1244,11 @@ DOMAIN: foreach $d (sort { $a->{'dom'} cmp $b->{'dom'} } @$doms) {
 	}
 
 # Remove duplicate done domains
-local %doneseen;
+my %doneseen;
 @donedoms = grep { !$doneseen{$_->{'id'}}++ } @donedoms;
 
 # Add all requested Virtualmin config information
-local $vcount = 0;
+my $vcount = 0;
 if (@$vbs) {
 	&$first_print($text{'backup_global2'});
 	&$indent_print();
@@ -1259,8 +1259,8 @@ if (@$vbs) {
 		&make_dir($backupdir, 0755);
 		}
 	foreach my $v (@$vbs) {
-		local $vfile = "$backupdir/virtualmin_".$v;
-		local $vfunc = "virtualmin_backup_".$v;
+		my $vfile = "$backupdir/virtualmin_".$v;
+		my $vfunc = "virtualmin_backup_".$v;
 		if (defined(&$vfunc)) {
 			if (my $donecount = &$vfunc($vfile, $vbs)) {
 				$vcount += $donecount;
@@ -1274,7 +1274,7 @@ if (@$vbs) {
 if ($ok) {
 	# Work out command for writing to backup destination (which may use
 	# su, so that permissions are correct)
-	local ($out, $err);
+	my ($out, $err);
 	if ($homefmt) {
 		# No final step is needed for home-format backups, because
 		# we have already reached it!
@@ -1294,8 +1294,8 @@ if ($ok) {
 
 		foreach $d (@donedoms) {
 			# Work out dest file and compression command
-			local $destfile = "$d->{'dom'}.tar";
-			local $comp = "cat";
+			my $destfile = "$d->{'dom'}.tar";
+			my $comp = "cat";
 			if ($compression == 0) {
 				$destfile .= ".gz";
 				$comp = &get_gzip_command();
@@ -1313,8 +1313,8 @@ if ($ok) {
 				}
 
 			# Create command that writes to the final file
-			local $qf = quotemeta("$dest/$destfile");
-			local $writer = "cat >$qf";
+			my $qf = quotemeta("$dest/$destfile");
+			my $writer = "cat >$qf";
 			if ($asd) {
 				$writer = &command_as_user(
 					$asd->{'user'}, 0, $writer);
@@ -1327,7 +1327,7 @@ if ($ok) {
 				}
 
 			# Create the dest file with strict permissions
-			local $toucher = "touch $qf && chmod 600 $qf";
+			my $toucher = "touch $qf && chmod 600 $qf";
 			if ($asd) {
 				$toucher = &command_as_user(
 					$asd->{'user'}, 0, $toucher);
@@ -1367,7 +1367,7 @@ if ($ok) {
 		}
 	else {
 		# Tar up the directory into the final file
-		local $comp;
+		my $comp;
 		if ($dest =~ /\.(gz|tgz)$/i) {
 			$comp = &get_gzip_command();
 			}
@@ -1394,7 +1394,7 @@ if ($ok) {
 			}
 
 		# Create writer command, which may run as the domain user
-		local $writer = "cat >$dest";
+		my $writer = "cat >$dest";
 		if ($asd) {
 			&open_tempfile_as_domain_user(
 				$asd, DEST, ">$dest", 0, 1);
@@ -1443,9 +1443,9 @@ if ($ok) {
 # Create a separate file in the destination directory for Virtualmin
 # config backups
 if (@$vbs && ($homefmt || $dirfmt)) {
-	local $comp;
-	local $vdestfile;
-	local ($out, $err);
+	my $comp;
+	my $vdestfile;
+	my ($out, $err);
 	if (&has_command("gzip")) {
 		$comp = &get_gzip_command();
 		$vdestfile = "virtualmin.tar.gz";
@@ -1506,23 +1506,23 @@ foreach my $f (@backupfeatures) {
 	}
 
 # Work out backup size, including files already transferred and deleted
-local $sz = 0;
+my $sz = 0;
 if ($dirfmt) {
 	# Multiple files
 	foreach my $f (@destfiles) {
-		local @st = stat("$dest/$f");
+		my @st = stat("$dest/$f");
 		$sz += $st[7];
 		}
 	}
 else {
 	# One file
-	local @st = stat($dest);
+	my @st = stat($dest);
 	$sz = $st[7];
 	}
 $sz += $transferred_sz;
 
 foreach my $desturl (@$desturls) {
-	local ($mode, $user, $pass, $server, $path, $port) =
+	my ($mode, $user, $pass, $server, $path, $port) =
 		&parse_backup_url($desturl);
 	if ($ok && ($mode == 1 || $mode == 14) && (@destfiles || !$dirfmt)) {
 		# Upload file(s) to FTP server
@@ -1530,19 +1530,19 @@ foreach my $desturl (@$desturls) {
 			? \&ftp_encrypted_tryload
 			: \&ftp_tryload;
 		&$first_print(&text('backup_upload', "<tt>$server</tt>"));
-		local $err;
-		local $infotemp = &transname();
-		local $domtemp = &transname();
+		my $err;
+		my $infotemp = &transname();
+		my $domtemp = &transname();
 		if ($dirfmt) {
 			# Need to upload entire directory .. which has to be
 			# created first
 			foreach my $df (@destfiles) {
-				local $tstart = time();
-				local $d = $destfiles_map{$df};
-				local $n = $d eq "virtualmin" ? "virtualmin"
+				my $tstart = time();
+				my $d = $destfiles_map{$df};
+				my $n = $d eq "virtualmin" ? "virtualmin"
 							      : $d->{'dom'};
-				local $binfo = { $n => $donefeatures{$n} };
-				local $bdom =
+				my $binfo = { $n => $donefeatures{$n} };
+				my $bdom =
 					{ $n => &clean_domain_passwords($d) };
 				&uncat_file($infotemp,
 					    &serialise_variable($binfo));
@@ -1568,7 +1568,7 @@ foreach my $desturl (@$desturls) {
 					}
 				elsif ($asd && $d) {
 					# Log bandwidth used by this domain
-					local @tst = stat("$dest/$df");
+					my @tst = stat("$dest/$df");
 					&record_backup_bandwidth(
 					    $d, 0, $tst[7], $tstart, time());
 					}
@@ -1576,7 +1576,7 @@ foreach my $desturl (@$desturls) {
 			}
 		else {
 			# Just a single file
-			local $tstart = time();
+			my $tstart = time();
 			&uncat_file($infotemp,
 				    &serialise_variable(\%donefeatures));
 			&uncat_file($domtemp,
@@ -1597,7 +1597,7 @@ foreach my $desturl (@$desturls) {
 				}
 			elsif ($asd) {
 				# Log bandwidth used by whole transfer
-				local @tst = stat($dest);
+				my @tst = stat($dest);
 				&record_backup_bandwidth($asd, 0, $tst[7], 
 							 $tstart, time());
 				}
@@ -1609,17 +1609,17 @@ foreach my $desturl (@$desturls) {
 	elsif ($ok && ($mode == 2 || $mode == 13) && (@destfiles || !$dirfmt)) {
 		# Upload to SSH server with scp or SFTP server with sftp
 		&$first_print(&text('backup_upload'.$mode, "<tt>$server</tt>"));
-		local $err;
-		local $qserver = &check_ip6address($server) ?
+		my $err;
+		my $qserver = &check_ip6address($server) ?
 					"[$server]" : $server;
-		local $r = ($user ? "$user\@" : "")."$qserver:$path";
-		local $infotemp = &transname();
-		local $domtemp = &transname();
+		my $r = ($user ? "$user\@" : "")."$qserver:$path";
+		my $infotemp = &transname();
+		my $domtemp = &transname();
 		my $cfunc = $mode == 2 ? \&scp_copy : \&sftp_upload;
 		if ($dirfmt) {
 			# Need to upload all backup files in the directory
 			$err = undef;
-			local $tstart = time();
+			my $tstart = time();
 			foreach my $df (@destfiles) {
 				&$cfunc("$dest/$df", "$r/$df",
 					  $pass, \$err, $port, $asuser);
@@ -1634,11 +1634,11 @@ foreach my $desturl (@$desturls) {
 				}
 			# Upload each domain's .info and .dom files
 			foreach my $df (@destfiles) {
-				local $d = $destfiles_map{$df};
-				local $n = $d eq "virtualmin" ? "virtualmin"
+				my $d = $destfiles_map{$df};
+				my $n = $d eq "virtualmin" ? "virtualmin"
 							      : $d->{'dom'};
-				local $binfo = { $n => $donefeatures{$n} };
-				local $bdom = { $n => $d };
+				my $binfo = { $n => $donefeatures{$n} };
+				my $bdom = { $n => $d };
 				&uncat_file($infotemp,
 					    &serialise_variable($binfo));
 				&uncat_file($domtemp,
@@ -1652,9 +1652,9 @@ foreach my $desturl (@$desturls) {
 			if (!$err && $asd) {
 				# Log bandwidth used by domain
 				foreach my $df (@destfiles) {
-					local $d = $destfiles_map{$df};
+					my $d = $destfiles_map{$df};
 					if ($d) {
-						local @tst = stat("$dest/$df");
+						my @tst = stat("$dest/$df");
 						&record_backup_bandwidth(
 							$d, 0, $tst[7],
 							$tstart, time());
@@ -1664,7 +1664,7 @@ foreach my $desturl (@$desturls) {
 			}
 		else {
 			# Just a single file
-			local $tstart = time();
+			my $tstart = time();
 			&uncat_file($infotemp,
 				    &serialise_variable(\%donefeatures));
 			&uncat_file($domtemp,
@@ -1677,7 +1677,7 @@ foreach my $desturl (@$desturls) {
 			$err =~ s/\Q$pass\E/$starpass/g;
 			if ($asd && !$err) {
 				# Log bandwidth used by whole transfer
-				local @tst = stat($dest);
+				my @tst = stat($dest);
 				&record_backup_bandwidth($asd, 0, $tst[7], 
 							 $tstart, time());
 				}
@@ -1692,17 +1692,17 @@ foreach my $desturl (@$desturls) {
 		}
 	elsif ($ok && $mode == 3 && (@destfiles || !$dirfmt)) {
 		# Upload to S3 server
-		local $err;
+		my $err;
 		&$first_print($text{'backup_upload3'});
 		if ($dirfmt) {
 			# Upload an entire directory of files
 			foreach my $df (@destfiles) {
-				local $tstart = time();
-				local $d = $destfiles_map{$df};
-				local $n = $d eq "virtualmin" ? "virtualmin"
+				my $tstart = time();
+				my $d = $destfiles_map{$df};
+				my $n = $d eq "virtualmin" ? "virtualmin"
 							      : $d->{'dom'};
-				local $binfo = { $n => $donefeatures{$n} };
-				local $bdom = $d eq "virtualmin" ? undef :
+				my $binfo = { $n => $donefeatures{$n} };
+				my $bdom = $d eq "virtualmin" ? undef :
 					{ $n => &clean_domain_passwords($d) };
 				$err = &s3_upload($user, $pass, $server,
 						  "$dest/$df",
@@ -1717,7 +1717,7 @@ foreach my $desturl (@$desturls) {
 					}
 				elsif ($asd && $d) {
 					# Log bandwidth used by this domain
-					local @tst = stat("$dest/$df");
+					my @tst = stat("$dest/$df");
 					&record_backup_bandwidth(
 						$d, 0, $tst[7], $tstart,time());
 					}
@@ -1725,8 +1725,8 @@ foreach my $desturl (@$desturls) {
 			}
 		else {
 			# Upload one file to the bucket
-			local %donebydname;
-			local $tstart = time();
+			my %donebydname;
+			my $tstart = time();
 			$err = &s3_upload($user, $pass, $server, $dest,
 					  $path, \%donefeatures, \%donedoms,
 					  $s3_upload_tries, $port);
@@ -1737,7 +1737,7 @@ foreach my $desturl (@$desturls) {
 				}
 			elsif ($asd) {
 				# Log bandwidth used by whole transfer
-				local @tst = stat($dest);
+				my @tst = stat($dest);
 				&record_backup_bandwidth($asd, 0, $tst[7], 
 							 $tstart, time());
 				}
@@ -1746,24 +1746,24 @@ foreach my $desturl (@$desturls) {
 		}
 	elsif ($ok && $mode == 6 && (@destfiles || !$dirfmt)) {
 		# Upload to Rackspace cloud files
-		local $err;
+		my $err;
 		&$first_print($text{'backup_upload6'});
-		local $infotemp = &transname();
-		local $domtemp = &transname();
+		my $infotemp = &transname();
+		my $domtemp = &transname();
 		if ($dirfmt) {
 			# Upload an entire directory of files
-			local $tstart = time();
+			my $tstart = time();
 			foreach my $df (@destfiles) {
-				local $d = $destfiles_map{$df};
-				local $n = $d eq "virtualmin" ? "virtualmin"
+				my $d = $destfiles_map{$df};
+				my $n = $d eq "virtualmin" ? "virtualmin"
 							      : $d->{'dom'};
-				local $binfo = { $n => $donefeatures{$n} };
-				local $bdom = { $n => $d };
+				my $binfo = { $n => $donefeatures{$n} };
+				my $bdom = { $n => $d };
 				&uncat_file($infotemp,
 					    &serialise_variable($binfo));
 				&uncat_file($domtemp,
 					    &serialise_variable($bdom));
-				local $dfpath = $path ? $path."/".$df : $df;
+				my $dfpath = $path ? $path."/".$df : $df;
 				$err = &rs_upload_object($rsh, $server,
 					$dfpath, $dest."/".$df);
 				$err = &rs_upload_object($rsh, $server,
@@ -1774,9 +1774,9 @@ foreach my $desturl (@$desturls) {
 			if (!$err && $asd) {
 				# Log bandwidth used by domain
 				foreach my $df (@destfiles) {
-					local $d = $destfiles_map{$df};
+					my $d = $destfiles_map{$df};
 					if ($d) {
-						local @tst = stat("$dest/$df");
+						my @tst = stat("$dest/$df");
 						&record_backup_bandwidth(
 							$d, 0, $tst[7],
 							$tstart, time());
@@ -1786,7 +1786,7 @@ foreach my $desturl (@$desturls) {
 			}
 		else {
 			# Upload one file to the container
-			local $tstart = time();
+			my $tstart = time();
 			&uncat_file($infotemp,
 				    &serialise_variable(\%donefeatures));
 			&uncat_file($domtemp,
@@ -1798,7 +1798,7 @@ foreach my $desturl (@$desturls) {
 					  $domtemp) if (!$err);
 			if ($asd && !$err) {
 				# Log bandwidth used by whole transfer
-				local @tst = stat($dest);
+				my @tst = stat($dest);
 				&record_backup_bandwidth($asd, 0, $tst[7], 
 							 $tstart, time());
 				}
@@ -1815,32 +1815,32 @@ foreach my $desturl (@$desturls) {
 		       $mode == 11 || $mode == 12) &&
 	       (@destfiles || !$dirfmt)) {
 		# Upload to Google cloud storage, Dropbox or Backblaze
-		local $err;
+		my $err;
 		&$first_print($text{'backup_upload'.$mode});
-		local $func = $mode == 7 ? \&upload_gcs_file :
+		my $func = $mode == 7 ? \&upload_gcs_file :
 			      $mode == 8 ? \&upload_dropbox_file :
 			      $mode == 11 ? \&upload_azure_file :
 			      $mode == 12 ? \&upload_drive_file :
 					   \&upload_bb_file;
-		local $tries = $mode == 7 ? $gcs_upload_tries :
+		my $tries = $mode == 7 ? $gcs_upload_tries :
 			       $mode == 8 ? $dropbox_upload_tries :
 					    $rr_upload_tries;
-		local $infotemp = &transname();
-		local $domtemp = &transname();
+		my $infotemp = &transname();
+		my $domtemp = &transname();
 		if ($dirfmt) {
 			# Upload an entire directory of files
-			local $tstart = time();
+			my $tstart = time();
 			foreach my $df (@destfiles) {
-				local $d = $destfiles_map{$df};
-				local $n = $d eq "virtualmin" ? "virtualmin"
+				my $d = $destfiles_map{$df};
+				my $n = $d eq "virtualmin" ? "virtualmin"
 							      : $d->{'dom'};
-				local $binfo = { $n => $donefeatures{$n} };
-				local $bdom = { $n => $d };
+				my $binfo = { $n => $donefeatures{$n} };
+				my $bdom = { $n => $d };
 				&uncat_file($infotemp,
 					    &serialise_variable($binfo));
 				&uncat_file($domtemp,
 					    &serialise_variable($bdom));
-				local $dfpath = $path ? $path."/".$df : $df;
+				my $dfpath = $path ? $path."/".$df : $df;
 				$err = &$func($server, $dfpath,
 					      $dest."/".$df, $tries);
 				$err = &$func($server, $dfpath.".info",
@@ -1851,9 +1851,9 @@ foreach my $desturl (@$desturls) {
 			if (!$err && $asd) {
 				# Log bandwidth used by domain
 				foreach my $df (@destfiles) {
-					local $d = $destfiles_map{$df};
+					my $d = $destfiles_map{$df};
 					if ($d) {
-						local @tst = stat("$dest/$df");
+						my @tst = stat("$dest/$df");
 						&record_backup_bandwidth(
 							$d, 0, $tst[7],
 							$tstart, time());
@@ -1863,7 +1863,7 @@ foreach my $desturl (@$desturls) {
 			}
 		else {
 			# Upload one file to the container
-			local $tstart = time();
+			my $tstart = time();
 			&uncat_file($infotemp,
 				    &serialise_variable(\%donefeatures));
 			&uncat_file($domtemp,
@@ -1875,7 +1875,7 @@ foreach my $desturl (@$desturls) {
 				      $domtemp, $tries) if (!$err);
 			if ($asd && !$err) {
 				# Log bandwidth used by whole transfer
-				local @tst = stat($dest);
+				my @tst = stat($dest);
 				&record_backup_bandwidth($asd, 0, $tst[7], 
 							 $tstart, time());
 				}
@@ -1891,12 +1891,12 @@ foreach my $desturl (@$desturls) {
 	elsif ($ok && $mode == 9 && (@destfiles || !$dirfmt)) {
 		# Upload to Webmin server
 		&$first_print(&text('backup_upload9', "<tt>$server</tt>"));
-		local $w = &dest_to_webmin($desturl);
-		local $infotemp = &transname();
-		local $domtemp = &transname();
+		my $w = &dest_to_webmin($desturl);
+		my $infotemp = &transname();
+		my $domtemp = &transname();
 		if ($dirfmt) {
 			# Need to upload all backup files in the directory
-			local $tstart = time();
+			my $tstart = time();
 			eval {
 				local $main::error_must_die = 1;
 				&remote_finished();
@@ -1910,11 +1910,11 @@ foreach my $desturl (@$desturls) {
 
 			# Upload each domain's .info and .dom files
 			foreach my $df (@destfiles) {
-				local $d = $destfiles_map{$df};
-				local $n = $d eq "virtualmin" ? "virtualmin"
+				my $d = $destfiles_map{$df};
+				my $n = $d eq "virtualmin" ? "virtualmin"
 							      : $d->{'dom'};
-				local $binfo = { $n => $donefeatures{$n} };
-				local $bdom = { $n => $d };
+				my $binfo = { $n => $donefeatures{$n} };
+				my $bdom = { $n => $d };
 				&uncat_file($infotemp,
 					    &serialise_variable($binfo));
 				&uncat_file($domtemp,
@@ -1930,9 +1930,9 @@ foreach my $desturl (@$desturls) {
 			if (!$err && $asd) {
 				# Log bandwidth used by domain
 				foreach my $df (@destfiles) {
-					local $d = $destfiles_map{$df};
+					my $d = $destfiles_map{$df};
 					if ($d) {
-						local @tst = stat("$dest/$df");
+						my @tst = stat("$dest/$df");
 						&record_backup_bandwidth(
 							$d, 0, $tst[7],
 							$tstart, time());
@@ -1943,7 +1943,7 @@ foreach my $desturl (@$desturls) {
 			}
 		else {
 			# Just a single file
-			local $tstart = time();
+			my $tstart = time();
 			&uncat_file($infotemp,
 				    &serialise_variable(\%donefeatures));
 			&uncat_file($domtemp,
@@ -1960,7 +1960,7 @@ foreach my $desturl (@$desturls) {
 			$err =~ s/\s+at\s+\S+\s+line\s+\d+.*//g;
 			if ($asd && !$err) {
 				# Log bandwidth used by whole transfer
-				local @tst = stat($dest);
+				my @tst = stat($dest);
 				&record_backup_bandwidth($asd, 0, $tst[7], 
 							 $tstart, time());
 				}
@@ -2016,12 +2016,12 @@ foreach my $desturl (@$desturls) {
 		if ($dirfmt) {
 			# One .info and .dom file per domain
 			foreach my $df (@destfiles) {
-				local $d = $destfiles_map{$df};
-				local $n = $d eq "virtualmin" ? "virtualmin"
+				my $d = $destfiles_map{$df};
+				my $n = $d eq "virtualmin" ? "virtualmin"
 							      : $d->{'dom'};
-				local $binfo = { $n => $donefeatures{$n} };
-				local $bdom = { $n => $d };
-				local $wcode = sub { 
+				my $binfo = { $n => $donefeatures{$n} };
+				my $bdom = { $n => $d };
+				my $wcode = sub {
 					&uncat_file("$dest/$df.info",
 					    &serialise_variable($binfo));
 					if ($d ne "virtualmin") {
@@ -2039,7 +2039,7 @@ foreach my $desturl (@$desturls) {
 			}
 		else {
 			# A single file
-			local $wcode = sub {
+			my $wcode = sub {
 				&uncat_file("$dest.info",
 					&serialise_variable(\%donefeatures));
 				&uncat_file("$dest.dom",
@@ -2136,10 +2136,10 @@ return if (!$d || !$d->{'id'});
 # If under the temp directory, this is always done as root.
 sub make_backup_dir
 {
-local ($dir, $perms, $recur, $d) = @_;
-local $cmd = "mkdir".($recur ? " -p" : "")." ".quotemeta($dir)." 2>&1";
-local $out;
-local $tempbase = $gconfig{'tempdir_'.$module_name} ||
+my ($dir, $perms, $recur, $d) = @_;
+my $cmd = "mkdir".($recur ? " -p" : "")." ".quotemeta($dir)." 2>&1";
+my $out;
+my $tempbase = $gconfig{'tempdir_'.$module_name} ||
 		  $gconfig{'tempdir'} ||
 		  "/tmp/.webmin";
 if ($d && !&is_under_directory($tempbase, $dir)) {
@@ -2172,17 +2172,17 @@ return $? ? $out : undef;
 # Restore multiple domains from the given file
 sub restore_domains
 {
-local ($file, $doms, $features, $opts, $vbs, $onlyfeats, $ipinfo, $asowner,
+my ($file, $doms, $features, $opts, $vbs, $onlyfeats, $ipinfo, $asowner,
        $skipwarnings, $key, $continue, $delete_existing) = @_;
 
 # Find owning domain
-local $asd = $asowner ? &get_backup_as_domain($doms) : undef;
-local $asuser = $asd ? $asd->{'user'} : undef;
+my $asd = $asowner ? &get_backup_as_domain($doms) : undef;
+my $asuser = $asd ? $asd->{'user'} : undef;
 
 # Work out where the backup is located
-local $ok = 1;
-local $backup;
-local ($mode, $user, $pass, $server, $path, $port) = &parse_backup_url($file);
+my $ok = 1;
+my $backup;
+my ($mode, $user, $pass, $server, $path, $port) = &parse_backup_url($file);
 if ($mode < 0) {
 	&$second_print(&text('backup_edesturl', $file, $user));
 	return 0;
@@ -2191,7 +2191,7 @@ if ($mode == 0) {
 	# Canonicalize path
 	$file = $path;
 	}
-local $starpass = "*" x length($pass);
+my $starpass = "*" x length($pass);
 if ($mode > 0) {
 	# Need to download to temp file/directory first
 	&$first_print($mode == 1 || $mode == 14 ? $text{'restore_download'} :
@@ -2205,8 +2205,8 @@ if ($mode > 0) {
 		      $mode == 12 ? $text{'restore_downloaddr'} :
 				   $text{'restore_downloadssh'});
 	$backup = &transname_owned($asd);
-	local $tstart = time();
-	local $derr = &download_backup($_[0], $backup,
+	my $tstart = time();
+	my $derr = &download_backup($_[0], $backup,
 		[ map { $_->{'dom'} } @$doms ], $vbs, 0, $asd);
 	if ($derr) {
 		$derr =~ s/\Q$pass\E/$starpass/g;
@@ -2216,7 +2216,7 @@ if ($mode > 0) {
 	else {
 		# Done .. account for bandwidth
 		if ($asd && $asd->{'id'}) {
-			local $sz = &disk_usage_kb($backup)*1024;
+			my $sz = &disk_usage_kb($backup)*1024;
 			&record_backup_bandwidth($asd, $sz, 0, $tstart, time());
 			}
 		&$second_print($text{'setup_done'});
@@ -2252,14 +2252,14 @@ if ($onlyfeats && @anymissing) {
 		}
 	}
 
-local $restoredir;
-local %homeformat;
+my $restoredir;
+my %homeformat;
 if ($ok) {
 	# Create a temp dir for the backup archive contents
 	$restoredir = &transname();
 	&make_dir($restoredir, 0711);
 
-	local @files;
+	my @files;
 	if (-d $backup) {
 		# Extracting a directory of backup files
 		&$first_print($text{'restore_first2'});
@@ -2276,19 +2276,19 @@ if ($ok) {
 		}
 
 	# Extract each of the files
-	local $f;
+	my $f;
 	foreach $f (@files) {
-		local $out;
-		local $q = quotemeta($f);
+		my $out;
+		my $q = quotemeta($f);
 
 		# Make sure file is for a domain we want to restore, unless
 		# we are restoring templates or from a single file, in which
 		# case all files need to be extracted.
 		if (-r $f.".info" && !@$vbs && -d $backup) {
-			local $info = &unserialise_variable(
+			my $info = &unserialise_variable(
 					&read_file_contents($f.".info"));
 			if ($info) {
-				local @wantdoms = grep { $info->{$_->{'dom'}} }
+				my @wantdoms = grep { $info->{$_->{'dom'}} }
 						       @$doms;
 				next if (!@wantdoms);
 				}
@@ -2296,12 +2296,12 @@ if ($ok) {
 
 		# See if this is a home-format backup, by looking for a .backup
 		# sub-directory
-		local ($lout, $lerr, @lines, $reader);
-		local $cf = &compression_format($f, $key);
+		my ($lout, $lerr, @lines, $reader);
+		my $cf = &compression_format($f, $key);
 
 		# Create command to read the file, as the correct user and
 		# possibly with decryption
-		local $catter = "cat $q";
+		my $catter = "cat $q";
 		if ($asowner && $mode == 0) {
 			$catter = &command_as_user(
 				$doms[0]->{'user'}, 0, $catter);
@@ -2335,12 +2335,12 @@ if ($ok) {
 			}
 		else {
 			# Other formats use uncompress | tar
-			local $comp = $cf == 1 ? &get_gunzip_command()." -c" :
+			my $comp = $cf == 1 ? &get_gunzip_command()." -c" :
 				      $cf == 2 ? "uncompress -c" :
 				      $cf == 3 ? &get_bunzip2_command()." -c" :
 				      $cf == 6 ? &get_unzstd_command() :
 						 "cat";
-			local ($compcmd) = &split_quoted_string($comp);
+			my ($compcmd) = &split_quoted_string($comp);
 			if (!&has_command($compcmd)) {
 				&$second_print(&text('restore_zipcmd',
 						     "<tt>$compcmd</tt>"));
@@ -2353,7 +2353,7 @@ if ($ok) {
 					 \$lout, \$lerr);
 			@lines = split(/\n/, $lout);
 			}
-		local $extract;
+		my $extract;
 		if (&indexof("./.backup/", @lines) >= 0 ||
 		    &indexof("./.backup", @lines) >= 0) {
 			# Home format! Only extract the .backup directory, as it
@@ -2456,17 +2456,17 @@ if ($opts->{'reuid'}) {
 # Clear left-frame links cache, as the restore may change them
 &clear_links_cache();
 
-local $vcount = 0;
-local %restoreok;	# Which domain IDs were restored OK?
+my $vcount = 0;
+my %restoreok;	# Which domain IDs were restored OK?
 if ($ok) {
 	# Restore any Virtualmin settings
 	if (@$vbs) {
 		&$first_print($text{'restore_global2'});
 		&$indent_print();
 		foreach my $v (@$vbs) {
-			local $vfile = "$restoredir/virtualmin_".$v;
+			my $vfile = "$restoredir/virtualmin_".$v;
 			if (-r $vfile) {
-				local $vfunc = "virtualmin_restore_".$v;
+				my $vfunc = "virtualmin_restore_".$v;
 				if (defined(&$vfunc)) {
 					$ok = &$vfunc($vfile, $vbs);
 					$vcount++;
@@ -2499,7 +2499,7 @@ if ($ok) {
 		}
 
 	# Now restore each of the domain/feature files
-	local $d;
+	my $d;
 	DOMAIN: foreach $d (sort { $a->{'parent'} <=> $b->{'parent'} ||
 				   $a->{'alias'} <=> $b->{'alias'} } @$doms) {
 
@@ -2534,7 +2534,7 @@ if ($ok) {
 				      &show_domain_name($d)));
 
 			# Check if licence limits are exceeded
-			local ($dleft, $dreason, $dmax) = &count_domains(
+			my ($dleft, $dreason, $dmax) = &count_domains(
 				$d->{'alias'} ? "aliasdoms" :
 				$d->{'parent'} ? "realdoms" : "topdoms");
 			if ($dleft == 0) {
@@ -2563,7 +2563,7 @@ if ($ok) {
 
 			# If the domain originally had a different webserver
 			# enabled, use the one from this system instead
-			local $oldweb = $d->{'backup_web_type'};
+			my $oldweb = $d->{'backup_web_type'};
 			my $changedweb = 0;
 			if (!$oldweb && $d->{'web'}) {
 				$oldweb = 'web';
@@ -2578,7 +2578,7 @@ if ($ok) {
 				$d->{$newweb} = 1 if ($newweb);
 				$changedweb = 1;
 				}
-			local $oldssl = $d->{'backup_ssl_type'};
+			my $oldssl = $d->{'backup_ssl_type'};
 			if (!$oldssl && $d->{'ssl'}) {
 				$oldssl = 'ssl';
 				}
@@ -2592,7 +2592,7 @@ if ($ok) {
 				$d->{$newssl} = 1 if ($newssl);
 				}
 
-			local ($parentdom, $parentuser);
+			my ($parentdom, $parentuser);
 			if ($d->{'parent'}) {
 				# Does the parent exist?
 				$parentdom = &get_domain($d->{'parent'});
@@ -2619,10 +2619,10 @@ if ($ok) {
 				}
 
 			# Does the template exist?
-			local $tmpl = &get_template($d->{'template'});
+			my $tmpl = &get_template($d->{'template'});
 			if (!$tmpl) {
 				# No .. does the backup have it?
-				local $tmplfile =
+				my $tmplfile =
 				  "$restoredir/$d->{'dom'}_virtualmin_template";
 				if (-r $tmplfile) {
 					# Yes - create on this system and use
@@ -2643,9 +2643,9 @@ if ($ok) {
 				}
 
 			# Does the plan exist? If not, get it from the backup
-			local $plan = &get_plan($d->{'plan'});
+			my $plan = &get_plan($d->{'plan'});
 			if (!$plan) {
-				local $planfile =
+				my $planfile =
 				  "$restoredir/$d->{'dom'}_virtualmin_plan";
 				if (-r $planfile) {
 					&make_dir($plans_dir, 0700);
@@ -2797,7 +2797,7 @@ if ($ok) {
 				}
 
 			# Build maps of used UIDs and GIDs
-			local (%gtaken, %taken, %usertaken, %grouptaken);
+			my (%gtaken, %taken, %usertaken, %grouptaken);
 			&build_group_taken(\%gtaken, \%grouptaken);
 			&build_taken(\%taken, \%usertaken);
 
@@ -2811,14 +2811,14 @@ if ($ok) {
 			elsif ($opts->{'reuid'}) {
 				# Re-allocate the UID and GID
 				&$first_print($text{'restore_reuiding'});
-				local ($samegid) = ($d->{'gid'}==$d->{'ugid'});
+				my ($samegid) = ($d->{'gid'}==$d->{'ugid'});
 				$d->{'gid'} = &allocate_gid(\%gtaken);
 				$d->{'ugid'} = $d->{'gid'};
 				$d->{'uid'} = &allocate_uid(\%taken);
                                 if (!$samegid) {
                                         # Old ugid was custom, so set from old
                                         # group name
-                                        local @ginfo = getgrnam($d->{'ugroup'});
+                                        my @ginfo = getgrnam($d->{'ugroup'});
                                         if (@ginfo) {
                                                 $d->{'ugid'} = $ginfo[2];
                                                 }
@@ -2885,8 +2885,8 @@ if ($ok) {
 			# but only if the old one is not compatible with this
 			# system, or the username changed
 			&require_useradmin();
-			local $newhome = &server_home_directory($d, $parentdom);
-			local $oldhome = $d->{'home'};
+			my $newhome = &server_home_directory($d, $parentdom);
+			my $oldhome = $d->{'home'};
 			if (($oldhome !~ /^\Q$home_base\E\// || $changeduser) &&
 			    $newhome ne $oldhome) {
 				&change_home_directory($d, $newhome);
@@ -2894,10 +2894,10 @@ if ($ok) {
 
 			# Fix up the IPv4 address if needed
 			$d->{'old_ip'} = $d->{'ip'};
-			local $defip = &get_default_ip($d->{'reseller'});
+			my $defip = &get_default_ip($d->{'reseller'});
 			if ($d->{'alias'}) {
 				# Alias domains always have same IP as parent
-				local $alias = &get_domain($d->{'alias'});
+				my $alias = &get_domain($d->{'alias'});
 				$d->{'ip'} = $alias->{'ip'};
 				}
 			elsif ($ipinfo && $ipinfo->{'mode'} == 5) {
@@ -2906,7 +2906,7 @@ if ($ok) {
 				if ($d->{'virt'}) {
 					# Try to allocate, assuming template
 					# defines an IP range
-					local %taken =&interface_ip_addresses();
+					my %taken =&interface_ip_addresses();
 					if ($tmpl->{'ranges'} eq "none") {
 						&$second_print(
 						    &text('setup_evirttmpl'));
@@ -2983,10 +2983,10 @@ if ($ok) {
 
 			# Fix up the IPv6 address if needed
 			$d->{'old_ip6'} = $d->{'ip6'};
-			local $defip6 = &get_default_ip6($d->{'reseller'});
+			my $defip6 = &get_default_ip6($d->{'reseller'});
 			if ($d->{'alias'}) {
 				# Alias domains always have same IP as parent
-				local $alias = &get_domain($d->{'alias'});
+				my $alias = &get_domain($d->{'alias'});
 				$d->{'ip6'} = $alias->{'ip6'};
 				}
 			elsif ($ipinfo && $ipinfo->{'mode6'} == -2) {
@@ -3000,7 +3000,7 @@ if ($ok) {
 				if ($d->{'virt6'}) {
 					# Try to allocate, assuming template
 					# defines an IPv6 range
-					local %taken = &interface_ip_addresses();
+					my %taken = &interface_ip_addresses();
 					if ($tmpl->{'ranges6'} eq "none") {
 						&$second_print(
 						    &text('setup_evirt6tmpl'));
@@ -3102,7 +3102,7 @@ if ($ok) {
 
 			# Check for clashes
 			$d->{'wasmissing'} = 1;
-			local $cerr = &virtual_server_clashes(
+			my $cerr = &virtual_server_clashes(
 					$d, undef, undef, $opts->{'repl'});
 			if ($cerr) {
 				&$second_print(&text('restore_eclash', $cerr));
@@ -3113,7 +3113,7 @@ if ($ok) {
 
 			# Check for warnings
 			if (!$skipwarnings) {
-				local @warns = &virtual_server_warnings(
+				my @warns = &virtual_server_warnings(
 						$d, undef, $opts->{'repl'});
 				if (@warns) {
 					&$second_print(
@@ -3169,7 +3169,7 @@ if ($ok) {
 			}
 
 		# Users need to be restored last
-		local @rfeatures = @$features;
+		my @rfeatures = @$features;
 		if (&indexof("mail", @rfeatures) >= 0) {
 			@rfeatures =((grep { $_ ne "mail" } @$features),"mail");
 			}
@@ -3179,7 +3179,7 @@ if ($ok) {
 
 		# Run the before command
 		&set_domain_envs($dom, "RESTORE_DOMAIN");
-		local $merr = &making_changes();
+		my $merr = &making_changes();
 		&reset_domain_envs($d);
 		if (defined($merr)) {
 			&$second_print(&text('setup_emaking',"<tt>$merr</tt>"));
@@ -3194,8 +3194,8 @@ if ($ok) {
 
 			# Now do the actual restore, feature by feature
 			&$indent_print();
-			local $f;
-			local %oldd;
+			my $f;
+			my %oldd;
 			my $domain_failed = 0;
 			foreach $f (@rfeatures) {
 				# Restore features
@@ -3207,14 +3207,14 @@ if ($ok) {
 				    ($d->{$f} || $f eq "virtualmin" ||
 				     $f eq "mail" &&
 				     &can_domain_have_users($d))) {
-					local $p = "$backup/$d->{'dom'}";
-					local $hft =
+					my $p = "$backup/$d->{'dom'}";
+					my $hft =
 					    $homeformat{"$p.tar.gz"} ||
 					    $homeformat{"$p.tar.bz2"}||
 					    $homeformat{"$p.tar"} ||
 					    $homeformat{"$p.zip"} ||
 					    $homeformat{$backup};
-					local @fopts;
+					my @fopts;
 					if ($hft && $f eq "dir") {
 						# For a home-format backup, the
 						# backup itself is the home
@@ -3286,7 +3286,7 @@ if ($ok) {
 
 			# Run the post-restore command
 			&set_domain_envs($d, "RESTORE_DOMAIN", undef, \%oldd);
-			local $merr = &made_changes();
+			my $merr = &made_changes();
 			&$second_print(&text('setup_emade', "<tt>$merr</tt>"))
 				if (defined($merr));
 			&reset_domain_envs($d);
@@ -3315,17 +3315,17 @@ elsif (!$ok) {
 	}
 
 # If any created restored domains had scripts, re-verify their dependencies
-local @wasmissing = grep { $_->{'wasmissing'} } @$doms;
+my @wasmissing = grep { $_->{'wasmissing'} } @$doms;
 my $bootcount = 0;
-local %scache;
+my %scache;
 if (@wasmissing) {
 	&$first_print($text{'restore_phpmods'});
-	local (@phpinstalled, $phpanyfailed, @phpbad);
+	my (@phpinstalled, $phpanyfailed, @phpbad);
 	foreach my $d (@wasmissing) {
-		local @sinfos = &list_domain_scripts($d);
+		my @sinfos = &list_domain_scripts($d);
 		foreach my $sinfo (@sinfos) {
 			# Get the script, with caching
-			local $script = $scache{$sinfo->{'name'}};
+			my $script = $scache{$sinfo->{'name'}};
 			if (!$script) {
 				$script = $scache{$sinfo->{'name'}} =
 					&get_script($sinfo->{'name'});
@@ -3339,8 +3339,8 @@ if (@wasmissing) {
 			# Work out PHP version for this particular install. Use
 			# the version recorded at script install time first,
 			# then that from it's directory.
-			local $phpver = $sinfo->{'opts'}->{'phpver'};
-			local @dirs = &list_domain_php_directories($d);
+			my $phpver = $sinfo->{'opts'}->{'phpver'};
+			my @dirs = &list_domain_php_directories($d);
 			foreach my $dir (@dirs) {
 				if ($dir->{'dir'} eq $sinfo->{'dir'}) {
 					$phpver ||= $dir->{'version'};
@@ -3351,7 +3351,7 @@ if (@wasmissing) {
 					$phpver ||= $dir->{'version'};
 					}
 				}
-			local @allvers = map { $_->[0] }
+			my @allvers = map { $_->[0] }
 					     &list_available_php_versions($d);
 			$phpver ||= $allvers[0];
 
@@ -3363,7 +3363,7 @@ if (@wasmissing) {
 
 			# Re-activate it's PHP modules
 			&push_all_print();
-			local $pok = &setup_php_modules($d, $script,
+			my $pok = &setup_php_modules($d, $script,
 			   $sinfo->{'version'}, $phpver, $sinfo->{'opts'},
 			   \@phpinstalled);
 			&pop_all_print();
@@ -3400,9 +3400,9 @@ if (@wasmissing && $bootcount) {
 	&$first_print($text{'restore_scriptstart'});
 	my $booted = 0;
 	foreach my $d (@wasmissing) {
-		local @sinfos = &list_domain_scripts($d);
+		my @sinfos = &list_domain_scripts($d);
 		foreach my $sinfo (@sinfos) {
-			local $script = $scache{$sinfo->{'name'}};
+			my $script = $scache{$sinfo->{'name'}};
 			next if (!$script);
 			my $bfunc = $script->{'bootup_func'};
 			my $sfunc = $script->{'start_server_func'};
@@ -3457,23 +3457,23 @@ return $ok;
 # structures are also returned as a list of hash refs (except for S3).
 sub backup_contents
 {
-local ($file, $wantdoms, $key, $asd) = @_;
-local $backup;
-local ($mode, $user, $pass, $server, $path, $port) = &parse_backup_url($file);
-local $doms;
+my ($file, $wantdoms, $key, $asd) = @_;
+my $backup;
+my ($mode, $user, $pass, $server, $path, $port) = &parse_backup_url($file);
+my $doms;
 if ($mode == 0) {
 	# Canonicalize path
 	$file = $path;
 	}
-local @fst = stat($file);
-local @ist = stat($file.".info");
-local @dst = stat($file.".dom");
+my @fst = stat($file);
+my @ist = stat($file.".info");
+my @dst = stat($file.".dom");
 
 # First download the .info file(s) always
-local %info;
+my %info;
 if ($mode == 3) {
 	# For S3, just download the .info backup contents files
-	local $s3b = &s3_list_backups($user, $pass, $server, $path);
+	my $s3b = &s3_list_backups($user, $pass, $server, $path);
 	return $s3b if (!ref($s3b));
 	foreach my $b (keys %$s3b) {
 		$info{$b} = $s3b->{$b}->{'features'};
@@ -3481,15 +3481,15 @@ if ($mode == 3) {
 	}
 elsif ($mode > 0) {
 	# Download info files via SSH or FTP
-	local $infotemp = &transname_owned($asd);
-	local $infoerr = &download_backup($file, $infotemp, undef, undef, 1, $asd);
+	my $infotemp = &transname_owned($asd);
+	my $infoerr = &download_backup($file, $infotemp, undef, undef, 1, $asd);
 	if (!$infoerr) {
 		if (-d $infotemp) {
 			# Got a whole dir of .info files
 			opendir(INFODIR, $infotemp);
 			foreach my $f (readdir(INFODIR)) {
 				next if ($f !~ /\.(info|dom)$/);
-				local $oneinfo = &unserialise_variable(
+				my $oneinfo = &unserialise_variable(
 					&read_file_contents("$infotemp/$f"));
 				foreach my $dname (keys %$oneinfo) {
 					$info{$dname} = $oneinfo->{$dname};
@@ -3500,7 +3500,7 @@ elsif ($mode > 0) {
 			}
 		else {
 			# One file
-			local $oneinfo = &unserialise_variable(
+			my $oneinfo = &unserialise_variable(
 					&read_file_contents($infotemp));
 			&unlink_file($infotemp);
 			%info = %$oneinfo if (%$oneinfo);
@@ -3509,7 +3509,7 @@ elsif ($mode > 0) {
 	}
 elsif (@ist && $ist[9] >= $fst[9]) {
 	# Local .info file exists, and is new
-	local $oneinfo = &unserialise_variable(
+	my $oneinfo = &unserialise_variable(
 			&read_file_contents($file.".info"));
 	%info = %$oneinfo if (%$oneinfo);
 	}
@@ -3520,10 +3520,10 @@ if (!$wantdoms && %info) {
 	}
 
 # Try to download .dom files, which contain full domain hashes
-local %dom;
+my %dom;
 if ($mode == 3) {
 	# For S3, just download the .dom files
-	local $s3b = &s3_list_domains($user, $pass, $server, $path);
+	my $s3b = &s3_list_domains($user, $pass, $server, $path);
 	if (ref($s3b)) {
 		foreach my $b (keys %$s3b) {
 			$dom{$b} = $s3b->{$b};
@@ -3532,15 +3532,15 @@ if ($mode == 3) {
 	}
 elsif ($mode > 0) {
 	# Download .dom files via SSH or FTP
-	local $domtemp = &transname_owned($asd);
-	local $domerr = &download_backup($file, $domtemp, undef, undef, 2, $asd);
+	my $domtemp = &transname_owned($asd);
+	my $domerr = &download_backup($file, $domtemp, undef, undef, 2, $asd);
 	if (!$domerr) {
 		if (-d $domtemp) {
 			# Got a whole dir of .dom files
 			opendir(INFODIR, $domtemp);
 			foreach my $f (readdir(INFODIR)) {
 				next if ($f !~ /\.dom$/);
-				local $onedom = &unserialise_variable(
+				my $onedom = &unserialise_variable(
 					&read_file_contents("$domtemp/$f"));
 				foreach my $dname (keys %$onedom) {
 					$dom{$dname} = $onedom->{$dname};
@@ -3551,7 +3551,7 @@ elsif ($mode > 0) {
 			}
 		else {
 			# One file
-			local $onedom = &unserialise_variable(
+			my $onedom = &unserialise_variable(
 					&read_file_contents($domtemp));
 			&unlink_file($domtemp);
 			%dom = %$onedom if (%$onedom);
@@ -3560,7 +3560,7 @@ elsif ($mode > 0) {
 	}
 elsif (@dst && $dst[9] >= $fst[9]) {
 	# Local .dom file exists, and is new
-	local $onedom = &unserialise_variable(
+	my $onedom = &unserialise_variable(
 			&read_file_contents($file.".dom"));
 	%dom = %$onedom if (%$onedom);
 	}
@@ -3586,7 +3586,7 @@ if (%dom && %nvinfo && keys(%dom) >= keys(%nvinfo)) {
 if ($mode > 0) {
 	# Need to download the whole file
 	$backup = &transname_owned($asd);
-	local $derr = &download_backup($file, $backup, undef, undef, 0, $asd);
+	my $derr = &download_backup($file, $backup, undef, undef, 0, $asd);
 	return $derr if ($derr);
 	}
 else {
@@ -3594,13 +3594,13 @@ else {
 	$backup = $file;
 	}
 
-local %rv;
+my %rv;
 if (-d $backup) {
 	# A directory of backup files, one per domain
 	opendir(DIR, $backup);
 	foreach my $f (readdir(DIR)) {
 		next if ($f =~ /^\./ || $f =~ /\.(info|dom)$/);
-		local ($cont, $fdoms);
+		my ($cont, $fdoms);
 		if ($wantdoms) {
 			($cont, $fdoms) = &backup_contents(
 						"$backup/$f", 1, $key, $asd);
@@ -3610,7 +3610,7 @@ if (-d $backup) {
 			}
 		if (ref($cont)) {
 			# Merge in contents of file
-			local $d;
+			my $d;
 			foreach $d (keys %$cont) {
 				if ($rv{$d}) {
 					return &text('restore_edup', $d);
@@ -3633,11 +3633,11 @@ if (-d $backup) {
 	}
 else {
 	# A single file
-	local $err;
-	local $out;
-	local $q = quotemeta($backup);
-	local $cf = &compression_format($backup, $key);
-	local $comp;
+	my $err;
+	my $out;
+	my $q = quotemeta($backup);
+	my $cf = &compression_format($backup, $key);
+	my $comp;
 	if ($cf == 4) {
 		# Special handling for zip
 		if (!&has_command("unzip")) {
@@ -3646,7 +3646,7 @@ else {
 		$out = &backquote_command("unzip -l $q 2>&1");
 		}
 	else {
-		local $catter;
+		my $catter;
 		if ($key) {
 			$catter = &backup_decryption_command($key)." ".$q;
 			}
@@ -3658,7 +3658,7 @@ else {
 			$cf == 3 ? &get_bunzip2_command()." -c" :
 			$cf == 4 ? &get_unzstd_command() :
 				   "cat";
-		local ($compcmd) = &split_quoted_string($comp);
+		my ($compcmd) = &split_quoted_string($comp);
 		if (!&has_command($compcmd)) {
 			return &text('restore_ezipcmd', "<tt>$compcmd</tt>");
 			}
@@ -3671,7 +3671,7 @@ else {
 		}
 
 	# Look for a home-format backup first
-	local ($l, %done, $dotbackup, @virtfiles);
+	my ($l, %done, $dotbackup, @virtfiles);
 	foreach $l (split(/\n/, $out)) {
 		if ($l =~ /(^|\s)(.\/)?.backup\/([^_ ]+)_([a-z0-9\-]+)(\.(?:\S+))?$/) {
 			# Found a .backup/domain_feature file
@@ -3698,9 +3698,9 @@ else {
 
 	# Extract and read domain files
 	if ($wantdoms) {
-		local $vftemp = &transname();
+		my $vftemp = &transname();
 		&make_dir($vftemp, 0711);
-		local $qvirtfiles = join(" ", map { quotemeta($_) } @virtfiles);
+		my $qvirtfiles = join(" ", map { quotemeta($_) } @virtfiles);
 		if ($cf == 4) {
 			$out = &backquote_command("cd $vftemp && ".
 				"unzip $q $qvirtfiles 2>&1");
@@ -3715,7 +3715,7 @@ else {
 		if (!$?) {
 			$doms = [ ];
 			foreach my $f (@virtfiles) {
-				local %d;
+				my %d;
 				&read_file("$vftemp/$f", \%d);
 				push(@$doms, \%d);
 				}
@@ -3741,10 +3741,10 @@ else {
 # this system.
 sub missing_restore_features
 {
-local ($cont, $doms) = @_;
+my ($cont, $doms) = @_;
 
 # Work out all features in the backup
-local @allfeatures;
+my @allfeatures;
 foreach my $dname (keys %$cont) {
 	if ($dname ne "virtualmin") {
 		push(@allfeatures, @{$cont->{$dname}});
@@ -3767,7 +3767,7 @@ if ($doms) {
 	}
 @allfeatures = &unique(@allfeatures);
 
-local @rv;
+my @rv;
 foreach my $f (@allfeatures) {
 	next if ($f eq 'virtualmin');
 	if (&indexof($f, @features) >= 0) {
@@ -3779,7 +3779,7 @@ foreach my $f (@allfeatures) {
 		}
 	elsif (&indexof($f, @plugins) < 0) {
 		# Assume missing plugin
-		local $desc = "Plugin $f";
+		my $desc = "Plugin $f";
 		if (&foreign_check($f)) {
 			# Plugin exists, but isn't enabled
 			eval {
@@ -3878,16 +3878,16 @@ return @rv;
 # Returns undef on success, or an error message.
 sub download_backup
 {
-local ($url, $temp, $domnames, $vbs, $infoonly, $asd) = @_;
-local $asuser = $asd ? $asd->{'user'} : undef;
-local $cache = $main::download_backup_cache{$url};
+my ($url, $temp, $domnames, $vbs, $infoonly, $asd) = @_;
+my $asuser = $asd ? $asd->{'user'} : undef;
+my $cache = $main::download_backup_cache{$url};
 if ($cache && -r $cache && !$infoonly) {
 	# Already got the file .. no need to re-download
 	link($cache, $temp) || symlink($cache, $temp);
 	return undef;
 	}
-local ($mode, $user, $pass, $server, $path, $port) = &parse_backup_url($url);
-local $sfx = $infoonly == 1 ? ".info" : $infoonly == 2 ? ".dom" : "";
+my ($mode, $user, $pass, $server, $path, $port) = &parse_backup_url($url);
+my $sfx = $infoonly == 1 ? ".info" : $infoonly == 2 ? ".dom" : "";
 if ($mode == 1 || $mode == 14) {
 	# Download from FTP server
 	my $cmdfunc = $mode == 14
@@ -3899,15 +3899,15 @@ if ($mode == 1 || $mode == 14) {
 	my $downfunc = $mode == 14
 		? \&ftp_encrypted_download
 		: \&ftp_download;
-	local $cwderr;
-	local $isdir = &$cmdfunc($server, "CWD $path", \$cwderr,
+	my $cwderr;
+	my $isdir = &$cmdfunc($server, "CWD $path", \$cwderr,
 				 $user, $pass, $port);
-	local $err;
+	my $err;
 	if ($isdir) {
 		# Need to download entire directory.
 		# In info-only mode, skip files that don't end with .info / .dom
 		&make_dir($temp, 0711);
-		local $list = &$listfunc($server, $path, \$err, $user, $pass,
+		my $list = &$listfunc($server, $path, \$err, $user, $pass,
 					 $port);
 		return $err if (!$list);
 		foreach $f (@$list) {
@@ -3934,7 +3934,7 @@ if ($mode == 1 || $mode == 14) {
 	}
 elsif ($mode == 2 || $mode == 13) {
 	# Download from SSH or SFTP server
-	local $qserver = &check_ip6address($server) ? "[$server]" : $server;
+	my $qserver = &check_ip6address($server) ? "[$server]" : $server;
 	my $cfunc = $mode == 2 ? \&scp_copy : \&sftp_download;
 	if ($infoonly) {
 		# First try file with .info or .dom extension
@@ -3952,14 +3952,14 @@ elsif ($mode == 2 || $mode == 13) {
 	else {
 		# If a list of domain names was given, first try to scp down
 		# only the files for those domains in the directory
-		local $gotfiles = 0;
+		my $gotfiles = 0;
 		if (@$domnames) {
 			&unlink_file($temp);
 			&make_dir($temp, 0711);
-			local @wantdoms;
+			my @wantdoms;
 			push(@wantdoms, @$domnames) if (@$domnames);
 			push(@wantdoms, "virtualmin") if (@$vbs);
-			local $domfiles = @wantdoms > 1 ?
+			my $domfiles = @wantdoms > 1 ?
 				"{".join(",", @wantdoms)."}" : $wantdoms[0];
 			&$cfunc(($user ? "$user\@" : "").
 				  "$qserver:$path/$domfiles.*",
@@ -3982,36 +3982,36 @@ elsif ($mode == 3) {
 	# Download from S3 server
 	$infoonly && return "Info-only mode is not supported by the ".
 			    "download_backup function for S3";
-	local $s3b = &s3_list_backups($user, $pass, $server, $path);
+	my $s3b = &s3_list_backups($user, $pass, $server, $path);
 	return $s3b if (!ref($s3b));
-	local @wantdoms;
+	my @wantdoms;
 	push(@wantdoms, @$domnames) if (@$domnames);
 	push(@wantdoms, "virtualmin") if (@$vbs);
 	@wantdoms = (keys %$s3b) if (!@wantdoms);
 	&make_dir($temp, 0711);
 	my %done;
 	foreach my $dname (@wantdoms) {
-		local $si = $s3b->{$dname};
+		my $si = $s3b->{$dname};
 		if (!$si) {
 			return &text('restore_es3info', $dname);
 			}
 		next if ($done{$si->{'file'}}++);
-		local $tempfile = $si->{'file'};
+		my $tempfile = $si->{'file'};
 		$tempfile =~ s/^(\S+)\///;
-		local $err = &s3_download($user, $pass, $server,
+		my $err = &s3_download($user, $pass, $server,
 					  $si->{'file'}, "$temp/$tempfile");
 		return $err if ($err);
 		}
 	}
 elsif ($mode == 6) {
 	# Download from Rackspace cloud files
-	local $rsh = &rs_connect($config{'rs_endpoint'}, $user, $pass);
+	my $rsh = &rs_connect($config{'rs_endpoint'}, $user, $pass);
 	if (!ref($rsh)) {
 		return $rsh;
 		}
-	local $files = &rs_list_objects($rsh, $server);
+	my $files = &rs_list_objects($rsh, $server);
 	return "Failed to list $server : $files" if (!ref($files));
-	local $pathslash = $path ? $path."/" : "";
+	my $pathslash = $path ? $path."/" : "";
 	if ($infoonly) {
 		# First try file with .info or .dom extension
 		$err = &rs_download_object($rsh, $server, $path.$sfx, $temp);
@@ -4032,7 +4032,7 @@ elsif ($mode == 6) {
 	else {
 		# If a list of domain names was given, first try to download
 		# only the files for those domains in the directory
-		local $gotfiles = 0;
+		my $gotfiles = 0;
 		if (@$domnames) {
                         &unlink_file($temp);
                         &make_dir($temp, 0711);
@@ -4083,8 +4083,8 @@ elsif ($mode == 6) {
 	}
 elsif ($mode == 7 || $mode == 8 || $mode == 10 || $mode == 11 || $mode == 12) {
 	# Download from Google cloud storage, Dropbox or Backblaze
-	local $files;
-	local $func;
+	my $files;
+	my $func;
 	if ($mode == 7) {
 		# Get files under bucket from Google
 		$files = &list_gcs_files($server);
@@ -4143,7 +4143,7 @@ elsif ($mode == 7 || $mode == 8 || $mode == 10 || $mode == 11 || $mode == 12) {
 			$func = \&download_bb_file;
 			}
 		}
-	local $pathslash = $path ? $path."/" : "";
+	my $pathslash = $path ? $path."/" : "";
 	if ($infoonly) {
 		# First try file with .info or .dom extension
 		$err = &$func($server, $path.$sfx, $temp);
@@ -4164,7 +4164,7 @@ elsif ($mode == 7 || $mode == 8 || $mode == 10 || $mode == 11 || $mode == 12) {
 	else {
 		# If a list of domain names was given, first try to download
 		# only the files for those domains in the directory
-		local $gotfiles = 0;
+		my $gotfiles = 0;
 		if (@$domnames) {
                         &unlink_file($temp);
                         &make_dir($temp, 0711);
@@ -4241,7 +4241,7 @@ elsif ($mode == 9) {
 	else {
 		# If a list of domain names was given, first try to scp down
 		# only the files for those domains in the directory
-		local $gotfiles = 0;
+		my $gotfiles = 0;
 		if (@$domnames) {
 			&unlink_file($temp);
 			&make_dir($temp, 0711);
@@ -4498,7 +4498,7 @@ elsif (!$url || $url =~ /^\//) {
 	}
 else {
 	# Relative to current dir
-	local $pwd = $ENV{'WRAPPER_ORIGINAL_PWD'} || &get_current_dir();
+	my $pwd = $ENV{'WRAPPER_ORIGINAL_PWD'} || &get_current_dir();
 	@rv = (0, undef, undef, undef, $pwd."/".$url, undef);
 	$rv[4] =~ s/\/+$//;
 	}
@@ -4650,8 +4650,8 @@ return $rv;
 # Converts a backup URL to a nice human-readable format
 sub nice_backup_url
 {
-local ($url, $caps, $show) = @_;
-local ($proto, $user, $pass, $host, $path, $port) = &parse_backup_url($url);
+my ($url, $caps, $show) = @_;
+my ($proto, $user, $pass, $host, $path, $port) = &parse_backup_url($url);
 my $name_only;
 if ($show && $config{'show_backuppath'} == 2) {
 	$name_only = 1;
@@ -4660,7 +4660,7 @@ elsif ($show && $path && $config{'show_backuppath'} == 1) {
 	my ($pdir, $pfile) = &split_path_file($path);
 	$path = $pfile || $pdir;
 	}
-local $rv;
+my $rv;
 if ($proto == 1) {
 	# FTP server
 	if ($name_only) {
@@ -4842,7 +4842,7 @@ return $rv;
 # Returns a human-friendly HTML description of what is included in a backup
 sub nice_backup_doms
 {
-local ($s) = @_;
+my ($s) = @_;
 if ($s->{'all'} == 1) {
 	if ($s->{'plan'}) {
 		# All on some plans
@@ -4872,12 +4872,12 @@ if ($s->{'all'} == 1) {
 		}
 	}
 elsif ($s->{'doms'}) {
-	local @dnames;
+	my @dnames;
 	foreach my $did (split(/\s+/, $s->{'doms'})) {
-		local $d = &get_domain($did);
+		my $d = &get_domain($did);
 		push(@dnames, &show_domain_name($d)) if ($d);
 		}
-	local $msg = @dnames > 4 ? join(", ", @dnames).", ..."
+	my $msg = @dnames > 4 ? join(", ", @dnames).", ..."
 				 : join(", ", @dnames);
 	return $s->{'all'} == 2 ? &text('sched_except', $msg) : $msg;
 	}
@@ -4894,20 +4894,20 @@ else {
 # Returns HTML for fields for selecting a local or FTP file
 sub show_backup_destination
 {
-local ($name, $value, $nolocal, $d, $nodownload, $noupload, $remove,
+my ($name, $value, $nolocal, $d, $nodownload, $noupload, $remove,
        $sched) = @_;
-local ($mode, $user, $pass, $server, $path, $port) = &parse_backup_url($value);
-local $ftptls = $mode == 14;
+my ($mode, $user, $pass, $server, $path, $port) = &parse_backup_url($value);
+my $ftptls = $mode == 14;
 $mode = 1 if ($ftptls);
 $mode = 1 if (!$value && $nolocal);	# Default to FTP
-local $defport = $mode == 1 ? 21 :
+my $defport = $mode == 1 ? 21 :
 		 $mode == 2 ? 22 :
 		 $mode == 9 ? 10000 : undef;
 $server = "[$server]" if (&check_ip6address($server));
-local $serverport = $port && $port != $defport ? "$server:$port" : $server;
-local $rv;
+my $serverport = $port && $port != $defport ? "$server:$port" : $server;
+my $rv;
 
-local @opts;
+my @opts;
 if ($remove) {
 	# Remove this destination
 	push(@opts, [ -1, $text{'backup_moderemove'} ]);
@@ -4927,7 +4927,7 @@ if ($d && $d->{'dir'}) {
 		$plugged = &ui_hidden('plugged', $sched->{'plugged'})
 			if ($name =~ /\A(?:src|dest0)\z/);
 		}
-	local $bdir = "$d->{'home'}/$user_backup_dir";
+	my $bdir = "$d->{'home'}/$user_backup_dir";
 	$bdir =~ s/\.\///g;	# Fix /./ in directory path
 	my $file_chooser = &file_chooser_button($name."_file", 0, 0, $bdir);
 	$file_chooser = '' if ($sched && $sched->{'opts'} &&
@@ -4951,8 +4951,8 @@ elsif (!$nolocal) {
 my $tablestart = sub { return "<table data-table-backup-mode=\"$_[0]\">\n" };
 
 # FTP file fields
-local $noac = "autocomplete=off";
-local $ft = &$tablestart('ftp');
+my $noac = "autocomplete=off";
+my $ft = &$tablestart('ftp');
 $ft .= "<tr> <td>$text{'backup_ftpserver'}</td> <td>".
        &ui_textbox($name."_server", $mode == 1 ? $serverport :
                      undef, 20, undef, undef, "placeholder='example.com:21'").
@@ -4975,7 +4975,7 @@ $ft .= "</table>\n";
 push(@opts, [ 1, $text{'backup_mode1'}, $ft ]);
 
 # SCP file fields
-local $st = &$tablestart('ssh');
+my $st = &$tablestart('ssh');
 $st .= "<tr> <td>$text{'backup_sshserver'}</td> <td>".
        &ui_textbox($name."_sserver", $mode == 2 ? $serverport :
                      undef, 20, undef, undef, "placeholder='example.com:22'").
@@ -4998,7 +4998,7 @@ $st .= "</table>\n";
 push(@opts, [ 2, $text{'backup_mode2'}, $st ]);
 
 # SFTP file fields
-local $st = &$tablestart('sftp');
+my $st = &$tablestart('sftp');
 $st .= "<tr> <td>$text{'backup_sftpserver'}</td> <td>".
        &ui_textbox($name."_sfserver", $mode == 13 ? $serverport :
                      undef, 20, undef, undef, "placeholder='example.com:22'").
@@ -5021,7 +5021,7 @@ $st .= "</table>\n";
 push(@opts, [ 13, $text{'backup_mode13'}, $st ]);
 
 # Webmin RPC fields
-local $wt = &$tablestart('webmin');
+my $wt = &$tablestart('webmin');
 $wt .= "<tr> <td>$text{'backup_webminserver'}</td> <td>".
        &ui_textbox($name."_wserver", $mode == 9 ? $serverport :
                      undef, 20, undef, undef, "placeholder='example.com:10000'").
@@ -5043,9 +5043,9 @@ push(@opts, [ 9, $text{'backup_mode9'}, $wt ]);
 # S3 backup fields (bucket, account and file)
 my @s3s;
 if (&can_use_cloud("s3") && (@s3s = &list_s3_accounts())) {
-	local $s3user = $mode == 3 ? $user : undef;
-	local $s3pass = $mode == 3 ? $pass : undef;
-	local $st = &$tablestart('s3');
+	my $s3user = $mode == 3 ? $user : undef;
+	my $s3pass = $mode == 3 ? $pass : undef;
+	my $st = &$tablestart('s3');
 	my ($s3) = grep { ($_->{'access'} eq $s3user ||
 			   $_->{'id'} eq $s3user) &&
 			 (!$s3pass || $_->{'secret'} eq $s3pass) } @s3s;
@@ -5067,11 +5067,11 @@ if (&can_use_cloud("s3") && (@s3s = &list_s3_accounts())) {
 
 # Rackspace backup fields (username, API key and bucket/file)
 if (&can_use_cloud("rs")) {
-	local $rsuser = $mode == 6 ? $user : undef;
-	local $rspass = $mode == 6 ? $pass : undef;
+	my $rsuser = $mode == 6 ? $user : undef;
+	my $rspass = $mode == 6 ? $pass : undef;
 	$rsuser ||= $config{'rs_user'};
 	$rspass ||= $config{'rs_key'};
-	local $st = &$tablestart('rs');
+	my $st = &$tablestart('rs');
 	$st .= "<tr> <td>$text{'backup_rsuser'}</td> <td>".
 	       &ui_textbox($name."_rsuser", $rsuser, 40, 0, undef, $noac).
 	       "</td> </tr>\n";
@@ -5089,7 +5089,7 @@ if (&can_use_cloud("rs")) {
 # Google cloud files
 my $state = &cloud_google_get_state();
 if ($state->{'ok'} && &can_use_cloud("google")) {
-	local $st = &$tablestart('gc');
+	my $st = &$tablestart('gc');
 	$st .= "<tr> <td>$text{'backup_gcpath'}</td> <td>".
 	       &ui_textbox($name."_gcpath", $mode != 7 ? undef :
 					    $server.($path ? "/".$path : ""), 50).
@@ -5101,7 +5101,7 @@ if ($state->{'ok'} && &can_use_cloud("google")) {
 # Dropbox
 $state = &cloud_dropbox_get_state();
 if ($state->{'ok'} && &can_use_cloud("dropbox")) {
-	local $st = &$tablestart('db');
+	my $st = &$tablestart('db');
 	$st .= "<tr> <td>$text{'backup_dbpath'}</td> <td>".
 	       &ui_textbox($name."_dbpath", $mode != 8 ? undef :
 					    $server.($path ? "/".$path : ""), 50).
@@ -5113,7 +5113,7 @@ if ($state->{'ok'} && &can_use_cloud("dropbox")) {
 # Backblaze
 my $state = &cloud_bb_get_state();
 if ($state->{'ok'} && &can_use_cloud("bb")) {
-	local $st = &$tablestart('bb');
+	my $st = &$tablestart('bb');
 	$st .= "<tr> <td>$text{'backup_bbpath'}</td> <td>".
 	       &ui_textbox($name."_bbpath", $mode != 10 ? undef :
 					    $server.($path ? "/".$path : ""), 50).
@@ -5125,7 +5125,7 @@ if ($state->{'ok'} && &can_use_cloud("bb")) {
 # Azure blob storage
 my $state = &cloud_azure_get_state();
 if ($state->{'ok'} && &can_use_cloud("azure")) {
-	local $st = &$tablestart('az');
+	my $st = &$tablestart('az');
 	$st .= "<tr> <td>$text{'backup_azpath'}</td> <td>".
 	       &ui_textbox($name."_azpath", $mode != 11 ? undef :
 					    $server.($path ? "/".$path : ""), 50).
@@ -5137,7 +5137,7 @@ if ($state->{'ok'} && &can_use_cloud("azure")) {
 # Google drive storage
 my $state = &cloud_drive_get_state();
 if ($state->{'ok'} && &can_use_cloud("drive")) {
-	local $st = &$tablestart('dr');
+	my $st = &$tablestart('dr');
 	$st .= "<tr> <td>$text{'backup_drpath'}</td> <td>".
 	       &ui_textbox($name."_drpath", $mode != 12 ? undef :
 			   $server.($path ? "/".$path : ""), 50).
@@ -5165,9 +5165,9 @@ return &ui_radio_selector(\@opts, $name."_mode", $mode, 1);
 # Returns a backup destination string, or calls error
 sub parse_backup_destination
 {
-local ($name, $in, $nolocal, $d, $fmt) = @_;
-local %in = %$in;
-local $mode = $in{$name."_mode"};
+my ($name, $in, $nolocal, $d, $fmt) = @_;
+my %in = %$in;
+my $mode = $in{$name."_mode"};
 if ($mode == -1) {
 	# Removing this one
 	return undef;
@@ -5202,7 +5202,7 @@ elsif ($mode == 0 && !$nolocal) {
 	}
 elsif ($mode == 1) {
 	# FTP server
-	local ($server, $port);
+	my ($server, $port);
 	if ($in{$name."_server"} =~ /^\[([^\]]+)\](:(\d+))?$/) {
 		($server, $port) = ($1, $3);
 		}
@@ -5222,14 +5222,14 @@ elsif ($mode == 1) {
 		# Strip trailing /
 		$in{$name."_path"} =~ s/\/+$//;
 		}
-	local $sep = $in{$name."_path"} =~ /^\// ? "" : ":";
-	local $proto = $in{$name."_tls"} ? "ftps" : "ftp";
+	my $sep = $in{$name."_path"} =~ /^\// ? "" : ":";
+	my $proto = $in{$name."_tls"} ? "ftps" : "ftp";
 	return $proto."://".$in{$name."_user"}.":".$in{$name."_pass"}.
 	       "\@".$in{$name."_server"}.$sep.$in{$name."_path"};
 	}
 elsif ($mode == 2) {
 	# SSH server
-	local ($server, $port);
+	my ($server, $port);
 	if ($in{$name."_sserver"} =~ /^\[([^\]]+)\](:(\d+))?$/) {
 		($server, $port) = ($1, $3);
 		}
@@ -5259,7 +5259,7 @@ elsif ($mode == 2) {
 	}
 elsif ($mode == 13) {
 	# SFTP server
-	local ($server, $port);
+	my ($server, $port);
 	if ($in{$name."_sfserver"} =~ /^\[([^\]]+)\](:(\d+))?$/) {
 		($server, $port) = ($1, $3);
 		}
@@ -5293,7 +5293,7 @@ elsif ($mode == 3) {
 	$in{$name.'_s3path'} =~ /\\/ && &error($text{'backup_es3pathslash'});
 	($in{$name.'_s3path'} =~ /^\// || $in{$name.'_s3path'} =~ /\/$/) &&
 		&error($text{'backup_es3path2'});
-	local $proto = $in{$name.'_rrs'} ? 's3rrs' : 's3';
+	my $proto = $in{$name.'_rrs'} ? 's3rrs' : 's3';
 	my @s3s = &list_s3_accounts();
 	my ($s3) = grep { $_->{'id'} eq $in{$name."_as3"} } @s3s;
 	$s3 || &error($text{'backup_eas3'});
@@ -5359,7 +5359,7 @@ elsif ($mode == 12 && &can_use_cloud("drive")) {
 	}
 elsif ($mode == 9) {
 	# Webmin server
-	local ($server, $port);
+	my ($server, $port);
 	if ($in{$name."_wserver"} =~ /^\[([^\]]+)\](:(\d+))?$/) {
 		($server, $port) = ($1, $3);
 		}
@@ -5395,7 +5395,7 @@ else {
 # schedules at all.
 sub can_backup_sched
 {
-local ($sched) = @_;
+my ($sched) = @_;
 if (&master_admin()) {
 	# Master admin can do anything
 	return 1;
@@ -5418,7 +5418,7 @@ else {
 	return 0 if (!$access{'edit_sched'});
 	if ($sched) {
 		return 0 if (!$sched->{'owner'});	# Master admin's backup
-		local $myd = &get_domain_by_user($base_remote_user);
+		my $myd = &get_domain_by_user($base_remote_user);
 		return 0 if (!$myd || $myd->{'id'} ne $sched->{'owner'});
 		}
 	return 1;
@@ -5599,8 +5599,8 @@ else {
 # Returns the full path to the bzip2-compatible command
 sub get_bzip2_command
 {
-local $cmd = $config{'pbzip2'} ? 'pbzip2' : 'bzip2';
-local $fullcmd = &has_command($cmd) || $cmd;
+my $cmd = $config{'pbzip2'} ? 'pbzip2' : 'bzip2';
+my $fullcmd = &has_command($cmd) || $cmd;
 $fullcmd .= " -c $config{'zip_args'}";
 return $fullcmd;
 }
@@ -5625,8 +5625,8 @@ else {
 # Returns the full path to the gzip-compatible command
 sub get_gzip_command
 {
-local $cmd = $config{'pigz'} ? 'pigz' : 'gzip';
-local $fullcmd = &has_command($cmd) || $cmd;
+my $cmd = $config{'pigz'} ? 'pigz' : 'gzip';
+my $fullcmd = &has_command($cmd) || $cmd;
 $fullcmd .= " -c $config{'zip_args'}";
 return $fullcmd;
 }
@@ -5667,7 +5667,7 @@ return &has_command("zstd")." -c -d";
 # long descriptions, the fourth is codes.
 sub get_backup_actions
 {
-local (@links, @titles, @descs, @codes);
+my (@links, @titles, @descs, @codes);
 if (&can_backup_domain()) {
 	if (&can_backup_sched()) {
 		# Can do scheduled backups, so show list
@@ -5752,7 +5752,7 @@ return &master_admin();
 # If a domain is given, checks if backups of that domain are allowed.
 sub can_backup_domain
 {
-local ($d, $acluser) = @_;
+my ($d, $acluser) = @_;
 $acluser ||= $base_remote_user;
 local $base_remote_user = $acluser;
 local %access = &get_module_acl($acluser);	# Use local for scoping
@@ -5783,7 +5783,7 @@ else {
 # dir/mysql restores are allowed, 0 if nothing
 sub can_restore_domain
 {
-local ($d) = @_;
+my ($d) = @_;
 if (&master_admin()) {
 	# Master admin always can
 	return 1;
@@ -5810,11 +5810,11 @@ else {
 # was created by root)
 sub can_backup_log
 {
-local ($log) = @_;
+my ($log) = @_;
 return 1 if (&master_admin());
 if ($log) {
 	# Only allow non-admins to view their own logs
-	local @dnames = &backup_log_own_domains($log);
+	my @dnames = &backup_log_own_domains($log);
 	if (!@dnames) {
 		# None of this user's domains are in the backup
 		return 0;
@@ -5855,11 +5855,11 @@ return 2;				# Domain owner / reseller can access own
 # can restore
 sub backup_log_own_domains
 {
-local ($log, $errormode) = @_;
-local @dnames = split(/\s+/, $errormode ? $log->{'errdoms'} : $log->{'doms'});
+my ($log, $errormode) = @_;
+my @dnames = split(/\s+/, $errormode ? $log->{'errdoms'} : $log->{'doms'});
 return @dnames if (&master_admin() || $log->{'user'} eq $remote_user);
 if ($log->{'ownrestore'}) {
-	local @rv;
+	my @rv;
 	foreach my $d (&get_domains_by_names(@dnames)) {
 		push(@rv, $d->{'dom'}) if (&can_edit_domain($d));
 		}
@@ -5874,13 +5874,13 @@ return ( );
 # (like .*-.*-.*)
 sub extract_purge_path
 {
-local ($dest) = @_;
-local ($mode, undef, undef, $host, $path) = &parse_backup_url($dest);
+my ($dest) = @_;
+my ($mode, undef, undef, $host, $path) = &parse_backup_url($dest);
 if (($mode == 0 || $mode == 1 || $mode == 2 || $mode == 9 ||
      $mode == 13 || $mode == 14) &&
     $path =~ /^(\S+)\/([^%]*%.*)$/) {
 	# Local, FTP, SSH or Webmin file like /backup/%d-%m-%Y
-	local ($base, $date) = ($1, $2);
+	my ($base, $date) = ($1, $2);
 	$date =~ s/%[_\-0\^\#]*\d*[A-Za-z]/\.\*/g;
 	return ($base, $date);
 	}
@@ -5888,7 +5888,7 @@ elsif (($mode == 1 || $mode == 2 || $mode == 9 ||
 	$mode == 13 || $mode == 14) &&
        $path =~ /^([^%\/]+%.*)$/) {
 	# FTP, SSH or Webmin file like backup-%d-%m-%Y
-	local ($base, $date) = ("", $1);
+	my ($base, $date) = ("", $1);
 	$date =~ s/%[_\-0\^\#]*\d*[A-Za-z]/\.\*/g;
 	return ($base, $date);
 	}
@@ -5910,7 +5910,7 @@ elsif ($mode == 8) {
 	if ($fullpath =~ /^\/?(\S+)\/([^%]*%.*)$/) {
 		# Dropbox path - has to be handled differently to S3 and GCS,
 		# as it really does support sub-directories
-		local ($base, $date) = ($1, $2);
+		my ($base, $date) = ($1, $2);
 		$base = "/".$base if ($base !~ /^\//);
 		$date =~ s/%[_\-0\^\#]*\d*[A-Za-z]/\.\*/g;
 		return ($base, $date);
@@ -5975,11 +5975,11 @@ return $err;
 # same number of days, and deletes them. May print stuff using first_print.
 sub purge_domain_backups
 {
-local ($dest, $days, $start, $asd, $detail) = @_;
-local $asuser = $asd ? $asd->{'user'} : undef;
-local ($mode, $user, $pass, $host, $path, $port) = &parse_backup_url($dest);
-local ($base, $re) = &extract_purge_path($dest);
-local $nicebase = $base;
+my ($dest, $days, $start, $asd, $detail) = @_;
+my $asuser = $asd ? $asd->{'user'} : undef;
+my ($mode, $user, $pass, $host, $path, $port) = &parse_backup_url($dest);
+my ($base, $re) = &extract_purge_path($dest);
+my $nicebase = $base;
 if ($dest =~ /^(([a-z0-9]+):\/\/[^\/]*\@[^\/]*)/) {
 	# Add protocol prefix back, if formatted like ftp://user:pass@host/dir
 	$nicebase = $1.$nicebase;
@@ -5997,18 +5997,18 @@ if (!$base && !$re) {
 
 &$indent_print();
 $start ||= time();
-local $cutoff = $start - $days*24*60*60;
-local $pcount = 0;
-local $mcount = 0;
-local $ok = 1;
+my $cutoff = $start - $days*24*60*60;
+my $pcount = 0;
+my $mcount = 0;
+my $ok = 1;
 
 if ($mode == 0) {
 	# Just search a local directory for matching files, and remove them
 	opendir(PURGEDIR, $base);
 	foreach my $f (readdir(PURGEDIR)) {
 		next if ($f eq "." || $f eq "..");
-		local $path = "$base/$f";
-		local @st = stat($path);
+		my $path = "$base/$f";
+		my @st = stat($path);
 		if ($detail) {
 			&$first_print(&text('backup_purgeposs', $path,
 					    &make_date($st[9])));
@@ -6023,7 +6023,7 @@ if ($mode == 0) {
 					}
 				next;
 				}
-			local $old = int((time() - $st[9]) / (24*60*60));
+			my $old = int((time() - $st[9]) / (24*60*60));
 			if ($detail) {
 				&$second_print(&text('backup_purgecan',
 						     $re, $old));
@@ -6031,7 +6031,7 @@ if ($mode == 0) {
 			&$first_print(&text(-d $path ? 'backup_deletingdir'
 					             : 'backup_deletingfile',
 				            "<tt>$path</tt>", $old));
-			local $sz = &nice_size(&disk_usage_kb($path)*1024);
+			my $sz = &nice_size(&disk_usage_kb($path)*1024);
 			&unlink_file($path.".info") if (!-d $path);
 			&unlink_file($path.".dom") if (!-d $path);
 			&unlink_file($path);
@@ -6053,8 +6053,8 @@ elsif ($mode == 1 || $mode == 14) {
 	my $delfunc = $mode == 14
 		? \&ftp_encrypted_deletefile
 		: \&ftp_deletefile;
-	local $err;
-	local $dir = &$listfunc($host, $base, \$err, $user, $pass, $port, 1);
+	my $err;
+	my $dir = &$listfunc($host, $base, \$err, $user, $pass, $port, 1);
 	if ($err) {
 		&$second_print(&text('backup_purgeelistdir', $err));
 		return 0;
@@ -6079,21 +6079,21 @@ elsif ($mode == 1 || $mode == 14) {
 					}
 				next;
 				}
-			local $old = int((time() - $f->[9]) / (24*60*60));
+			my $old = int((time() - $f->[9]) / (24*60*60));
 			if ($detail) {
 				&$second_print(&text('backup_purgecan',
 						     $re, $old));
 				}
 			&$first_print(&text('backup_deletingftp',
 					    "<tt>$base/$f->[13]</tt>", $old));
-			local $err;
-			local $sz = $f->[7];
+			my $err;
+			my $sz = $f->[7];
 			$sz += &$delfunc($host, "$base/$f->[13]",
 					 \$err, $user, $pass, $port);
-			local $infoerr;
+			my $infoerr;
 			&$delfunc($host, "$base/$f->[13].info",
 				  \$infoerr, $user, $pass, $port);
-			local $domerr;
+			my $domerr;
 			&$delfunc($host, "$base/$f->[13].dom",
 				  \$domerr, $user, $pass, $port);
 			if ($err) {
@@ -6114,14 +6114,14 @@ elsif ($mode == 1 || $mode == 14) {
 
 elsif ($mode == 2) {
 	# Use ls -l via SSH to list the directory
-	local $qhost = &check_ip6address($host) ? "[$host]" : $host;
-	local $sshcmd = "ssh".($port ? " -p $port" : "")." ".
+	my $qhost = &check_ip6address($host) ? "[$host]" : $host;
+	my $sshcmd = "ssh".($port ? " -p $port" : "")." ".
 			$config{'ssh_args'}." ".
 			($user ? quotemeta($user)."\@" : "").
 			quotemeta($qhost);
-	local $err;
-	local $lscmd = $sshcmd." LANG=C ls -l ".quotemeta($base);
-	local $lsout = &run_ssh_command($lscmd, $pass, \$err, $asuser);
+	my $err;
+	my $lscmd = $sshcmd." LANG=C ls -l ".quotemeta($base);
+	my $lsout = &run_ssh_command($lscmd, $pass, \$err, $asuser);
 	if ($err) {
 		# Try again without LANG=C , in case shell isn't bash/sh
 		$err = undef;
@@ -6133,7 +6133,7 @@ elsif ($mode == 2) {
 		return 0;
 		}
 	foreach my $l (split(/\r?\n/, $lsout)) {
-		local @st = &parse_lsl_line($l);
+		my @st = &parse_lsl_line($l);
 		next if (!scalar(@st));
 		next if ($st[13] eq "." || $st[13] eq "..");
 		if ($detail) {
@@ -6149,18 +6149,18 @@ elsif ($mode == 2) {
 					}
 				next;
 				}
-			local $old = int((time() - $st[9]) / (24*60*60));
+			my $old = int((time() - $st[9]) / (24*60*60));
 			if ($detail) {
 				&$second_print(&text('backup_purgecan',
 						     $re, $old));
 				}
 			&$first_print(&text('backup_deletingssh',
 					    "<tt>$base/$st[13]</tt>", $old));
-			local $rmcmd = $sshcmd." rm -rf".
+			my $rmcmd = $sshcmd." rm -rf".
 				       " ".quotemeta("$base/$st[13]").
 				       " ".quotemeta("$base/$st[13].info").
 				       " ".quotemeta("$base/$st[13].dom");
-			local $rmerr;
+			my $rmerr;
 			&run_ssh_command($rmcmd, $pass, \$rmerr, $asuser);
 			if ($rmerr) {
 				&$second_print(&text('backup_edelssh', $rmerr));
@@ -6180,9 +6180,9 @@ elsif ($mode == 2) {
 
 elsif ($mode == 9) {
 	# Use stat via Webmin RPC to list directory
-	local $err;
-	local $w = &dest_to_webmin($dest);
-	local $files;
+	my $err;
+	my $w = &dest_to_webmin($dest);
+	my $files;
 	eval {
 		local $main::error_must_die = 1;
 		&remote_foreign_require($w, "webmin");
@@ -6215,7 +6215,7 @@ elsif ($mode == 9) {
 					}
 				next;
 				}
-			local $old = int((time() - $st[9]) / (24*60*60));
+			my $old = int((time() - $st[9]) / (24*60*60));
 			if ($detail) {
 				&$second_print(&text('backup_purgecan',
 						     $re, $old));
@@ -6251,7 +6251,7 @@ elsif ($mode == 9) {
 
 elsif ($mode == 3 && $host =~ /\%/) {
 	# Search S3 for S3 buckets matching the regexp
-	local $buckets = &s3_list_buckets($user, $pass);
+	my $buckets = &s3_list_buckets($user, $pass);
 	if (!ref($buckets)) {
 		&$second_print(&text('backup_purgeebuckets', $buckets));
 		return 0;
@@ -6263,7 +6263,7 @@ elsif ($mode == 3 && $host =~ /\%/) {
 			}
 		if ($b->{'Name'} =~ /^$re$/) {
 			# Found one to delete
-			local $ctime = &s3_parse_date($b->{'CreationDate'});
+			my $ctime = &s3_parse_date($b->{'CreationDate'});
 			$mcount++;
 			if (!$ctime || $ctime >= $cutoff) {
 				if ($detail) {
@@ -6272,7 +6272,7 @@ elsif ($mode == 3 && $host =~ /\%/) {
 					}
 				next;
 				}
-			local $old = int((time() - $ctime) / (24*60*60));
+			my $old = int((time() - $ctime) / (24*60*60));
 			if ($detail) {
 				&$second_print(&text('backup_purgecan',
 						     $re, $old));
@@ -6281,15 +6281,15 @@ elsif ($mode == 3 && $host =~ /\%/) {
 					    "<tt>$b->{'Name'}</tt>", $old));
 
 			# Sum up size of files
-			local $files = &s3_list_files($user, $pass,
+			my $files = &s3_list_files($user, $pass,
 						      $b->{'Name'});
-			local $sz = 0;
+			my $sz = 0;
 			if (ref($files)) {
 				foreach my $f (@$files) {
 					$sz += $f->{'Size'};
 					}
 				}
-			local $err = &s3_delete_bucket($user, $pass,
+			my $err = &s3_delete_bucket($user, $pass,
 						       $b->{'Name'});
 			if ($err) {
 				&$second_print(&text('backup_edelbucket',$err));
@@ -6309,7 +6309,7 @@ elsif ($mode == 3 && $host =~ /\%/) {
 
 elsif ($mode == 3 && $path =~ /\%/) {
 	# Search for S3 files under the bucket
-	local $files = &s3_list_files($user, $pass, $host);
+	my $files = &s3_list_files($user, $pass, $host);
 	if (!ref($files)) {
 		&$second_print(&text('backup_purgeefiles', $files));
 		return 0;
@@ -6323,7 +6323,7 @@ elsif ($mode == 3 && $path =~ /\%/) {
 		     $f->{'Key'} =~ /^$re\/.*\.(tar\.gz|tar\.bz2|zip|tar)$/) &&
 		    $f->{'Key'} !~ /\.(dom|info)$/) {
 			# Found one to delete
-			local $ctime = &s3_parse_date($f->{'LastModified'});
+			my $ctime = &s3_parse_date($f->{'LastModified'});
 			$mcount++;
 			if (!$ctime || $ctime >= $cutoff) {
 				if ($detail) {
@@ -6332,14 +6332,14 @@ elsif ($mode == 3 && $path =~ /\%/) {
 					}
 				next;
 				}
-			local $old = int((time() - $ctime) / (24*60*60));
+			my $old = int((time() - $ctime) / (24*60*60));
 			if ($detail) {
 				&$second_print(&text('backup_purgecan',
 						     $re, $old));
 				}
 			&$first_print(&text('backup_deletingfile',
 					    "<tt>$f->{'Key'}</tt>", $old));
-			local $err = &s3_delete_file($user, $pass, $host,
+			my $err = &s3_delete_file($user, $pass, $host,
 						     $f->{'Key'});
 			if ($err) {
 				&$second_print(&text('backup_edelbucket',$err));
@@ -6363,17 +6363,17 @@ elsif ($mode == 3 && $path =~ /\%/) {
 
 elsif ($mode == 6 && $host =~ /\%/) {
 	# Search Rackspace for containers matching the regexp
-	local $rsh = &rs_connect($config{'rs_endpoint'}, $user, $pass);
+	my $rsh = &rs_connect($config{'rs_endpoint'}, $user, $pass);
 	if (!ref($rsh)) {
 		return &text('backup_purgeersh', $rsh);
 		}
-	local $containers = &rs_list_containers($rsh);
+	my $containers = &rs_list_containers($rsh);
 	if (!ref($containers)) {
 		&$second_print(&text('backup_purgeecontainers', $containers));
 		return 0;
 		}
 	foreach my $c (@$containers) {
-		local $st = &rs_stat_container($rsh, $c);
+		my $st = &rs_stat_container($rsh, $c);
 		next if (!ref($st));
 		if ($detail) {
 			&$first_print(&text('backup_purgeposs3', $c,
@@ -6381,7 +6381,7 @@ elsif ($mode == 6 && $host =~ /\%/) {
 			}
 		if ($c =~ /^$re$/) {
 			# Found one to delete
-			local $ctime = int($st->{'X-Timestamp'});
+			my $ctime = int($st->{'X-Timestamp'});
 			$mcount++;
 			if (!$ctime || $ctime >= $cutoff) {
 				if ($detail) {
@@ -6390,7 +6390,7 @@ elsif ($mode == 6 && $host =~ /\%/) {
 					}
 				next;
 				}
-			local $old = int((time() - $ctime) / (24*60*60));
+			my $old = int((time() - $ctime) / (24*60*60));
 			if ($detail) {
 				&$second_print(&text('backup_purgecan',
 						     $re, $old));
@@ -6398,7 +6398,7 @@ elsif ($mode == 6 && $host =~ /\%/) {
 			&$first_print(&text('backup_deletingcontainer',
 					    "<tt>$c</tt>", $old));
 
-			local $err = &rs_delete_container($rsh, $c, 1);
+			my $err = &rs_delete_container($rsh, $c, 1);
 			if ($err) {
 				&$second_print(
 					&text('backup_edelcontainer',$err));
@@ -6418,17 +6418,17 @@ elsif ($mode == 6 && $host =~ /\%/) {
 
 elsif ($mode == 6 && $path =~ /\%/) {
 	# Search for Rackspace files under the container
-	local $rsh = &rs_connect($config{'rs_endpoint'}, $user, $pass);
+	my $rsh = &rs_connect($config{'rs_endpoint'}, $user, $pass);
 	if (!ref($rsh)) {
 		return &text('backup_purgeersh', $rsh);
 		}
-	local $files = &rs_list_objects($rsh, $host);
+	my $files = &rs_list_objects($rsh, $host);
 	if (!ref($files)) {
 		&$second_print(&text('backup_purgeefiles2', $files));
 		return 0;
 		}
 	foreach my $f (@$files) {
-		local $st = &rs_stat_object($rsh, $host, $f);
+		my $st = &rs_stat_object($rsh, $host, $f);
 		next if (!ref($st));
 		if ($detail) {
 			&$first_print(&text('backup_purgeposs', $c,
@@ -6437,7 +6437,7 @@ elsif ($mode == 6 && $path =~ /\%/) {
 		if ($f =~ /^$re($|\/)/ && $f !~ /\.(dom|info)$/ &&
 		    $f !~ /\.\d+$/) {
 			# Found one to delete
-			local $ctime = int($st->{'X-Timestamp'});
+			my $ctime = int($st->{'X-Timestamp'});
 			$mcount++;
 			if (!$ctime || $ctime >= $cutoff) {
 				if ($detail) {
@@ -6446,14 +6446,14 @@ elsif ($mode == 6 && $path =~ /\%/) {
 					}
 				next;
 				}
-			local $old = int((time() - $ctime) / (24*60*60));
+			my $old = int((time() - $ctime) / (24*60*60));
 			if ($detail) {
 				&$second_print(&text('backup_purgecan',
 						     $re, $old));
 				}
 			&$first_print(&text('backup_deletingfile',
 					    "<tt>$f</tt>", $old));
-			local $err = &rs_delete_object($rsh, $host, $f);
+			my $err = &rs_delete_object($rsh, $host, $f);
 			if ($err) {
 				&$second_print(&text('backup_edelbucket',$err));
 				$ok = 0;
@@ -6474,7 +6474,7 @@ elsif ($mode == 6 && $path =~ /\%/) {
 
 elsif ($mode == 7 && $host =~ /\%/) {
 	# Search Google for buckets matching the regexp
-	local $buckets = &list_gcs_buckets();
+	my $buckets = &list_gcs_buckets();
 	if (!ref($buckets)) {
 		&$second_print(&text('backup_purgeegcbuckets', $buckets));
 		return 0;
@@ -6487,7 +6487,7 @@ elsif ($mode == 7 && $host =~ /\%/) {
 			}
 		if ($c =~ /^$re$/) {
 			# Found one with a name to delete
-			local $ctime = &google_timestamp($st->{'timeCreated'});
+			my $ctime = &google_timestamp($st->{'timeCreated'});
 			$mcount++;
 			if (!$ctime || $ctime >= $cutoff) {
 				if ($detail) {
@@ -6496,7 +6496,7 @@ elsif ($mode == 7 && $host =~ /\%/) {
 					}
 				next;
 				}
-			local $old = int((time() - $ctime) / (24*60*60));
+			my $old = int((time() - $ctime) / (24*60*60));
 			if ($detail) {
 				&$second_print(&text('backup_purgecan',
 						     $re, $old));
@@ -6504,8 +6504,8 @@ elsif ($mode == 7 && $host =~ /\%/) {
 			&$first_print(&text('backup_deletingbucket',
 					    "<tt>$c</tt>", $old));
 
-			local $st2 = &stat_gcs_bucket($c, 1);
-			local $err = &delete_gcs_bucket($c, 1);
+			my $st2 = &stat_gcs_bucket($c, 1);
+			my $err = &delete_gcs_bucket($c, 1);
 			if ($err) {
 				&$second_print(
 					&text('backup_edelbucket', $err));
@@ -6525,7 +6525,7 @@ elsif ($mode == 7 && $host =~ /\%/) {
 
 elsif ($mode == 7 && $path =~ /\%/) {
 	# Search for Google files under the bucket
-	local $files = &list_gcs_files($host);
+	my $files = &list_gcs_files($host);
 	if (!ref($files)) {
 		&$second_print(&text('backup_purgeefiles3', $files));
 		return 0;
@@ -6539,7 +6539,7 @@ elsif ($mode == 7 && $path =~ /\%/) {
 		if ($f =~ /^$re($|\/)/ && $f !~ /\.(dom|info)$/ &&
 		    $f !~ /\.\d+$/) {
 			# Found one to delete
-			local $ctime = &google_timestamp($st->{'updated'});
+			my $ctime = &google_timestamp($st->{'updated'});
 			$mcount++;
 			if (!$ctime || $ctime >= $cutoff) {
 				if ($detail) {
@@ -6548,14 +6548,14 @@ elsif ($mode == 7 && $path =~ /\%/) {
 					}
 				next;
 				}
-			local $old = int((time() - $ctime) / (24*60*60));
+			my $old = int((time() - $ctime) / (24*60*60));
 			if ($detail) {
 				&$second_print(&text('backup_purgecan',
 						     $re, $old));
 				}
 			&$first_print(&text('backup_deletingfile',
 					    "<tt>$f</tt>", $old));
-			local $err = &delete_gcs_file($host, $f);
+			my $err = &delete_gcs_file($host, $f);
 			if ($err) {
 				&$second_print(&text('backup_edelbucket',$err));
 				$ok = 0;
@@ -6576,7 +6576,7 @@ elsif ($mode == 7 && $path =~ /\%/) {
 
 elsif ($mode == 8) {
 	# Search for Dropbox files matching the date pattern
-	local $files = &list_dropbox_files($base);
+	my $files = &list_dropbox_files($base);
 	if (!ref($files)) {
 		&$second_print(&text('backup_purgeefiles4', $files));
 		return 0;
@@ -6584,7 +6584,7 @@ elsif ($mode == 8) {
 	foreach my $st (@$files) {
 		my $f = $st->{'path_display'};
 		$f =~ s/^\/?\Q$base\E\/?// || next;
-		local $ctime;
+		my $ctime;
 		if ($st->{'.tag'} eq 'folder') {
 			# Age is age of the oldest file
 			$ctime = time();
@@ -6616,7 +6616,7 @@ elsif ($mode == 8) {
 					}
 				next;
 				}
-                        local $old = int((time() - $ctime) / (24*60*60));
+                        my $old = int((time() - $ctime) / (24*60*60));
 			if ($detail) {
 				&$second_print(&text('backup_purgecan',
 						     $re, $old));
@@ -6628,9 +6628,9 @@ elsif ($mode == 8) {
 			my $size = $st->{'.tag'} eq 'folder' ?
 					&size_dropbox_directory($p) :
 					$st->{'size'};
-			local $dropbase = $base;
+			my $dropbase = $base;
 			$dropbase =~ s/^\///;
-			local $err = &delete_dropbox_path($dropbase, $f);
+			my $err = &delete_dropbox_path($dropbase, $f);
 			if ($err) {
 				&$second_print(&text('backup_edelbucket',$err));
 				$ok = 0;
@@ -6720,7 +6720,7 @@ elsif ($mode == 10 && $path =~ /\%/) {
 	if ($re =~ /^(.*)\//) {
 		$dir = $1;
 		}
-	local $files = &list_bb_files($base, $dir);
+	my $files = &list_bb_files($base, $dir);
 	if (!ref($files)) {
 		&$second_print(&text('backup_purgeefiles5', $files));
 		return 0;
@@ -6756,7 +6756,7 @@ elsif ($mode == 10 && $path =~ /\%/) {
 					}
 				next;
 				}
-                        local $old = int((time() - $ctime) / (24*60*60));
+                        my $old = int((time() - $ctime) / (24*60*60));
 			if ($detail) {
 				&$second_print(&text('backup_purgecan',
 						     $re, $old));
@@ -6794,7 +6794,7 @@ elsif ($mode == 10 && $path =~ /\%/) {
 
 elsif ($mode == 11 && $path =~ /\%/) {
 	# Search for Azure files under the container
-	local $files = &list_azure_files($host);
+	my $files = &list_azure_files($host);
 	if (!ref($files)) {
 		&$second_print(&text('backup_purgeefiles3', $files));
 		return 0;
@@ -6808,7 +6808,7 @@ elsif ($mode == 11 && $path =~ /\%/) {
 		if ($f =~ /^$re($|\/)/ && $f !~ /\.(dom|info)$/ &&
 		    $f !~ /\.\d+$/) {
 			# Found one to delete
-			local $ctime = &google_timestamp(
+			my $ctime = &google_timestamp(
 				$st->{'properties'}->{'lastModified'});
 			$mcount++;
 			if (!$ctime || $ctime >= $cutoff) {
@@ -6818,14 +6818,14 @@ elsif ($mode == 11 && $path =~ /\%/) {
 					}
 				next;
 				}
-			local $old = int((time() - $ctime) / (24*60*60));
+			my $old = int((time() - $ctime) / (24*60*60));
 			if ($detail) {
 				&$second_print(&text('backup_purgecan',
 						     $re, $old));
 				}
 			&$first_print(&text('backup_deletingfile',
 					    "<tt>$f</tt>", $old));
-			local $err = &delete_azure_file($host, $f);
+			my $err = &delete_azure_file($host, $f);
 			if ($err) {
 				&$second_print(&text('backup_edelbucket',$err));
 				$ok = 0;
@@ -6846,7 +6846,7 @@ elsif ($mode == 11 && $path =~ /\%/) {
 
 elsif ($mode == 12 && $path =~ /\%/) {
 	# Search for Google drive files under the folder
-	local $files = &list_drive_files($host, 1);
+	my $files = &list_drive_files($host, 1);
 	if (!ref($files)) {
 		&$second_print(&text('backup_purgeefiles6', $files));
 		return 0;
@@ -6861,7 +6861,7 @@ elsif ($mode == 12 && $path =~ /\%/) {
 		if ($f =~ /^$re($|\/)/ && $f !~ /\.(dom|info)$/ &&
 		    $f !~ /\.\d+$/) {
 			# Found one to delete
-			local $ctime = &google_timestamp(
+			my $ctime = &google_timestamp(
 				$st->{'modifiedTime'});
 			$mcount++;
 			if (!$ctime || $ctime >= $cutoff) {
@@ -6871,14 +6871,14 @@ elsif ($mode == 12 && $path =~ /\%/) {
 					}
 				next;
 				}
-			local $old = int((time() - $ctime) / (24*60*60));
+			my $old = int((time() - $ctime) / (24*60*60));
 			if ($detail) {
 				&$second_print(&text('backup_purgecan',
 						     $re, $old));
 				}
 			&$first_print(&text('backup_deletingfile',
 					    "<tt>$f</tt>", $old));
-			local $err = &delete_drive_file($host, $f);
+			my $err = &delete_drive_file($host, $f);
 			if ($err) {
 				&$second_print(&text('backup_edelbucket',$err));
 				$ok = 0;
@@ -6908,7 +6908,7 @@ elsif ($mode == 12 && $host =~ /\%/) {
 		return $parent if (!ref($parent));
 		$pfx = $pname."/";
 		}
-	local $folders = &list_drive_folders(1, $parent);
+	my $folders = &list_drive_folders(1, $parent);
 	if (!ref($folders)) {
 		&$second_print(&text('backup_purgeefiles6', $folders));
 		return 0;
@@ -6922,7 +6922,7 @@ elsif ($mode == 12 && $host =~ /\%/) {
 			}
 		if ($f =~ /^$re$/) {
 			# Found one to delete
-			local $ctime = &google_timestamp(
+			my $ctime = &google_timestamp(
 				$st->{'modifiedTime'});
 			$mcount++;
 			if (!$ctime || $ctime >= $cutoff) {
@@ -6932,7 +6932,7 @@ elsif ($mode == 12 && $host =~ /\%/) {
 					}
 				next;
 				}
-			local $old = int((time() - $ctime) / (24*60*60));
+			my $old = int((time() - $ctime) / (24*60*60));
 			if ($detail) {
 				&$second_print(&text('backup_purgecan',
 						     $re, $old));
@@ -6985,7 +6985,7 @@ elsif ($mode == 13) {
 					}
 				next;
 				}
-			local $old = int((time() - $st[9]) / (24*60*60));
+			my $old = int((time() - $st[9]) / (24*60*60));
 			if ($detail) {
 				&$second_print(&text('backup_purgecan',
 						     $re, $old));
@@ -7038,7 +7038,7 @@ return $ok;
 # Record that some backup was made and succeeded or failed
 sub write_backup_log
 {
-local ($doms, $dest, $increment, $start, $size, $ok, $mode, $output, $errdoms,
+my ($doms, $dest, $increment, $start, $size, $ok, $mode, $output, $errdoms,
        $user, $key, $schedid, $separate, $ownrestore, $compression, $nosign,
        $desc, $sched) = @_;
 $compression = $config{'compression'}
@@ -7053,7 +7053,7 @@ if ($sched && $sched->{plugged}) {
 	$plugged{plugged_opts} = $sched->{"backup_opts_$sched->{plugged}"};
 	@plugged = %plugged;
 	}
-local %log = ( 'doms' => join(' ', map { $_->{'dom'} } @$doms),
+my %log = ( 'doms' => join(' ', map { $_->{'dom'} } @$doms),
 	       'errdoms' => join(' ', map { $_->{'dom'} } @$errdoms),
 	       'dest' => $dest,
 	       'increment' => $increment,
@@ -7106,8 +7106,8 @@ if ($config{'backuplog_age'}) {
 # Returns a list of all backup logs, optionally limited to after some time
 sub list_backup_logs
 {
-local ($start) = @_;
-local @rv;
+my ($start) = @_;
+my @rv;
 opendir(LOGS, $backups_log_dir);
 while(my $id = readdir(LOGS)) {
 	next if ($id eq "." || $id eq "..");
@@ -7115,7 +7115,7 @@ while(my $id = readdir(LOGS)) {
 	my ($time, $pid, $count) = split(/\-/, $id);
 	next if (!$time || !$pid);
 	next if ($start && $time < $start);
-	local %log;
+	my %log;
 	&read_file("$backups_log_dir/$id", \%log) || next;
 	$log{'output'} = &read_file_contents("$backups_log_dir/$id.out");
 	$log{'id'} = $id;
@@ -7129,8 +7129,8 @@ return @rv;
 # Read and return a single logged backup
 sub get_backup_log
 {
-local ($id) = @_;
-local %log;
+my ($id) = @_;
+my %log;
 &read_file("$backups_log_dir/$id", \%log) || return undef;
 $log{'output'} = &read_file_contents("$backups_log_dir/$id.out");
 return \%log;
@@ -7150,11 +7150,11 @@ return undef;
 # Add to the bandwidth files for some domain data transfer used by a backup
 sub record_backup_bandwidth
 {
-local ($d, $inb, $outb, $start, $end) = @_;
+my ($d, $inb, $outb, $start, $end) = @_;
 if ($config{'bw_backup'}) {
-	local $bwinfo = &get_bandwidth($d);
-	local $startday = int($start / (24*60*60));
-	local $endday = int($end / (24*60*60));
+	my $bwinfo = &get_bandwidth($d);
+	my $startday = int($start / (24*60*60));
+	my $endday = int($end / (24*60*60));
 	for(my $day=$startday; $day<=$endday; $day++) {
 		$bwinfo->{"backup_".$day} += $outb / ($endday - $startday + 1);
 		$bwinfo->{"restore_".$day} += $inb / ($endday - $startday + 1);
@@ -7169,10 +7169,10 @@ if ($config{'bw_backup'}) {
 # print a message if waiting.
 sub check_backup_limits
 {
-local ($asowner, $sched, $dest) = @_;
-local %maxes;
-local $start = time();
-local $printed;
+my ($asowner, $sched, $dest) = @_;
+my %maxes;
+my $start = time();
+my $printed;
 
 while(1) {
 	# Lock the file listing current backups, clean it up and read it
@@ -7182,8 +7182,8 @@ while(1) {
 	&read_file($backup_maxes_file, \%maxes);
 
 	# Check if we are under the limit, or it doesn't apply
-	local @pids = keys %maxes;
-	local $waiting = time() - $start;
+	my @pids = keys %maxes;
+	my $waiting = time() - $start;
 	if (!$config{'max_backups'} ||
 	    @pids < $config{'max_backups'} ||
 	    !$asowner && $config{'max_all'} == 0 ||
@@ -7229,8 +7229,8 @@ return undef;
 # Delete from the backup limits file any entries for PIDs that are not running
 sub cleanup_backup_limits
 {
-local ($nolock, $includethis) = @_;
-local (%maxes, $changed);
+my ($nolock, $includethis) = @_;
+my (%maxes, $changed);
 &lock_file($backup_maxes_file) if (!$nolock);
 &read_file($backup_maxes_file, \%maxes);
 foreach my $pid (keys %maxes) {
@@ -7249,8 +7249,8 @@ if ($changed) {
 # Returns a list of destinations for some scheduled backup
 sub get_scheduled_backup_dests
 {
-local ($sched) = @_;
-local @dests = ( $sched->{'dest0'} || $sched->{'dest'} );
+my ($sched) = @_;
+my @dests = ( $sched->{'dest0'} || $sched->{'dest'} );
 for(my $i=1; $sched->{'dest'.$i}; $i++) {
 	push(@dests, $sched->{'dest'.$i});
 	}
@@ -7261,8 +7261,8 @@ return @dests;
 # Returns a list of purge times for some scheduled backup
 sub get_scheduled_backup_purges
 {
-local ($sched) = @_;
-local @purges = ( $sched->{'purge0'} || $sched->{'purge'} );
+my ($sched) = @_;
+my @purges = ( $sched->{'purge0'} || $sched->{'purge'} );
 for(my $i=1; exists($sched->{'purge'.$i}); $i++) {
 	push(@purges, $sched->{'purge'.$i});
 	}
@@ -7273,8 +7273,8 @@ return @purges;
 # Returns a list of encryption key IDs for some scheduled backup
 sub get_scheduled_backup_keys
 {
-local ($sched) = @_;
-local @keys = ( $sched->{'key0'} || $sched->{'key'} );
+my ($sched) = @_;
+my @keys = ( $sched->{'key0'} || $sched->{'key'} );
 for(my $i=1; exists($sched->{'key'.$i}); $i++) {
 	push(@keys, $sched->{'key'.$i});
 	}
@@ -7285,8 +7285,8 @@ return @keys;
 # Removes any passwords or other secure information from a domain hash
 sub clean_domain_passwords
 {
-local ($d) = @_;
-local $rv = { %$d };
+my ($d) = @_;
+my $rv = { %$d };
 foreach my $f ("pass", "enc_pass", "mysql_pass", "postgres_pass") {
 	delete($rv->{$f});
 	}
@@ -7297,10 +7297,10 @@ return $rv;
 # Updates all scheduled backups and backup keys to reflect a username change
 sub rename_backup_owner
 {
-local ($d, $oldd) = @_;
-local $owner = $d->{'parent'} ? &get_domain($d->{'parent'})->{'user'}
+my ($d, $oldd) = @_;
+my $owner = $d->{'parent'} ? &get_domain($d->{'parent'})->{'user'}
 			      : $d->{'user'};
-local $oldowner = $oldd->{'parent'} ? &get_domain($oldd->{'parent'})->{'user'}
+my $oldowner = $oldd->{'parent'} ? &get_domain($oldd->{'parent'})->{'user'}
 			            : $oldd->{'user'};
 if ($owner ne $oldowner) {
 	if (defined(&list_backup_keys)) {
@@ -7318,7 +7318,7 @@ if ($owner ne $oldowner) {
 # Update the IP in a domain based on an ipinfo hash
 sub merge_ipinfo_domain
 {
-local ($d, $ipinfo) = @_;
+my ($d, $ipinfo) = @_;
 $d->{'virt'} = $ipinfo->{'virt'};
 $d->{'ip'} = $ipinfo->{'ip'};
 $d->{'virtalready'} = $ipinfo->{'virtalready'};
@@ -7447,7 +7447,7 @@ foreach my $sfx ("", ".info", ".dom") {
 		# File on this system (but skip if missing)
 		if (-e $spath) {
 			# Avoid loading backup files into memory (can be huge)
-			local $no_log_file_changes = 1;
+			my $no_log_file_changes = 1;
 			$err = &unlink_logged($spath) ? undef : $!;
 			}
 		}

--- a/bw.pl
+++ b/bw.pl
@@ -37,11 +37,11 @@ foreach $d (@bwdoms) {
 # For each feature that has a function for doing bandwidth for all domains
 # at once, call it
 foreach $f (@bandwidth_features) {
-	local $bwfunc = "bandwidth_all_$f";
+	my $bwfunc = "bandwidth_all_$f";
 	if (defined(&$bwfunc)) {
-		local %starts = map { $_, $bwinfomap{$_}->{"last_$f"} }
+		my %starts = map { $_, $bwinfomap{$_}->{"last_$f"} }
 				    (keys %bwinfomap);
-		local $newstarts = &$bwfunc(\@bwdoms, \%starts, \%bwinfomap);
+		my $newstarts = &$bwfunc(\@bwdoms, \%starts, \%bwinfomap);
 		foreach my $did (keys %$newstarts) {
 			$bwinfomap{$did}->{"last_$f"} = $newstarts->{$did};
 			}
@@ -55,7 +55,7 @@ foreach $d (@bwdoms) {
 	# Add bandwidth for all features
 	$bwinfo = $bwinfomap{$d->{'id'}};
 	foreach $f (@bandwidth_features) {
-		local $bwfunc = "bandwidth_$f";
+		my $bwfunc = "bandwidth_$f";
 		if (defined(&$bwfunc)) {
 			my $l = &$bwfunc($d, $bwinfo->{"last_$f"}, $bwinfo);
 			if ($l > $now + $oneday) {
@@ -110,8 +110,8 @@ foreach $d (@doms) {
 	%usage = ( );
 	foreach $dd (@alld) {
 		$bwinfo = &get_bandwidth($dd);
-		local $usage_only = 0;
-		local %usage_only = ( );
+		my $usage_only = 0;
+		my %usage_only = ( );
 		foreach $k (keys %$bwinfo) {
 			if ($k =~ /^(\S+)_(\d+)$/ && $2 >= $start_day) {
 				$usage += $bwinfo->{$k};
@@ -139,7 +139,7 @@ foreach $d (@doms) {
 	foreach $k (keys %usage) {
 		$d->{'bw_usage_'.$k} = $usage{$k};
 		}
-	local $from = &get_global_from_address($d);
+	my $from = &get_global_from_address($d);
 	if ($d->{'bw_limit'} && $usage > $d->{'bw_limit'}) {
 		# Over the limit! But check limit on how often to notify
 		$etime = $now - $d->{'bw_notify'} > $config{'bw_notify'}*60*60;
@@ -154,7 +154,7 @@ foreach $d (@doms) {
 				$tkeys{'bw_usage_'.$k} =
 					&nice_size($tkeys{'bw_usage_'}.$k);
 				}
-			local @addrs;
+			my @addrs;
 			push(@addrs, $d->{'email'} ||
 				   $d->{'user'}.'@'.&get_system_hostname() )
 				if ($config{'bw_owner'});
@@ -206,7 +206,7 @@ foreach $d (@doms) {
 					&nice_size($tkeys{'bw_usage_'.$k});
 				}
 			$tkeys{'bw_warn'} = $config{'bw_warn'};
-			local @addrs;
+			my @addrs;
 			push(@addrs, $d->{'email'} ||
 				   $d->{'user'}.'@'.&get_system_hostname() )
 				if ($config{'bw_owner'});
@@ -248,7 +248,7 @@ foreach $d (@doms) {
 			# Enable all disabled features
 			foreach my $f (@features) {
 				if ($dd->{$f} && $enable{$f}) {
-					local $efunc = "enable_$f";
+					my $efunc = "enable_$f";
 					&try_function($f, $efunc, $dd);
 					}
 				}

--- a/bwgraph.cgi
+++ b/bwgraph.cgi
@@ -235,7 +235,7 @@ if ($max) {
 		# Get bandwidth for relevant domains and sub-domains
 		foreach $d (@doms) {
 			foreach $dd ($d, &get_domain_by("parent", $d->{'id'})) {
-				local $bwinfo = &get_bandwidth($dd);
+				my $bwinfo = &get_bandwidth($dd);
 				push(@bands, $bwinfo);
 				}
 			}
@@ -258,9 +258,9 @@ if ($max) {
 			print "<tr>\n";
 			print "<td>",&make_date($i*24*60*60, 1),"</td>\n";
 			print "<td>";
-			local $usage = 0;
+			my $usage = 0;
 			foreach $f (@bandwidth_features) {
-				local $fusage = &usage_for_days($i, $i, $f,
+				my $fusage = &usage_for_days($i, $i, $f,
 								@bands);
 				$usage += $fusage;
 				if ($fusage) {
@@ -286,9 +286,9 @@ if ($max) {
 		$start_day = undef;
 		foreach $d (@doms) {
 			foreach $dd ($d, &get_domain_by("parent", $d->{'id'})) {
-				local $bwinfo = &get_bandwidth($dd);
+				my $bwinfo = &get_bandwidth($dd);
 				push(@bands, $bwinfo);
-				local $min = &minimum_day($bwinfo);
+				my $min = &minimum_day($bwinfo);
 				if ($min && (!defined($start_day) ||
 					     $min < $start_day)) {
 					$start_day = $min;
@@ -326,9 +326,9 @@ if ($max) {
 			print "<tr>\n";
 			print "<td>",strftime("%m/%Y", @tm),"</td>\n";
 			print "<td>";
-			local $usage = 0;
+			my $usage = 0;
 			foreach $f (@bandwidth_features) {
-				local $fusage = &usage_for_days(
+				my $fusage = &usage_for_days(
 					$istart[$i], $iend[$i], $f, @bands);
 				$usage += $fusage;
 				if ($fusage) {
@@ -351,7 +351,7 @@ if ($max) {
 		if ($donecolour{$f}) {
 			print "<img src=images/usage-$f.gif ",
 			      "width=10 height=10>\n";
-			local $label = $text{'bandwidth_'.$f} ||
+			my $label = $text{'bandwidth_'.$f} ||
 				       $text{'feature_'.$f};
 			print $label," (",
 			      &nice_size($donecolour{$f}),")\n";
@@ -368,8 +368,8 @@ if ($max) {
 		@mago = ( );
 		@tm = localtime(time());
 		for($i=0; $i<24; $i++) {
-			local $sday = &bandwidth_period_start($i);
-			local $eday = &bandwidth_period_end($i);
+			my $sday = &bandwidth_period_start($i);
+			my $eday = &bandwidth_period_end($i);
 			push(@mago, [ $i, &make_date($sday*24*60*60, 1)." - ".
 					  &make_date($eday*24*60*60, 1) ]);
 			}
@@ -407,10 +407,10 @@ push(@rets, "", $text{'index_return'});
 # usage_colours(&domain, &usage)
 sub usage_colours
 {
-local ($d, $usage) = @_;
-local ($f, $total);
+my ($d, $usage) = @_;
+my ($f, $total);
 foreach $f (@bandwidth_features) {
-	local $fusage = $usage->{$f}->{$d->{'id'}};
+	my $fusage = $usage->{$f}->{$d->{'id'}};
 	if ($fusage) {
 		printf "<img src=images/usage-$f.gif width=%s height=10>",
 			int($width*$fusage/$max)+($f eq "web" ? 1 : 0);
@@ -426,7 +426,7 @@ if (!$total) {
 # minimum_day(&bandwidth)
 sub minimum_day
 {
-local $min = undef;
+my $min = undef;
 foreach $k (keys %{$_[0]}) {
 	if ($k =~ /^(\S+)_(\d+)$/ && (!defined($min) || $2 < $min)) {
 		$min = $2;
@@ -438,9 +438,9 @@ return $min;
 # usage_for_days(start, end, feature, &bandwidth, ...)
 sub usage_for_days
 {
-local ($start, $end, $f, @bands) = @_;
-local $usage = 0;
-local ($i, $band);
+my ($start, $end, $f, @bands) = @_;
+my $usage = 0;
+my ($i, $band);
 for($i=int($start); $i<=int($end); $i++) {
 	foreach $band (@bands) {
 		$usage += $band->{$f.'_'.$i};

--- a/cert_form.cgi
+++ b/cert_form.cgi
@@ -706,7 +706,7 @@ if (defined(&theme_select_domain)) {
 # print_cert_fields(show-days)
 sub print_cert_fields
 {
-local ($showdays) = @_;
+my ($showdays) = @_;
 
 print &ui_table_row($webmin::text{'ssl_cn'},
 		    &ui_textbox("commonName", "www.$d->{'dom'}", 30));

--- a/change-licence.pl
+++ b/change-licence.pl
@@ -34,7 +34,7 @@ if (!$module_name) {
 
 # Parse args
 while(@ARGV > 0) {
-	local $a = shift(@ARGV);
+	my $a = shift(@ARGV);
 	if ($a eq "--serial") {
 		$serial = shift(@ARGV);
 		}

--- a/change-password.pl
+++ b/change-password.pl
@@ -100,7 +100,7 @@ if ($user->{'domainowner'}) {
 		# Update all features
 		foreach my $f (@features) {
 			if ($config{$f} && $d->{$f}) {
-				local $mfunc = "modify_".$f;
+				my $mfunc = "modify_".$f;
 				&$mfunc($d, $oldd);
 				}
 			}

--- a/check-config.pl
+++ b/check-config.pl
@@ -31,7 +31,7 @@ if (!$module_name) {
 @OLDARGV = @ARGV;
 
 while(@ARGV > 0) {
-        local $a = shift(@ARGV);
+        my $a = shift(@ARGV);
 	if ($a eq "--multiline") {
 		$multiline = 1;
 		}

--- a/check-scripts.pl
+++ b/check-scripts.pl
@@ -152,7 +152,7 @@ foreach $s (@scripts) {
 				}
 
 			# Extract all the versions
-			local @vers;
+			my @vers;
 			if (ref($re)) {
 				# By callback func on data
 				@vers = &$re($data, $v);
@@ -265,10 +265,10 @@ else {
 
 sub ftp_size
 {
-local ($host, $file) = @_;
+my ($host, $file) = @_;
 
 # connect to host and login
-local $error;
+my $error;
 &open_socket($host, 21, "SOCK", \$error) || return 0;
 alarm(0);
 if ($download_timed_out) {
@@ -277,7 +277,7 @@ if ($download_timed_out) {
 &ftp_command("", 2, \$error) || return 0;
 
 # Login as anonymous
-local @urv = &ftp_command("USER anonymous", [ 2, 3 ], \$error);
+my @urv = &ftp_command("USER anonymous", [ 2, 3 ], \$error);
 @urv || return 0;
 if (int($urv[1]/100) == 3) {
 	&ftp_command("PASS root\@".&get_system_hostname(), 2,
@@ -286,7 +286,7 @@ if (int($urv[1]/100) == 3) {
 
 # get the file size and tell the callback
 &ftp_command("TYPE I", 2, \$error) || return 0;
-local $size = &ftp_command("SIZE $file", 2, \$error);
+my $size = &ftp_command("SIZE $file", 2, \$error);
 
 &ftp_command("QUIT", 2, \$error) || return 0;
 return $size;

--- a/clone-domain.pl
+++ b/clone-domain.pl
@@ -47,7 +47,7 @@ if (!$module_name) {
 
 # Parse command-line args
 while(@ARGV > 0) {
-	local $a = shift(@ARGV);
+	my $a = shift(@ARGV);
 	if ($a eq "--domain") {
 		$domain = lc(shift(@ARGV));
 		}

--- a/collect-lib.pl
+++ b/collect-lib.pl
@@ -6,13 +6,13 @@ sub collect_system_info
 {
 my ($manual, $confchk) = @_;
 &foreign_require("system-status");
-local $info = &system_status::get_collected_info($manual);
+my $info = &system_status::get_collected_info($manual);
 
 # Memory may come from a custom command
 if ($config{'mem_cmd'}) {
 	# Get from custom command
-	local $out = &backquote_command($config{'mem_cmd'});
-	local @lines = split(/\r?\n/, $out);
+	my $out = &backquote_command($config{'mem_cmd'});
+	my @lines = split(/\r?\n/, $out);
 	$info->{'mem'} = [ map { $_/1024 } @lines ];
 	}
 
@@ -20,11 +20,11 @@ if ($config{'mem_cmd'}) {
 $info->{'startstop'} = [ &get_startstop_links() ];
 
 # Counts for domains
-local $dusers = &count_domain_users();
-local $daliases = &count_domain_aliases(1);
-local @doms = &list_visible_domains();
-local @doms_all = &list_domains();
-local %fcount = map { $_, 0 } @features;
+my $dusers = &count_domain_users();
+my $daliases = &count_domain_aliases(1);
+my @doms = &list_visible_domains();
+my @doms_all = &list_domains();
+my %fcount = map { $_, 0 } @features;
 $fcount{'doms'} = 0;
 $fcount{'webaliases'} = 0;
 foreach my $d (@doms) {
@@ -42,9 +42,9 @@ foreach my $d (@doms) {
 $info->{'fcount'} = \%fcount;
 $info->{'ftypes'} = [ "doms", "dns", "web", "ssl", "webaliases", "mail", "dbs",
 		      "users", "aliases" ];
-local (%fmax, %fextra, %fhide);
+my (%fmax, %fextra, %fhide);
 foreach my $f (@{$info->{'ftypes'}}) {
-	local ($extra, $reason, $max, $hide) =
+	my ($extra, $reason, $max, $hide) =
 		&count_feature($f);
 	$fmax{$f} = $max;
 	$fextra{$f} = $extra;
@@ -56,15 +56,15 @@ $info->{'fhide'} = \%fhide;
 
 # Quota use for domains
 if (&has_home_quotas()) {
-	local @quota;
-	local $homesize = &quota_bsize("home");
-	local $maxquota = 0;
+	my @quota;
+	my $homesize = &quota_bsize("home");
+	my $maxquota = 0;
 
 	# Work out quotas
 	foreach my $d (@doms) {
 		# If this is a parent domain, sum up quotas
 		if (!$d->{'parent'}) {
-			local ($home, $mail, $dbusage, $quota);
+			my ($home, $mail, $dbusage, $quota);
 			if ($config{'show_uquotas'} == 0) {
 				# Domain group quotas
 				($home, $dbusage) =
@@ -73,15 +73,15 @@ if (&has_home_quotas()) {
 				}
 			else {
 				# Just the domain owner
-				local $duser = &get_domain_owner($d, 1, 0, 1);
+				my $duser = &get_domain_owner($d, 1, 0, 1);
 				$home = $duser->{'uquota'};
 				$dbusage = 0;
 				$quota = $duser->{'quota'};
 				}
-			local $usage = $home*$homesize;
+			my $usage = $home*$homesize;
 			$maxquota = $usage+$dbusage
 				if ($usage+$dbusage > $maxquota);
-			local $limit = $quota * $homesize;
+			my $limit = $quota * $homesize;
 			$maxquota = $limit if ($limit > $maxquota);
 			push(@quota, [ $d, $usage, $limit, $dbusage ]);
 			}
@@ -91,7 +91,7 @@ if (&has_home_quotas()) {
 	}
 
 # IP addresses used
-local (%ipcount, %ipdom);
+my (%ipcount, %ipdom);
 foreach my $d (@doms) {
 	next if ($d->{'alias'});
 	$ipcount{$d->{'ip'}}++;
@@ -101,10 +101,10 @@ foreach my $d (@doms) {
 		$ipdom{$d->{'ip6'}} ||= $d;
 		}
 	}
-local %doneip;
+my %doneip;
 if (keys %ipdom > 1) {
-	local $defip = &get_default_ip();
-	local $defip6 = &get_default_ip6();
+	my $defip = &get_default_ip();
+	my $defip6 = &get_default_ip6();
 	if (defined(&list_resellers)) {
 		foreach my $r (&list_resellers()) {
 			if ($r->{'acl'}->{'defip'}) {
@@ -123,7 +123,7 @@ if (keys %ipdom > 1) {
 			$sharedip{$ip6}++;
 			}
 		}
-	local @ips;
+	my @ips;
 	foreach my $ip ($defip,
 		     (sort { $a cmp $b } keys %reselip),
 		     (sort { $a cmp $b } keys %ipcount)) {
@@ -141,16 +141,16 @@ if (keys %ipdom > 1) {
 	}
 
 # IP ranges available
-local $tmpl = &get_template(0);
-local @ranges = split(/\s+/, $tmpl->{'ranges'});
-local @ipranges;
-local %taken = &interface_ip_addresses();
+my $tmpl = &get_template(0);
+my @ranges = split(/\s+/, $tmpl->{'ranges'});
+my @ipranges;
+my %taken = &interface_ip_addresses();
 foreach my $r (@ranges) {
 	$r =~ /^(\d+\.\d+\.\d+)\.(\d+)\-(\d+)$/ || next;
-        local ($base, $s, $e) = ($1, $2, $3);
-	local ($ipcount, $usedcount) = (0, 0);
+        my ($base, $s, $e) = ($1, $2, $3);
+	my ($ipcount, $usedcount) = (0, 0);
 	for(my $j=$s; $j<=$e; $j++) {
-		local $try = "$base.$j";
+		my $try = "$base.$j";
 		if ($doneip{$try} || $taken{$try}) {
 			$usedcount++;
 			}
@@ -163,10 +163,10 @@ if (@ipranges) {
 	}
 
 # Program information
-local @progs;
+my @progs;
 foreach my $f ("virtualmin", @features) {
 	if ($config{$f} || $f eq "virtualmin") {
-		local $ifunc = "sysinfo_$f";
+		my $ifunc = "sysinfo_$f";
 		if (defined(&$ifunc)) {
 			push(@progs, &$ifunc());
 			}
@@ -241,10 +241,10 @@ return $info;
 sub get_collected_info
 {
 my ($no_cache) = @_;
-local $infostr = $config{'collect_interval'} eq 'none' ? undef :
+my $infostr = $config{'collect_interval'} eq 'none' ? undef :
 			&read_file_contents($collected_info_file);
 if ($infostr && $no_cache ne 'no-cache') {
-	local $info = &unserialise_variable($infostr);
+	my $info = &unserialise_variable($infostr);
 	if (ref($info) eq 'HASH' && keys(%$info) > 0) {
 		return $info;
 		}
@@ -256,7 +256,7 @@ return &collect_system_info();
 # Save information collected on schedule
 sub save_collected_info
 {
-local ($info) = @_;
+my ($info) = @_;
 &open_tempfile(INFO, ">$collected_info_file");
 &print_tempfile(INFO, &serialise_variable($info));
 &close_tempfile(INFO);
@@ -266,7 +266,7 @@ local ($info) = @_;
 # Refresh regularly collected info on status of services
 sub refresh_startstop_status
 {
-local $info = &get_collected_info();
+my $info = &get_collected_info();
 $info->{'startstop'} = [ &get_startstop_links() ];
 &save_collected_info($info);
 }
@@ -276,11 +276,11 @@ $info->{'startstop'} = [ &get_startstop_links() ];
 # system_status::refresh_possible_packages has already been called.
 sub refresh_possible_packages
 {
-local ($pkgs) = @_;
-local %pkgs = map { $_, 1 } @$pkgs;
-local $info = &get_collected_info();
+my ($pkgs) = @_;
+my %pkgs = map { $_, 1 } @$pkgs;
+my $info = &get_collected_info();
 &foreign_require("system-status");
-local $sinfo = &system_status::get_collected_info();
+my $sinfo = &system_status::get_collected_info();
 $info->{'poss'} = $sinfo->{'poss'};
 my @vposs = grep { &is_virtualmin_package($_) } @{$info->{'poss'}};
 $info->{'vposs'} = \@vposs;
@@ -292,11 +292,11 @@ $info->{'vposs'} = \@vposs;
 # use, disk use and other info we might want to graph
 sub add_historic_collected_info
 {
-local ($info, $time) = @_;
+my ($info, $time) = @_;
 if (!-d $historic_info_dir) {
 	&make_dir($historic_info_dir, 0700);
 	}
-local @stats;
+my @stats;
 push(@stats, [ "load", $info->{'load'}->[0] ]) if ($info->{'load'});
 push(@stats, [ "load5", $info->{'load'}->[1] ]) if ($info->{'load'});
 push(@stats, [ "load15", $info->{'load'}->[2] ]) if ($info->{'load'});
@@ -329,8 +329,8 @@ if ($info->{'disk_total'}) {
 push(@stats, [ "doms", $info->{'fcount'}->{'doms'} ]);
 push(@stats, [ "users", $info->{'fcount'}->{'users'} ]);
 push(@stats, [ "aliases", $info->{'fcount'}->{'aliases'} ]);
-local $qlimit = 0;
-local $qused = 0;
+my $qlimit = 0;
+my $qused = 0;
 foreach my $q (@{$info->{'quota'}}) {
 	$qlimit += $q->[2];
 	$qused += $q->[1]+$q->[3];
@@ -339,13 +339,13 @@ push(@stats, [ "quotalimit", $qlimit ]);
 push(@stats, [ "quotaused", $qused ]);
 
 # Get messages processed by procmail since the last collection time
-local $now = time();
+my $now = time();
 my $hasprocmail = &mail_system_has_procmail();
 if (-r $procmail_log_file && $hasprocmail) {
 	# Get last seek position
-	local $lastinfo = &read_file_contents("$historic_info_dir/procmailpos");
-	local @st = stat($procmail_log_file);
-	local ($lastpos, $lastinode, $lasttime);
+	my $lastinfo = &read_file_contents("$historic_info_dir/procmailpos");
+	my @st = stat($procmail_log_file);
+	my ($lastpos, $lastinode, $lasttime);
 	if (defined($lastinfo)) {
 		($lastpos, $lastinode, $lasttime) = split(/\s+/, $lastinfo);
 		}
@@ -363,11 +363,11 @@ if (-r $procmail_log_file && $hasprocmail) {
 	else {
 		$lastpos = 0;
 		}
-	local ($mailcount, $spamcount, $viruscount) = (0, 0, 0);
+	my ($mailcount, $spamcount, $viruscount) = (0, 0, 0);
 	while(<PROCMAILLOG>) {
 		$lastpos += length($_);
 		s/\r|\n//g;
-		local %log = map { split(/:/, $_, 2) } split(/\s+/, $_);
+		my %log = map { split(/:/, $_, 2) } split(/\s+/, $_);
 		if ($log{'User'}) {
 			$mailcount++;
 			if ($log{'Mode'} eq 'Spam') {
@@ -379,7 +379,7 @@ if (-r $procmail_log_file && $hasprocmail) {
 			}
 		}
 	close(PROCMAILLOG);
-	local $mins = ($now - $lasttime) / 60.0;
+	my $mins = ($now - $lasttime) / 60.0;
 	push(@stats, [ "mailcount", $mins ? $mailcount / $mins : 0 ]);
 	push(@stats, [ "spamcount", $mins ? $spamcount / $mins : 0 ]);
 	push(@stats, [ "viruscount", $mins ? $viruscount / $mins : 0 ]);
@@ -391,19 +391,19 @@ if (-r $procmail_log_file && $hasprocmail) {
 	}
 
 # Read mail server log to count messages since the last run
-local $lastinfo = &read_file_contents("$historic_info_dir/maillogpos");
-local ($lastpos, $lastinode, $lasttime);
+my $lastinfo = &read_file_contents("$historic_info_dir/maillogpos");
+my ($lastpos, $lastinode, $lasttime);
 if (defined($lastinfo)) {
 	($lastpos, $lastinode, $lasttime) = split(/\s+/, $lastinfo);
 	}
-local $mail_log_file = $config{'bw_maillog'};
+my $mail_log_file = $config{'bw_maillog'};
 $mail_log_file = &get_mail_log($lasttime)
 	if ($mail_log_file eq "auto");
 
 if ($mail_log_file && $config{'mail'}) {
 	# Get last seek position
-	local ($spamcount, $mailcount) = (0, 0);
-	local @st = stat($mail_log_file);
+	my ($spamcount, $mailcount) = (0, 0);
+	my @st = stat($mail_log_file);
 	if (!defined($lastinfo)) {
 		# For the first run, start at the end of the file
 		$lastpos = $st[7];
@@ -413,7 +413,7 @@ if ($mail_log_file && $config{'mail'}) {
 
 	# Read the log, finding number of messages recived, bounced and
 	# greylisted
-	local ($recvcount, $bouncecount, $greycount, $ratecount) = (0, 0, 0);
+	my ($recvcount, $bouncecount, $greycount, $ratecount) = (0, 0, 0);
 	open(MAILLOG, $mail_log_file);
 	if ($mail_log_file !~ /\|$/) {
 		# Seek forwards in the file, unless rotated
@@ -477,7 +477,7 @@ if ($mail_log_file && $config{'mail'}) {
 	if ($lastpos <= 0) {
 		$lastpos = $st[7];
 		}
-	local $mins = ($now - $lasttime) / 60.0;
+	my $mins = ($now - $lasttime) / 60.0;
 	push(@stats, [ "recvcount", $mins ? $recvcount / $mins : 0 ]);
 	push(@stats, [ "bouncecount", $mins ? $bouncecount / $mins : 0 ]);
 	if ($greycount || !&check_postgrey()) {
@@ -503,8 +503,8 @@ if ($mail_log_file && $config{'mail'}) {
 # Get network traffic counts since last run
 if (&foreign_check("net") && $gconfig{'os_type'} =~ /-linux$/) {
 	# Get the current byte count
-	local $rxtotal = 0;
-	local $txtotal = 0;
+	my $rxtotal = 0;
+	my $txtotal = 0;
 	if ($config{'collect_ifaces'}) {
 		# From module config
 		@ifaces = split(/\s+/, $config{'collect_ifaces'});
@@ -526,22 +526,22 @@ if (&foreign_check("net") && $gconfig{'os_type'} =~ /-linux$/) {
 			}
 		}
 	@ifaces = &unique(@ifaces);
-	local $ifaces = join(" ", @ifaces);
+	my $ifaces = join(" ", @ifaces);
 	if (&has_command("ifconfig")) {
 		# Get traffic from old ifconfig command
 		foreach my $iname (@ifaces) {
-			local $out = &backquote_command(
+			my $out = &backquote_command(
 				"LC_ALL='' LANG='' ifconfig ".
 				quotemeta($iname)." 2>/dev/null");
-			local $rx = $out =~ /RX\s+bytes:\s*(\d+)/i ? $1 : undef;
-			local $tx = $out =~ /TX\s+bytes:\s*(\d+)/i ? $1 : undef;
+			my $rx = $out =~ /RX\s+bytes:\s*(\d+)/i ? $1 : undef;
+			my $tx = $out =~ /TX\s+bytes:\s*(\d+)/i ? $1 : undef;
 			$rxtotal += $rx;
 			$txtotal += $tx;
 			}
 		}
 	else {
 		# Get traffic from /proc/net/dev
-		local $out = &read_file_contents("/proc/net/dev");
+		my $out = &read_file_contents("/proc/net/dev");
 		foreach my $l (split(/\r?\n/, $out)) {
 			$l =~ s/^\s+//;
 			my @w = split(/[ \t:]+/, $l);
@@ -553,14 +553,14 @@ if (&foreign_check("net") && $gconfig{'os_type'} =~ /-linux$/) {
 		}
 
 	# Work out the diff since the last run, if we have it
-	local %netcounts;
+	my %netcounts;
 	if (&read_file("$historic_info_dir/netcounts", \%netcounts) &&
 	    $netcounts{'rx'} && $netcounts{'tx'} &&
 	    $netcounts{'ifaces'} eq $ifaces &&
 	    $rxtotal >= $netcounts{'rx'} && $txtotal >= $netcounts{'tx'}) {
-		local $secs = ($now - $netcounts{'now'}) * 1.0;
-		local $rxscaled = ($rxtotal - $netcounts{'rx'}) / $secs;
-		local $txscaled = ($txtotal - $netcounts{'tx'}) / $secs;
+		my $secs = ($now - $netcounts{'now'}) * 1.0;
+		my $rxscaled = ($rxtotal - $netcounts{'rx'}) / $secs;
+		my $txscaled = ($txtotal - $netcounts{'tx'}) / $secs;
 		if ($rxscaled >= $netcounts{'rx_max'}) {
 			$netcounts{'rx_max'} = $rxscaled;
 			}
@@ -580,7 +580,7 @@ if (&foreign_check("net") && $gconfig{'os_type'} =~ /-linux$/) {
 	}
 
 # Get drive temperatures
-local ($temptotal, $tempcount);
+my ($temptotal, $tempcount);
 foreach my $t (@{$info->{'drivetemps'}}) {
 	$temptotal += $t->{'temp'};
 	$tempcount++;
@@ -590,7 +590,7 @@ if ($temptotal) {
 	}
 
 # Get CPU temperature
-local ($temptotal, $tempcount);
+my ($temptotal, $tempcount);
 foreach my $t (@{$info->{'cputemps'}}) {
 	$temptotal += $t->{'temp'};
 	$tempcount++;
@@ -621,7 +621,7 @@ foreach my $stat (@stats) {
 	}
 
 # Update the file storing the max possible value for each variable
-local %maxpossible;
+my %maxpossible;
 &read_file("$historic_info_dir/maxes", \%maxpossible);
 foreach my $stat (@stats) {
 	if ($stat->[2] && $stat->[2] > $maxpossible{$stat->[0]}) {
@@ -636,14 +636,14 @@ foreach my $stat (@stats) {
 # time period
 sub list_historic_collected_info
 {
-local ($stat, $start, $end) = @_;
-local @rv;
-local $last_time;
-local $now = time();
+my ($stat, $start, $end) = @_;
+my @rv;
+my $last_time;
+my $now = time();
 open(HISTORY, "<$historic_info_dir/$stat");
 while(<HISTORY>) {
 	chop;
-	local ($time, $value) = split(" ", $_);
+	my ($time, $value) = split(" ", $_);
 	next if ($time < $last_time ||	# No time travel or future data
 		 $time > $now);
 	if ((!defined($start) || $time >= $start) &&
@@ -663,9 +663,9 @@ return @rv;
 # Returns a hash mapping stats to data within some time period
 sub list_all_historic_collected_info
 {
-local ($start, $end) = @_;
+my ($start, $end) = @_;
 foreach my $f (&list_historic_stats()) {
-	local @rv = &list_historic_collected_info($f, $start, $end);
+	my @rv = &list_historic_collected_info($f, $start, $end);
 	$all{$f} = \@rv;
 	}
 closedir(HISTDIR);
@@ -676,7 +676,7 @@ return \%all;
 # Returns a hash reference from stats to the max possible values ever seen
 sub get_historic_maxes
 {
-local %maxpossible;
+my %maxpossible;
 &read_file("$historic_info_dir/maxes", \%maxpossible);
 return \%maxpossible;
 }
@@ -685,19 +685,19 @@ return \%maxpossible;
 # Returns the Unix time for the first and last stats recorded
 sub get_historic_first_last
 {
-local ($stat) = @_;
+my ($stat) = @_;
 open(HISTORY, "<$historic_info_dir/$stat") || return (undef, undef);
-local $first = <HISTORY>;
+my $first = <HISTORY>;
 $first || return (undef, undef);
 chop($first);
-local ($firsttime, $firstvalue) = split(" ", $first);
+my ($firsttime, $firstvalue) = split(" ", $first);
 seek(HISTORY, 2, -256) || seek(HISTORY, 0, 0);
 while(<HISTORY>) {
 	$last = $_;
 	}
 close(HISTORY);
 chop($last);
-local ($lasttime, $lastvalue) = split(" ", $last);
+my ($lasttime, $lastvalue) = split(" ", $last);
 return ($firsttime, $lasttime);
 }
 
@@ -705,7 +705,7 @@ return ($firsttime, $lasttime);
 # Returns a list of variables on which we have stats
 sub list_historic_stats
 {
-local @rv;
+my @rv;
 opendir(HISTDIR, $historic_info_dir);
 foreach my $f (readdir(HISTDIR)) {
 	if ($f =~ /^[a-z]+[0-9]*$/ && $f ne "maxes" && $f ne "procmailpos" &&
@@ -723,15 +723,15 @@ return @rv;
 sub setup_collectinfo_job
 {
 # Work out correct steps
-local $step = $config{'collect_interval'};
+my $step = $config{'collect_interval'};
 $step = 5 if (!$step || $step eq 'none');
 $step = 60 if ($step > 60);
-local $offset = int(rand()*$step);
-local @mins;
+my $offset = int(rand()*$step);
+my @mins;
 for(my $i=$offset; $i<60; $i+= $step) {
 	push(@mins, $i);
 	}
-local $job = &find_cron_script($collect_cron_cmd);
+my $job = &find_cron_script($collect_cron_cmd);
 if (!$job && $config{'collect_interval'} ne 'none') {
 	# Create, and run for the first time
 	$job = { 'mins' => join(',', @mins),
@@ -746,8 +746,8 @@ if (!$job && $config{'collect_interval'} ne 'none') {
 	}
 elsif ($job && $config{'collect_interval'} ne 'none') {
 	# Update existing job, if step has changed
-	local @oldmins = split(/,/, $job->{'mins'});
-	local $oldstep = $oldmins[0] eq '*' ? 1 :
+	my @oldmins = split(/,/, $job->{'mins'});
+	my $oldstep = $oldmins[0] eq '*' ? 1 :
 			 @oldmins == 1 ? 60 :
 			 $oldmins[1]-$oldmins[0];
 	if ($step != $oldstep) {
@@ -766,7 +766,7 @@ elsif ($job && $config{'collect_interval'} eq 'none') {
 # afterwards, and update the info hash.
 sub restart_collected_services
 {
-local ($info) = @_;
+my ($info) = @_;
 my $count = 0;
 foreach my $ss (@{$info->{'startstop'}}) {
 	if (!$ss->{'status'}) {

--- a/commands-lib.pl
+++ b/commands-lib.pl
@@ -219,8 +219,8 @@ return ( "upload-api-docs.pl",
 # Returns a list of directories to check for API scripts
 sub list_api_directories
 {
-local ($pwd) = @_;
-local $par = $pwd;
+my ($pwd) = @_;
+my $par = $pwd;
 $par =~ s/\/([^\/]+)$//;
 return ( $pwd, glob("$par/virtualmin-*") );
 }
@@ -250,16 +250,16 @@ else {
 # an error message.
 sub create_api_helper_command
 {
-local ($extradirs) = @_;
-local @dirs = ( $module_root_directory );
+my ($extradirs) = @_;
+my @dirs = ( $module_root_directory );
 push(@dirs, @$extradirs) if ($extradirs);
-local $dirstr = join(" ", @dirs);
-local $proonly = join(" ", &list_pro_only_api_commands());
-local $api_helper_command = &get_api_helper_command();
+my $dirstr = join(" ", @dirs);
+my $proonly = join(" ", &list_pro_only_api_commands());
+my $api_helper_command = &get_api_helper_command();
 if (!$api_helper_command) {
 	return (0, "No writable path configured or auto-detected");
 	}
-local $bash = &has_command("bash") || &has_command("sh");
+my $bash = &has_command("bash") || &has_command("sh");
 if ($bash) {
 	&open_tempfile(HELPER, ">$api_helper_command", 1, 0) ||
 		return (0, "Failed to write to $api_helper_command : $!");

--- a/config_info.pl
+++ b/config_info.pl
@@ -3,7 +3,7 @@ require 'virtual-server-lib.pl';
 
 sub show_theme
 {
-local ($value, $desc, $type, $func, $name) = @_;
+my ($value, $desc, $type, $func, $name) = @_;
 &foreign_require("webmin");
 return &ui_select($name, $value,
 		  [ [ "*", $text{'config_deftheme'} ],
@@ -14,13 +14,13 @@ return &ui_select($name, $value,
 
 sub parse_theme
 {
-local ($value, $desc, $type, $func, $name) = @_;
+my ($value, $desc, $type, $func, $name) = @_;
 return $in{$name};
 }
 
 sub show_modules
 {
-local ($value, $desc, $type, $func, $name) = @_;
+my ($value, $desc, $type, $func, $name) = @_;
 return &ui_textbox($name, $value, 40)." ".
        &modules_chooser_button($name, 1,
 		$current_theme eq "virtual-server-theme" ? 1 : 0);
@@ -28,7 +28,7 @@ return &ui_textbox($name, $value, 40)." ".
 
 sub parse_modules
 {
-local ($value, $desc, $type, $func, $name) = @_;
+my ($value, $desc, $type, $func, $name) = @_;
 return $in{$name};
 }
 

--- a/copy-mailbox.pl
+++ b/copy-mailbox.pl
@@ -32,7 +32,7 @@ if (!$module_name) {
 # Parse command-line args
 $delete = 0;
 while(@ARGV > 0) {
-	local $a = shift(@ARGV);
+	my $a = shift(@ARGV);
 	if ($a eq "--source") {
 		$src = shift(@ARGV);
 		}

--- a/create-admin.pl
+++ b/create-admin.pl
@@ -60,7 +60,7 @@ if (!$module_name) {
 $norename = 1;
 $append = $config{'appendadmin'};
 while(@ARGV > 0) {
-	local $a = shift(@ARGV);
+	my $a = shift(@ARGV);
 	if ($a eq "--domain") {
 		$domain = shift(@ARGV);
 		}

--- a/create-alias.pl
+++ b/create-alias.pl
@@ -48,7 +48,7 @@ if (!$module_name) {
 # Parse command-line args
 &require_mail();
 while(@ARGV > 0) {
-	local $a = shift(@ARGV);
+	my $a = shift(@ARGV);
 	if ($a eq "--domain") {
 		$domain = shift(@ARGV);
 		}

--- a/create-database.pl
+++ b/create-database.pl
@@ -42,7 +42,7 @@ if (!$module_name) {
 
 # Parse command-line args
 while(@ARGV > 0) {
-	local $a = shift(@ARGV);
+	my $a = shift(@ARGV);
 	if ($a eq "--domain") {
 		$domain = shift(@ARGV);
 		}
@@ -53,8 +53,8 @@ while(@ARGV > 0) {
 		$type = shift(@ARGV);
 		}
 	elsif ($a eq "--opt") {
-		local $oname = shift(@ARGV);
-		local $ovalue;
+		my $oname = shift(@ARGV);
+		my $ovalue;
 		($oname, $ovalue) = split(/\s+/, $oname);
 		$ovalue ||= shift(@ARGV);
 		$oname && $ovalue ne '' ||

--- a/create-domain.pl
+++ b/create-domain.pl
@@ -135,7 +135,7 @@ $virt = 0;
 $anylimits = 0;
 $email = $config{'contact_email'};
 while(@ARGV > 0) {
-	local $a = shift(@ARGV);
+	my $a = shift(@ARGV);
 	if ($a eq "--domain") {
 		$domain = shift(@ARGV);
 		}
@@ -769,7 +769,7 @@ if (!$alias) {
 			$clash || &usage(&text('setup_evirtclash2'));
 			if ($virtalready == 1) {
 				# Don't allow clash with another domain
-				local $already = &get_domain_by("ip", $ip);
+				my $already = &get_domain_by("ip", $ip);
 				$already && &usage(&text('setup_evirtclash4',
 						 $already->{'dom'}));
 				}

--- a/create-login-link.pl
+++ b/create-login-link.pl
@@ -42,7 +42,7 @@ if (!$module_name) {
 # Parse command-line args
 $lifetime = 3600;
 while(@ARGV > 0) {
-	local $a = shift(@ARGV);
+	my $a = shift(@ARGV);
 	if ($a eq "--domain") {
 		$dname = shift(@ARGV);
 		}

--- a/create-plan.pl
+++ b/create-plan.pl
@@ -56,7 +56,7 @@ if (!$module_name) {
 # Parse command-line args
 $plan = { };
 while(@ARGV > 0) {
-	local $a = shift(@ARGV);
+	my $a = shift(@ARGV);
 	if ($a eq "--name") {
 		$plan->{'name'} = shift(@ARGV);
 		}

--- a/create-proxy.pl
+++ b/create-proxy.pl
@@ -47,7 +47,7 @@ if (!$module_name) {
 # Parse command-line args
 &require_mail();
 while(@ARGV > 0) {
-	local $a = shift(@ARGV);
+	my $a = shift(@ARGV);
 	if ($a eq "--domain") {
 		$domain = shift(@ARGV);
 		}

--- a/create-redirect.pl
+++ b/create-redirect.pl
@@ -69,7 +69,7 @@ if (!$module_name) {
 # Parse command-line args
 &require_mail();
 while(@ARGV > 0) {
-	local $a = shift(@ARGV);
+	my $a = shift(@ARGV);
 	if ($a eq "--domain") {
 		$domain = shift(@ARGV);
 		}

--- a/create-rs-container.pl
+++ b/create-rs-container.pl
@@ -35,7 +35,7 @@ if (!$module_name) {
 # Parse command-line args
 $tries = 1;
 while(@ARGV > 0) {
-	local $a = shift(@ARGV);
+	my $a = shift(@ARGV);
 	if ($a eq "--container") {
 		$container = shift(@ARGV);
 		}

--- a/create-s3-bucket.pl
+++ b/create-s3-bucket.pl
@@ -32,7 +32,7 @@ if (!$module_name) {
 # Parse command-line args
 $owner = 1;
 while(@ARGV > 0) {
-	local $a = shift(@ARGV);
+	my $a = shift(@ARGV);
 	if ($a eq "--bucket") {
 		$bucket = shift(@ARGV);
 		}

--- a/create-scheduled-backup.pl
+++ b/create-scheduled-backup.pl
@@ -121,12 +121,12 @@ $enabled = 1;
 @allplans = &list_plans();
 @OLDARGV = @ARGV;
 while(@ARGV > 0) {
-	local $a = shift(@ARGV);
+	my $a = shift(@ARGV);
 	if ($a eq "--dest") {
 		push(@dests, shift(@ARGV));
 		}
 	elsif ($a eq "--feature") {
-		local $f = shift(@ARGV);
+		my $f = shift(@ARGV);
 		&is_enabled_backup_feature($f) ||
 			&usage("Feature $f is not enabled on this system");
 		push(@bfeats, $f);

--- a/create-shared-address.pl
+++ b/create-shared-address.pl
@@ -36,7 +36,7 @@ if (!$module_name) {
 # Parse command-line args
 $owner = 1;
 while(@ARGV > 0) {
-	local $a = shift(@ARGV);
+	my $a = shift(@ARGV);
 	if ($a eq "--ip") {
 		$ip = shift(@ARGV);
 		}

--- a/create-simple-alias.pl
+++ b/create-simple-alias.pl
@@ -53,7 +53,7 @@ if (!$module_name) {
 # Parse command-line args
 &require_mail();
 while(@ARGV > 0) {
-	local $a = shift(@ARGV);
+	my $a = shift(@ARGV);
 	if ($a eq "--domain") {
 		$domain = shift(@ARGV);
 		}

--- a/create-template.pl
+++ b/create-template.pl
@@ -32,7 +32,7 @@ if (!$module_name) {
 
 # Parse command-line args
 while(@ARGV > 0) {
-	local $a = shift(@ARGV);
+	my $a = shift(@ARGV);
 	if ($a eq "--name") {
 		$tmplname = shift(@ARGV);
 		}

--- a/create-user.pl
+++ b/create-user.pl
@@ -90,7 +90,7 @@ if (!$module_name) {
 
 # Parse command-line args
 while(@ARGV > 0) {
-	local $a = shift(@ARGV);
+	my $a = shift(@ARGV);
 	if ($a eq "--domain") {
 		$domain = shift(@ARGV);
 		}
@@ -143,7 +143,7 @@ while(@ARGV > 0) {
 		$noemail++;
 		}
 	elsif ($a eq "--extra") {
-		local $extra = shift(@ARGV);
+		my $extra = shift(@ARGV);
 		push(@extra, $extra);
 		}
 	elsif ($a eq "--quota") {
@@ -231,8 +231,8 @@ foreach $e (@extra) {
 	if ($e !~ /^(\S+)\@(\S+)$/) {
 		usage(&text('user_eextra1', $e));
 		}
-	local ($eu, $ed) = ($1, $2);
-	local $edom = &get_domain_by("dom", $ed);
+	my ($eu, $ed) = ($1, $2);
+	my $edom = &get_domain_by("dom", $ed);
 	$edom && $edom->{'mail'} || usage(&text('user_eextra2', $ed));
 	!$edom->{'alias'} || !$edom->{'aliascopy'} ||
 		&usage(&text('user_eextra7', $ed));

--- a/cron-lib.pl
+++ b/cron-lib.pl
@@ -5,10 +5,10 @@
 # cron via a wrapper, run it within the same process
 sub run_cron_script
 {
-local ($script, $args) = @_;
-local @args = split(/\s+/, $args);
-local $fh = "CRONOUT";
-local $temp = &transname();
+my ($script, $args) = @_;
+my @args = split(/\s+/, $args);
+my $fh = "CRONOUT";
+my $temp = &transname();
 open($fh, ">$temp");
 my $pid = &execute_webmin_script("$module_root_directory/$script", $module_name,
 			         \@args, $fh);
@@ -29,10 +29,10 @@ my ($job, $mod) = @_;
 $mod ||= $module_name;
 &foreign_require("cron");
 &foreign_require("webmincron");
-local $cronjob = &find_module_cron_job($job->{'command'});
+my $cronjob = &find_module_cron_job($job->{'command'});
 if ($job->{'command'} =~ /(\Q$config_directory\E\/\E$mod\E\/([^ \|\&><;]+))/) {
 	# Run from this module
-	local ($wrapper, $script) = ($1, $2);
+	my ($wrapper, $script) = ($1, $2);
 	&cron::create_wrapper($wrapper, $mod, $script);
 
 	# Find existing classic cron job, and remove it
@@ -49,8 +49,8 @@ if ($job->{'command'} =~ /(\Q$config_directory\E\/\E$mod\E\/([^ \|\&><;]+))/) {
 		# Has command-line args 
 		$args = $1;
 		}
-	local @wcrons = &webmincron::list_webmin_crons();
-	local ($wjob) = grep { $_->{'module'} eq $mod &&
+	my @wcrons = &webmincron::list_webmin_crons();
+	my ($wjob) = grep { $_->{'module'} eq $mod &&
 			       $_->{'func'} eq "run_cron_script" &&
 			       $_->{'args'}->[0] eq $script &&
 			       $_->{'args'}->[1] eq $args } @wcrons;
@@ -78,7 +78,7 @@ else {
 	if (!$cronjob) {
 		if ($job->{'command'} =~
 		    /(\Q$config_directory\E\/([^\/]+)\/([^ \|\&><;]+))/) {
-			local ($wrapper, $m, $s) = ($1, $2, $3);
+			my ($wrapper, $m, $s) = ($1, $2, $3);
 			&cron::create_wrapper($wrapper, $m, $s);
 			}
 		&lock_file(&cron::cron_file($job));
@@ -96,7 +96,7 @@ my ($script_or_job, $mod) = @_;
 $mod ||= $module_name;
 if (ref($script_or_job)) {
 	# Delete a specific classic or webmincron job
-	local $job = $script_or_job;
+	my $job = $script_or_job;
 	if ($job->{'module'}) {
 		&foreign_require("webmincron");
 		&webmincron::delete_webmin_cron($job);
@@ -110,13 +110,13 @@ if (ref($script_or_job)) {
 	}
 else {
 	# Delete all matching the script
-	local $script = $script_or_job;
-	local $shortscript = $script;
+	my $script = $script_or_job;
+	my $shortscript = $script;
 	$shortscript =~ s/^.*\///;
 
 	# Classic cron
 	&foreign_require("cron");
-	local @jobs = &cron::list_cron_jobs();
+	my @jobs = &cron::list_cron_jobs();
 	foreach my $job (&find_module_cron_job($script, \@jobs)) {
 		&lock_file(&cron::cron_file($job));
 		&cron::delete_cron_job($job);
@@ -125,7 +125,7 @@ else {
 
 	# Webmin cron
 	&foreign_require("webmincron");
-	local @wcrons = &webmincron::list_webmin_crons();
+	my @wcrons = &webmincron::list_webmin_crons();
 	foreach my $wjob (grep { $_->{'module'} eq $mod &&
 				 $_->{'func'} eq "run_cron_script" &&
 				 $_->{'args'}->[0] eq $shortscript } @wcrons) {
@@ -140,7 +140,7 @@ sub convert_cron_script
 {
 my ($script, $mod) = @_;
 $mod ||= $module_name;
-local $shortscript = $script;
+my $shortscript = $script;
 $shortscript =~ s/^.*\///;
 
 &foreign_require("cron");
@@ -155,7 +155,7 @@ foreach my $job (&find_module_cron_job($script)) {
 		# Has command-line args 
 		$args = $1;
 		}
-	local ($wjob) = grep { $_->{'module'} eq $mod &&
+	my ($wjob) = grep { $_->{'module'} eq $mod &&
 			       $_->{'func'} eq "run_cron_script" &&
 			       $_->{'args'}->[0] eq $shortscript &&
 			       $_->{'args'}->[1] eq $args }
@@ -183,7 +183,7 @@ my $shortscript = $script;
 $shortscript =~ s/^.*\///;
 
 # Classic cron
-local @rv;
+my @rv;
 push(@rv, &find_module_cron_job($fullscript));
 
 # Webmin cron
@@ -193,7 +193,7 @@ foreach my $wjob (grep { $_->{'module'} eq $mod &&
 		         $_->{'args'}->[0] eq $shortscript }
 		       &webmincron::list_webmin_crons()) {
 	# Check rest of the args
-	local @a = @{$wjob->{'args'}};
+	my @a = @{$wjob->{'args'}};
 	shift(@a);
 	if (join(" ", @a) ne join(" ", @wantargs)) {
 		next;
@@ -214,7 +214,7 @@ return wantarray ? @rv : $rv[0];
 # Copy all time-related keys from one cron job to another
 sub copy_cron_sched_keys
 {
-local ($src, $dst) = @_;
+my ($src, $dst) = @_;
 foreach my $k ('mins', 'hours', 'days', 'months', 'weekdays',
 	       'special', 'interval') {
 	$dst->{$k} = $src->{$k};
@@ -225,14 +225,14 @@ foreach my $k ('mins', 'hours', 'days', 'months', 'weekdays',
 # Returns the cron job object that runs some command (perhaps with redirection)
 sub find_module_cron_job
 {
-local ($cmd, $jobs, $user) = @_;
+my ($cmd, $jobs, $user) = @_;
 return undef if (!$cmd);
 if (!$jobs) {
 	&foreign_require("cron");
 	$jobs = [ &cron::list_cron_jobs() ];
 	}
 $user ||= "root";
-local @rv = grep { $_->{'user'} eq $user &&
+my @rv = grep { $_->{'user'} eq $user &&
 	     $_->{'command'} =~ /(^|[ \|\&;\/])\Q$cmd\E($|[ \|\&><;])/ } @$jobs;
 return wantarray ? @rv : $rv[0];
 }

--- a/delete-admin.pl
+++ b/delete-admin.pl
@@ -30,7 +30,7 @@ if (!$module_name) {
 
 # Parse command-line args
 while(@ARGV > 0) {
-	local $a = shift(@ARGV);
+	my $a = shift(@ARGV);
 	if ($a eq "--domain") {
 		$domain = shift(@ARGV);
 		}

--- a/delete-alias.pl
+++ b/delete-alias.pl
@@ -36,7 +36,7 @@ if (!$module_name) {
 
 # Parse command-line args
 while(@ARGV > 0) {
-	local $a = shift(@ARGV);
+	my $a = shift(@ARGV);
 	if ($a eq "--domain") {
 		$domain = shift(@ARGV);
 		}

--- a/delete-backup.pl
+++ b/delete-backup.pl
@@ -31,7 +31,7 @@ if (!$module_name) {
 
 # Parse command-line args
 while(@ARGV > 0) {
-	local $a = shift(@ARGV);
+	my $a = shift(@ARGV);
 	if ($a eq "--id") {
 		$id = shift(@ARGV);
 		}

--- a/delete-database.pl
+++ b/delete-database.pl
@@ -31,7 +31,7 @@ if (!$module_name) {
 
 # Parse command-line args
 while(@ARGV > 0) {
-	local $a = shift(@ARGV);
+	my $a = shift(@ARGV);
 	if ($a eq "--domain") {
 		$domain = shift(@ARGV);
 		}

--- a/delete-domain.pl
+++ b/delete-domain.pl
@@ -43,7 +43,7 @@ if (!$module_name) {
 
 # Parse command-line args
 while(@ARGV > 0) {
-	local $a = shift(@ARGV);
+	my $a = shift(@ARGV);
 	if ($a eq "--domain") {
 		push(@domains, shift(@ARGV));
 		}

--- a/delete-php-directory.pl
+++ b/delete-php-directory.pl
@@ -32,7 +32,7 @@ if (!$module_name) {
 # Parse command-line args
 $owner = 1;
 while(@ARGV > 0) {
-	local $a = shift(@ARGV);
+	my $a = shift(@ARGV);
 	if ($a eq "--domain") {
 		$domain = shift(@ARGV);
 		}

--- a/delete-plan.pl
+++ b/delete-plan.pl
@@ -33,7 +33,7 @@ if (!$module_name) {
 # Parse command-line args
 $plan = { };
 while(@ARGV > 0) {
-	local $a = shift(@ARGV);
+	my $a = shift(@ARGV);
 	if ($a eq "--name") {
 		$planname = shift(@ARGV);
 		}

--- a/delete-proxy.pl
+++ b/delete-proxy.pl
@@ -32,7 +32,7 @@ if (!$module_name) {
 # Parse command-line args
 &require_mail();
 while(@ARGV > 0) {
-	local $a = shift(@ARGV);
+	my $a = shift(@ARGV);
 	if ($a eq "--domain") {
 		$domain = shift(@ARGV);
 		}

--- a/delete-redirect.pl
+++ b/delete-redirect.pl
@@ -34,7 +34,7 @@ if (!$module_name) {
 # Parse command-line args
 &require_mail();
 while(@ARGV > 0) {
-	local $a = shift(@ARGV);
+	my $a = shift(@ARGV);
 	if ($a eq "--domain") {
 		$domain = shift(@ARGV);
 		}

--- a/delete-rs-container.pl
+++ b/delete-rs-container.pl
@@ -36,7 +36,7 @@ if (!$module_name) {
 # Parse command-line args
 $tries = 1;
 while(@ARGV > 0) {
-	local $a = shift(@ARGV);
+	my $a = shift(@ARGV);
 	if ($a eq "--container") {
 		$container = shift(@ARGV);
 		}

--- a/delete-rs-file.pl
+++ b/delete-rs-file.pl
@@ -34,7 +34,7 @@ if (!$module_name) {
 # Parse command-line args
 $tries = 1;
 while(@ARGV > 0) {
-	local $a = shift(@ARGV);
+	my $a = shift(@ARGV);
 	if ($a eq "--container") {
 		$container = shift(@ARGV);
 		}

--- a/delete-s3-bucket.pl
+++ b/delete-s3-bucket.pl
@@ -34,7 +34,7 @@ if (!$module_name) {
 # Parse command-line args
 $owner = 1;
 while(@ARGV > 0) {
-	local $a = shift(@ARGV);
+	my $a = shift(@ARGV);
 	if ($a eq "--bucket") {
 		$bucket = shift(@ARGV);
 		}

--- a/delete-s3-file.pl
+++ b/delete-s3-file.pl
@@ -34,7 +34,7 @@ if (!$module_name) {
 # Parse command-line args
 $owner = 1;
 while(@ARGV > 0) {
-	local $a = shift(@ARGV);
+	my $a = shift(@ARGV);
 	if ($a eq "--bucket") {
 		$bucket = shift(@ARGV);
 		}

--- a/delete-scheduled-backup.pl
+++ b/delete-scheduled-backup.pl
@@ -33,7 +33,7 @@ if (!$module_name) {
 # Parse command-line args
 @OLDARGV = @ARGV;
 while(@ARGV > 0) {
-	local $a = shift(@ARGV);
+	my $a = shift(@ARGV);
 	if ($a eq "--id") {
 		$id = shift(@ARGV);
 		}

--- a/delete-script.pl
+++ b/delete-script.pl
@@ -42,7 +42,7 @@ $second_print = \&second_text_print;
 
 # Parse command-line args
 while(@ARGV > 0) {
-	local $a = shift(@ARGV);
+	my $a = shift(@ARGV);
 	if ($a eq "--domain") {
 		$domain = shift(@ARGV);
 		}

--- a/delete-shared-address.pl
+++ b/delete-shared-address.pl
@@ -32,7 +32,7 @@ if (!$module_name) {
 # Parse command-line args
 $owner = 1;
 while(@ARGV > 0) {
-	local $a = shift(@ARGV);
+	my $a = shift(@ARGV);
 	if ($a eq "--ip") {
 		$ip = shift(@ARGV);
 		}

--- a/delete-template.pl
+++ b/delete-template.pl
@@ -31,7 +31,7 @@ if (!$module_name) {
 # Parse command-line args
 $owner = 1;
 while(@ARGV > 0) {
-	local $a = shift(@ARGV);
+	my $a = shift(@ARGV);
 	if ($a eq "--name") {
 		$tmplname = shift(@ARGV);
 		}

--- a/delete-user.pl
+++ b/delete-user.pl
@@ -30,7 +30,7 @@ if (!$module_name) {
 
 # Parse command-line args
 while(@ARGV > 0) {
-	local $a = shift(@ARGV);
+	my $a = shift(@ARGV);
 	if ($a eq "--domain") {
 		$domain = shift(@ARGV);
 		}

--- a/delete_users.cgi
+++ b/delete_users.cgi
@@ -83,11 +83,11 @@ else {
 	@hclash = ( );
 	foreach $user (@dusers) {
 		if (!$user->{'nomailfile'} && !&mail_under_home()) {
-			local ($mailsz) = &mail_file_size($user);
+			my ($mailsz) = &mail_file_size($user);
 			$total += $mailsz;
 			}
 		if (!$user->{'nocreatehome'} && $user->{'home'}) {
-			local $homesz = &disk_usage_kb($user->{'home'});
+			my $homesz = &disk_usage_kb($user->{'home'});
 			$total += $homesz*1024;
 			}
 

--- a/detect-scripts.pl
+++ b/detect-scripts.pl
@@ -39,7 +39,7 @@ if (!$module_name) {
 
 # Parse command-line args
 while(@ARGV > 0) {
-	local $a = shift(@ARGV);
+	my $a = shift(@ARGV);
 	if ($a eq "--domain") {
 		$dname = shift(@ARGV);
 		}

--- a/disable-domain.pl
+++ b/disable-domain.pl
@@ -50,7 +50,7 @@ $second_print = \&second_text_print;
 
 # Parse command-line args
 while(@ARGV > 0) {
-	local $a = shift(@ARGV);
+	my $a = shift(@ARGV);
 	if ($a eq "--domain") {
 		$domain = lc(shift(@ARGV));
 		}

--- a/disable-feature.pl
+++ b/disable-feature.pl
@@ -42,7 +42,7 @@ if (!$module_name) {
 
 # Parse command-line args
 while(@ARGV > 0) {
-	local $a = shift(@ARGV);
+	my $a = shift(@ARGV);
 	if ($a eq "--domain") {
 		push(@dnames, shift(@ARGV));
 		}
@@ -178,7 +178,7 @@ foreach $d (sort { ($b->{'alias'} ? 2 : $b->{'parent'} ? 1 : 0) <=>
 
 	# Run the after command
 	&set_domain_envs($d, "MODIFY_DOMAIN");
-	local $merr = &made_changes();
+	my $merr = &made_changes();
 	&$second_print(&text('setup_emade', "<tt>$merr</tt>")) if (defined($merr));
 	&reset_domain_envs($d);
 

--- a/disable-limit.pl
+++ b/disable-limit.pl
@@ -40,7 +40,7 @@ $outdent_print = \&outdent_text_print;
 
 # Parse command-line args
 while(@ARGV > 0) {
-	local $a = shift(@ARGV);
+	my $a = shift(@ARGV);
 	if ($a eq "--domain") {
 		push(@dnames, shift(@ARGV));
 		}

--- a/disconnect-database.pl
+++ b/disconnect-database.pl
@@ -31,7 +31,7 @@ if (!$module_name) {
 
 # Parse command-line args
 while(@ARGV > 0) {
-	local $a = shift(@ARGV);
+	my $a = shift(@ARGV);
 	if ($a eq "--domain") {
 		$domain = shift(@ARGV);
 		}

--- a/domain_form.cgi
+++ b/domain_form.cgi
@@ -115,7 +115,7 @@ if ($subdom) {
 	}
 else {
 	# Full domain name
-	local $force = $access{'forceunder'} && $parentdom ?
+	my $force = $access{'forceunder'} && $parentdom ?
 			".$parentdom->{'dom'}" :
 		       $access{'subdom'} ? ".$access{'subdom'}" : undef;
 	print &ui_table_row(&hlink($text{'form_domain'}, "domainname"),
@@ -174,7 +174,7 @@ $js .= "function select_template(num)\n";
 $js .= "{\n";
 $js .= "var domain_form_target = document.querySelectorAll('form[action*=\"domain_setup.cgi\"]');\n";
 foreach $t (@availtmpls) {
-	local $tmpl = &get_template($t->{'id'});
+	my $tmpl = &get_template($t->{'id'});
 	if (!$parentdom && &can_choose_ugroup()) {
 		# Set group for unix user
 		$js .= "if (num == $tmpl->{'id'}) {\n";
@@ -241,7 +241,7 @@ foreach $plan (@availplans) {
 
 	# Set features if configured
 	if ($config{'plan_auto'}) {
-		local @fl = $plan->{'featurelimits'} ?
+		my @fl = $plan->{'featurelimits'} ?
 				split(/\s+/, $plan->{'featurelimits'}) :
 				@def_features;
 		foreach $f (@dom_features, @fplugins) {
@@ -338,7 +338,7 @@ if (!$parentuser) {
 
 	if (&can_choose_ugroup()) {
 		# Group for Unix user
-		local $ug = $deftmpl->{'ugroup'};
+		my $ug = $deftmpl->{'ugroup'};
 		$ug = "" if ($ug eq "none");
 		print &ui_table_row(&hlink($text{'form_group'},"unixgroupname"),
 			&ui_opt_textbox("group", $ug, 15,
@@ -434,7 +434,7 @@ if (!$parentuser && !$config{'template_auto'}) {
 
 	# Show input for restriction of number of sub-domains this domain
 	# owner can create
-	local $dlm = $defplan->{'domslimit'} eq '' ? 2 :
+	my $dlm = $defplan->{'domslimit'} eq '' ? 2 :
 		     $defplan->{'domslimit'} eq '0' ? 1 : 2;
 	print &ui_table_row(&hlink($text{'form_domslimit'}, "domslimit"),
 		&ui_radio("domslimit_def", $dlm,

--- a/domain_setup.cgi
+++ b/domain_setup.cgi
@@ -153,7 +153,7 @@ if (!$parentuser) {
 	if (!$in{'group_def'} && &can_choose_ugroup()) {
 		$in{'group'} = lc($in{'group'});
 		$in{'group'} eq $group && &error(&text('setup_egroup3', $group));
-		local ($sg) = &get_domain_by("group", $in{'group'});
+		my ($sg) = &get_domain_by("group", $in{'group'});
 		$sg && &error(&text('setup_egroup4', $sg->{'dom'}));
 		}
 	$home_base || &error($text{'setup_ehomebase'});
@@ -195,7 +195,7 @@ if (!$parentuser) {
 
 	# Check password restrictions
 	if (defined($pass)) {
-		local $fakeuser = { 'user' => $user, 'plainpass' => $pass };
+		my $fakeuser = { 'user' => $user, 'plainpass' => $pass };
 		$err = &check_password_restrictions($fakeuser, $in{'webmin'});
 		&error(&text('setup_epassvalid', $err)) if ($err);
 		}
@@ -291,7 +291,7 @@ if (&can_dnsip()) {
 	}
 
 # Make sure domain is under parent, if required
-local $derr = &allowed_domain_name($parentdom, $dname);
+my $derr = &allowed_domain_name($parentdom, $dname);
 &error($derr) if ($derr);
 
 if ($parentuser) {

--- a/download-dropbox-file.pl
+++ b/download-dropbox-file.pl
@@ -30,7 +30,7 @@ if (!$module_name) {
 # Parse command-line args
 $owner = 1;
 while(@ARGV > 0) {
-	local $a = shift(@ARGV);
+	my $a = shift(@ARGV);
 	if ($a eq "--dest") {
 		$dest = shift(@ARGV);
 		}

--- a/download-rs-file.pl
+++ b/download-rs-file.pl
@@ -35,7 +35,7 @@ if (!$module_name) {
 # Parse command-line args
 $tries = 1;
 while(@ARGV > 0) {
-	local $a = shift(@ARGV);
+	my $a = shift(@ARGV);
 	if ($a eq "--dest") {
 		$dest = shift(@ARGV);
 		}

--- a/download-s3-file.pl
+++ b/download-s3-file.pl
@@ -35,7 +35,7 @@ if (!$module_name) {
 # Parse command-line args
 $owner = 1;
 while(@ARGV > 0) {
-	local $a = shift(@ARGV);
+	my $a = shift(@ARGV);
 	if ($a eq "--dest") {
 		$dest = shift(@ARGV);
 		}

--- a/dynip-lib.pl
+++ b/dynip-lib.pl
@@ -21,11 +21,11 @@ return ( { 'name' => 'dyndns',
 # sent (if called in an array context)
 sub get_last_dynip_update
 {
-local ($service) = @_;
-local $file = "$module_config_directory/dynip.$service";
-local $ip = &read_file_contents($file);
+my ($service) = @_;
+my $file = "$module_config_directory/dynip.$service";
+my $ip = &read_file_contents($file);
 $ip =~ s/\r|\n//g;
-local @st = stat($file);
+my @st = stat($file);
 return wantarray ? ( $ip, $st[9] ) : $ip;
 }
 
@@ -33,8 +33,8 @@ return wantarray ? ( $ip, $st[9] ) : $ip;
 # Stores the IP that was successfully sent to the dynamic DNS service
 sub set_last_dynip_update
 {
-local ($service, $ip) = @_;
-local $file = "$module_config_directory/dynip.$service";
+my ($service, $ip) = @_;
+my $file = "$module_config_directory/dynip.$service";
 if ($ip) {
 	&open_tempfile(DYNIP, ">$file");
 	&print_tempfile(DYNIP, $ip,"\n");
@@ -277,7 +277,7 @@ foreach my $d (&list_domains()) {
 
 		# Update all features
 		foreach my $f (@features) {
-			local $mfunc = "modify_$f";
+			my $mfunc = "modify_$f";
 			if ($config{$f} && $d->{$f}) {
 				&try_function($f, $mfunc, $d, $oldd);
 				}
@@ -295,7 +295,7 @@ foreach my $d (&list_domains()) {
 
 		# Run the after command
 		&set_domain_envs($d, "MODIFY_DOMAIN", undef, \%oldd);
-		local $merr = &made_changes();
+		my $merr = &made_changes();
 		&$second_print(&text('setup_emade', "<tt>$merr</tt>"))
 			if (defined($merr));
 		&reset_domain_envs($d);

--- a/edit_alias.cgi
+++ b/edit_alias.cgi
@@ -91,7 +91,7 @@ else {
 # Print start of the alias form, either for simple or complex mode
 sub alias_form_start
 {
-local ($sfx) = @_;
+my ($sfx) = @_;
 my @tds = ( "width=30%" );
 print &ui_table_start($text{'alias_header'}, "width=100%", 2);
 

--- a/edit_bucket.cgi
+++ b/edit_bucket.cgi
@@ -171,9 +171,9 @@ else {
 # Returns HTML for selecting a day or date policy
 sub days_date_field
 {
-local ($name, $obj) = @_;
-local $mode = $obj->{'Days'} ? 1 : $obj->{'Date'} ? 2 : 0;
-local ($y, $m, $d) = $obj->{'Date'} =~ /^(\d+)\-(\d+)\-(\d+)/ ?
+my ($name, $obj) = @_;
+my $mode = $obj->{'Days'} ? 1 : $obj->{'Date'} ? 2 : 0;
+my ($y, $m, $d) = $obj->{'Date'} =~ /^(\d+)\-(\d+)\-(\d+)/ ?
 			($1, $2, $3) : ( );
 return &ui_radio($name, $mode,
 	[ [ 0, $text{'bucket_lnever'}."<br>" ],

--- a/edit_newfeatures.cgi
+++ b/edit_newfeatures.cgi
@@ -24,7 +24,7 @@ foreach $f (@features) {
 		next;
 		}
 
-	local @acts;
+	my @acts;
 	push(@acts, ui_link("search.cgi?field=$f&what=1",
 		                $text{'features_used'}));
 	my $vital = &indexof($f, @vital_features) >= 0;
@@ -77,8 +77,8 @@ foreach $m (sort { $a->{'desc'} cmp $b->{'desc'} } &get_all_module_infos()) {
 	$mdir = &module_root_directory($m->{'dir'});
 	if (-r "$mdir/virtual_feature.pl") {
 		&foreign_require($m->{'dir'}, "virtual_feature.pl");
-		local @acts;
-		local $config_link = &plugin_call($m->{'dir'},
+		my @acts;
+		my $config_link = &plugin_call($m->{'dir'},
 						  "feature_config_link");
 		if ($config_link || -r "$mdir/config.info") {
 			push(@acts, ui_link($config_link ||

--- a/edit_newlinks.cgi
+++ b/edit_newlinks.cgi
@@ -96,7 +96,7 @@ if ($in{'refresh'}) {
 
 sub shorten_category
 {
-local ($desc, $max) = @_;
+my ($desc, $max) = @_;
 $max ||= 12;
 if (length($desc) > $max) {
 	return substr($desc, 0, $max-2)."...";

--- a/edit_newplan.cgi
+++ b/edit_newplan.cgi
@@ -12,7 +12,7 @@ $bsize = &quota_bsize("home");
 @table = ( );
 $defplan = &get_default_plan(1);
 foreach $plan (@plans) {
-	local @cols;
+	my @cols;
 	push(@cols, { 'type' => 'checkbox', 'name' => 'd',
 		      'value' => $plan->{'id'} });
 	push(@cols, ui_link("edit_plan.cgi?id=$plan->{'id'}'",

--- a/edit_plugconfig.cgi
+++ b/edit_plugconfig.cgi
@@ -21,7 +21,7 @@ $mdir = defined(&module_root_directory) ? &module_root_directory($m)
 if (-r "$mdir/config_info.pl") {
 	# Module has a custom config editor
 	&foreign_require($m, "config_info.pl");
-	local $fn = "${m}::config_form";
+	my $fn = "${m}::config_form";
 	if (defined(&$fn)) {
 		$func++;
 		&foreign_call($m, "config_form", \%pconfig);

--- a/edit_record.cgi
+++ b/edit_record.cgi
@@ -190,8 +190,8 @@ else {
 # Returns a field for entering a TTL
 sub ttl_field
 {
-local ($name, $ttl) = @_;
-local $ttl_units;
+my ($name, $ttl) = @_;
+my $ttl_units;
 if ($ttl =~ /^(\d+)([a-z])$/i) {
 	$ttl = $1;
 	$ttl_units = lc($2);

--- a/edit_script.cgi
+++ b/edit_script.cgi
@@ -107,10 +107,10 @@ if (!$have_kit) {
 		}
 	
 	# If httpdauth option is available, show if enabled 
-	local $httpdauth_ifunc =
+	my $httpdauth_ifunc =
 		"script_".$sinfo->{'name'}."_httpdauth_is_enabled";
 	if (defined($opts->{'httpdauth'}) || defined(&$httpdauth_ifunc)) {
-		local $httpdauth_enabled = $opts->{'httpdauth'} ? 1 : 0;
+		my $httpdauth_enabled = $opts->{'httpdauth'} ? 1 : 0;
 		$httpdauth_enabled = &$httpdauth_ifunc($d, $opts) ? 1 : 0
 			if (defined(&$httpdauth_ifunc));
 		$content .= &ui_table_row(

--- a/edit_tmpl.cgi
+++ b/edit_tmpl.cgi
@@ -113,20 +113,20 @@ print "<script>",&virtualmin_ui_apply_radios(),"</script>\n";
 #		 &disable-fields, [no-disable-on-none])
 sub none_def_input
 {
-local ($name, $value, $final, $nonone, $nodef, $nonemsg, $dis, $nodisnone) = @_;
-local $rv;
-local $mode = $value eq "none" ? 0 :
+my ($name, $value, $final, $nonone, $nodef, $nonemsg, $dis, $nodisnone) = @_;
+my $rv;
+my $mode = $value eq "none" ? 0 :
 	      $value eq "" ? 1 : 2;
-local @opts;
+my @opts;
 push(@opts, 0) if (!$nonone);
 push(@opts, 1) if (!$tmpl->{'default'} && !$nodef);
 push(@opts, 2);
 if (@opts > 1) {
-	local $m;
-	local $dis1 = @$dis ? &js_disable_inputs($dis, [ ]) : undef;
-	local $dis2 = @$dis ? &js_disable_inputs([ ], $dis) : undef;
+	my $m;
+	my $dis1 = @$dis ? &js_disable_inputs($dis, [ ]) : undef;
+	my $dis2 = @$dis ? &js_disable_inputs([ ], $dis) : undef;
 	foreach $m (@opts) {
-		local $disn = $m == 2 ? $dis2 :
+		my $disn = $m == 2 ? $dis2 :
 			      $m == 0 && $nodisnone ? $dis2 :
 			      $m == 0 && !$nodisnone ? $dis1 :
 				        $dis1;

--- a/edit_user.cgi
+++ b/edit_user.cgi
@@ -125,8 +125,8 @@ if ($user_type eq 'ssh') {
 
 	if ($showhome) {
 		# Show home directory editing field
-		local $reshome = &resolve_links($user->{'home'});
-		local $helppage = "userhome";
+		my $reshome = &resolve_links($user->{'home'});
+		my $helppage = "userhome";
 		if ($user->{'brokenhome'}) {
 			# Home directory is in odd location, and so cannot
 			# be edited
@@ -221,7 +221,7 @@ elsif ($user_type eq 'ftp') {
 			}
 		elsif ($user->{'webowner'}) {
 			# Home can be public_html or a sub-dir
-			local $phd = &public_html_dir($d);
+			my $phd = &public_html_dir($d);
 			$homefield = &ui_radio("home_def", 1 ? 1 : 0,
 					[ [ 1, $text{'user_home2'} ],
 					  [ 0, $text{'user_homeunder2'} ] ]).
@@ -325,7 +325,7 @@ elsif ($user_type eq 'mail') {
 		@extra = @{$user->{'extraemail'}};
 		foreach $e (@extra) {
 			if ($e =~ /^(\S*)\@(\S+)$/) {
-				local ($eu, $ed) = ($1, $2);
+				my ($eu, $ed) = ($1, $2);
 				$ed = &show_domain_name($ed);
 				$e = $eu."\@".$ed;
 				}
@@ -705,7 +705,7 @@ else {
 				         &ui_textbox("mailpass", undef, 20) ]);
 			$pwfield = &ui_radio("mailpass_def", $mode, \@opts);
 			if ($user->{'change'}) {
-				local $tm = timelocal(gmtime($user->{'change'} *
+				my $tm = timelocal(gmtime($user->{'change'} *
 							     60*60*24));
 				$pwfield .= "&nbsp;&nbsp;".
 				    &text('user_lastch', &make_date($tm, 1));
@@ -830,8 +830,8 @@ else {
 
 	if ($showhome) {
 		# Show home directory editing field
-		local $reshome = &resolve_links($user->{'home'});
-		local $helppage = "userhome";
+		my $reshome = &resolve_links($user->{'home'});
+		my $helppage = "userhome";
 		if ($user->{'brokenhome'}) {
 			# Home directory is in odd location, and so cannot
 			# be edited
@@ -840,8 +840,8 @@ else {
 			}
 		elsif ($user->{'webowner'}) {
 			# Home can be public_html or a sub-dir
-			local $phd = &public_html_dir($d);
-			local $auto = $in{'new'} ||
+			my $phd = &public_html_dir($d);
+			my $auto = $in{'new'} ||
 				      $reshome eq &resolve_links($phd);
 			$homefield = &ui_radio("home_def", $auto ? 1 : 0,
 					[ [ 1, $text{'user_home2'} ],
@@ -853,7 +853,7 @@ else {
 			}
 		else {
 			# Home is under server root, and so can be edited
-			local $auto = $in{'new'} ||
+			my $auto = $in{'new'} ||
 			$reshome eq
 			&resolve_links("$d->{'home'}/$config{'homes_dir'}/$pop3");
 			$homefield = &ui_radio("home_def", $auto ? 1 : 0,
@@ -900,8 +900,8 @@ else {
 
 		if ($hasmailfile && $config{'show_mailuser'}) {
 			# Show the user's mail file
-			local ($sz, $umf, $lastmod) = &mail_file_size($user);
-			local $link = &read_mail_link($user, $d);
+			my ($sz, $umf, $lastmod) = &mail_file_size($user);
+			my $link = &read_mail_link($user, $d);
 			if ($link) {
 				$mffield = "<a href='$link'><tt>$umf</tt></a>\n";
 				}
@@ -928,7 +928,7 @@ else {
 			@extra = @{$user->{'extraemail'}};
 			foreach $e (@extra) {
 				if ($e =~ /^(\S*)\@(\S+)$/) {
-					local ($eu, $ed) = ($1, $2);
+					my ($eu, $ed) = ($1, $2);
 					$ed = &show_domain_name($ed);
 					$e = $eu."\@".$ed;
 					}
@@ -1144,7 +1144,7 @@ else {
 	if (&can_switch_usermin($d, $user) &&
 	    &foreign_installed("usermin", 1)) {
 		&foreign_require("usermin");
-		local %uminiserv;
+		my %uminiserv;
 		&usermin::get_usermin_miniserv_config(\%uminiserv);
 		if (&check_pid_file($uminiserv{'pidfile'}) &&
 		    &can_create_usermin_login_url(\%uminiserv)) {

--- a/enable-domain.pl
+++ b/enable-domain.pl
@@ -35,7 +35,7 @@ $second_print = \&second_text_print;
 
 # Parse command-line args
 while(@ARGV > 0) {
-	local $a = shift(@ARGV);
+	my $a = shift(@ARGV);
 	if ($a eq "--domain") {
 		$domain = lc(shift(@ARGV));
 		}

--- a/enable-feature.pl
+++ b/enable-feature.pl
@@ -44,7 +44,7 @@ if (!$module_name) {
 
 # Parse command-line args
 while(@ARGV > 0) {
-	local $a = shift(@ARGV);
+	my $a = shift(@ARGV);
 	if ($a eq "--domain") {
 		push(@dnames, shift(@ARGV));
 		}
@@ -212,7 +212,7 @@ foreach $d (sort { ($a->{'alias'} ? 2 : $a->{'parent'} ? 1 : 0) <=>
 
 	# Run the after command
 	&set_domain_envs($d, "MODIFY_DOMAIN", undef, $oldd);
-	local $merr = &made_changes();
+	my $merr = &made_changes();
 	&$second_print(&text('setup_emade', "<tt>$merr</tt>"))
 		if (defined($merr));
 	&reset_domain_envs($d);

--- a/enable-limit.pl
+++ b/enable-limit.pl
@@ -40,7 +40,7 @@ $outdent_print = \&outdent_text_print;
 
 # Parse command-line args
 while(@ARGV > 0) {
-	local $a = shift(@ARGV);
+	my $a = shift(@ARGV);
 	if ($a eq "--domain") {
 		push(@dnames, shift(@ARGV));
 		}

--- a/feature-dir.pl
+++ b/feature-dir.pl
@@ -5,7 +5,7 @@
 # own the files?
 sub check_depends_dir
 {
-local ($d) = @_;
+my ($d) = @_;
 if (!$d->{'parent'} && !$d->{'unix'}) {
 	return $text{'setup_edepunixdir'};
 	}
@@ -101,8 +101,8 @@ return 1;
 # Create the home directory for a server or sub-server
 sub create_domain_home_directory
 {
-local ($d, $uinfo) = @_;
-local $perms = oct($uconfig{'homedir_perms'});
+my ($d, $uinfo) = @_;
+my $perms = oct($uconfig{'homedir_perms'});
 if (&has_domain_user($d) && $d->{'parent'}) {
 	# Run as domain owner, as this is a sub-server
 	&make_dir_as_domain_user($d, $d->{'home'}, $perms, 1);
@@ -125,7 +125,7 @@ else {
 # Create and set permissions on standard directories
 sub create_standard_directories
 {
-local ($d) = @_;
+my ($d) = @_;
 foreach my $dir (&virtual_server_directories($d)) {
 	my $path = "$d->{'home'}/$dir->[0]";
 	&create_standard_directory_for_domain($d, $path, $dir->[1]);
@@ -163,15 +163,15 @@ else {
 # Rename home directory if needed
 sub modify_dir
 {
-local ($d, $oldd) = @_;
+my ($d, $oldd) = @_;
 
 # Special case .. converting alias to non-alias, so some directories need to
 # be created
 if ($oldd->{'alias'} && !$d->{'alias'}) {
 	&$first_print($text{'save_dirunalias'});
-	local $tmpl = &get_template($d->{'template'});
+	my $tmpl = &get_template($d->{'template'});
 	if ($tmpl->{'skel'} ne "none") {
-		local $uinfo = &get_domain_owner($d, 1);
+		my $uinfo = &get_domain_owner($d, 1);
 		&copy_skel_files(
 			&substitute_domain_template($tmpl->{'skel'}, $d),
 			$uinfo, $d->{'home'},
@@ -192,19 +192,19 @@ if ($d->{'home'} ne $oldd->{'home'}) {
 		if (defined(&set_php_wrappers_writable)) {
 			&set_php_wrappers_writable($d, 1);
 			}
-		local $wasjailed = 0;
+		my $wasjailed = 0;
 		if (!&check_jailkit_support() && !$oldd->{'parent'} &&
 		    &get_domain_jailkit($oldd)) {
 			# Turn off jail for the old home
 			&disable_domain_jailkit($oldd);
 			$wasjailed = 1;
 			}
-		local $cmd = $config{'move_command'} || "mv";
+		my $cmd = $config{'move_command'} || "mv";
 		$cmd .= " ".quotemeta($oldd->{'home'}).
 			" ".quotemeta($d->{'home'});
 		$cmd .= " 2>&1 </dev/null";
 		&set_domain_envs($oldd, "MODIFY_DOMAIN", $d);
-		local $out = &backquote_logged($cmd);
+		my $out = &backquote_logged($cmd);
 		&reset_domain_envs($oldd);
 		if ($?) {
 			&$second_print(&text('save_dirhomefailed',
@@ -234,14 +234,14 @@ if ($d->{'unix'} && !$oldd->{'unix'} ||
 	}
 if (!$d->{'subdom'} && $oldd->{'subdom'}) {
 	# No longer a sub-domain .. move the HTML dir
-	local $phsrc = &public_html_dir($oldd);
-	local $phdst = &public_html_dir($d);
+	my $phsrc = &public_html_dir($oldd);
+	my $phdst = &public_html_dir($d);
 	&copy_source_dest($phsrc, $phdst);
 	&unlink_file($phsrc);
 
 	# And the CGI directory
-	local $cgisrc = &cgi_bin_dir($oldd);
-	local $cgidst = &cgi_bin_dir($d);
+	my $cgisrc = &cgi_bin_dir($oldd);
+	my $cgidst = &cgi_bin_dir($d);
 	&copy_source_dest($cgisrc, $cgidst);
 	&unlink_file($cgisrc);
 	}
@@ -254,7 +254,7 @@ if (defined(&set_php_wrappers_writable)) {
 # Delete the home directory
 sub delete_dir
 {
-local ($d, $preserve) = @_;
+my ($d, $preserve) = @_;
 
 # Delete homedir
 &require_useradmin();
@@ -270,7 +270,7 @@ if (-d $d->{'home'} && &safe_delete_dir($d, $d->{'home'})) {
 	if (defined(&set_php_wrappers_writable)) {
 		&set_php_wrappers_writable($d, 1);
 		}
-	local $err = &backquote_logged("rm -rf ".quotemeta($d->{'home'}).
+	my $err = &backquote_logged("rm -rf ".quotemeta($d->{'home'}).
 				       " 2>&1");
 	if ($?) {
 		# Try again after running chattr
@@ -287,7 +287,7 @@ if (-d $d->{'home'} && &safe_delete_dir($d, $d->{'home'})) {
 		}
 	if ($err) {
 		# Ignore an error deleting a mount point
-		local @subs = &sub_mount_points($d->{'home'});
+		my @subs = &sub_mount_points($d->{'home'});
 		if (@subs) {
 			$err = undef;
 			}
@@ -306,14 +306,14 @@ return 1;
 # Copy home directory contents to a new cloned domain
 sub clone_dir
 {
-local ($d, $oldd) = @_;
+my ($d, $oldd) = @_;
 &$first_print($text{'clone_dir'});
 if (defined(&set_php_wrappers_writable)) {
 	&set_php_wrappers_writable($d, 1);
 	}
 
 # Exclude sub-server directories, logs, SSL certs and .zfs files
-local $xtemp = &transname();
+my $xtemp = &transname();
 &open_tempfile(XTEMP, ">$xtemp");
 &print_tempfile(XTEMP, "domains\n");
 &print_tempfile(XTEMP, "./domains\n");
@@ -361,7 +361,7 @@ if (!$d->{'parent'}) {
 if ($d->{'mail'}) {
 	&break_autoreply_alias_links($oldd);
 	}
-local $err = &backquote_logged(
+my $err = &backquote_logged(
 	       "cd ".quotemeta($oldd->{'home'})." && ".
 	       "tar cfX - ".quotemeta($xtemp)." . | ".
 	       "(cd ".quotemeta($d->{'home'})." && ".
@@ -392,23 +392,23 @@ else {
 # ownership
 sub validate_dir
 {
-local ($d) = @_;
+my ($d) = @_;
 
 # Make sure home dir exists and has the correct owner
 if (!-d $d->{'home'}) {
 	return &text('validate_edir', "<tt>$d->{'home'}</tt>");
 	}
-local @st = stat($d->{'home'});
-local $auser = &get_apache_user($d);
-local @ainfo = getpwnam($auser);
+my @st = stat($d->{'home'});
+my $auser = &get_apache_user($d);
+my @ainfo = getpwnam($auser);
 if ($d->{'uid'} && $st[4] != $d->{'uid'} && $st[4] != $ainfo[2]) {
-	local $owner = getpwuid($st[4]);
+	my $owner = getpwuid($st[4]);
 	return &text('validate_ediruser', "<tt>$d->{'home'}</tt>",
 		     $owner, $d->{'user'})
 	}
 if ($d->{'gid'} && $st[5] != $d->{'gid'} && $st[5] != $d->{'ugid'} &&
     $st[5] != $ainfo[3]) {
-	local $owner = getgrgid($st[5]);
+	my $owner = getgrgid($st[5]);
 	return &text('validate_edirgroup', "<tt>$d->{'home'}</tt>",
 		     $owner, $d->{'group'})
 	}
@@ -424,10 +424,10 @@ if (!$d->{'alias'}) {
 			return &text('validate_esubdir',
 				     "<tt>$sd->[0]</tt>")
 			}
-		local @st = stat("$d->{'home'}/$sd->[0]");
+		my @st = stat("$d->{'home'}/$sd->[0]");
 		if ($d->{'uid'} && $st[4] != $d->{'uid'} && $st[4] != $ainfo[2]) {
 			# UID is wrong
-			local $owner = getpwuid($st[4]);
+			my $owner = getpwuid($st[4]);
 			return &text('validate_esubdiruser',
 				     "<tt>$sd->[0]</tt>",
 				     $owner, $d->{'user'})
@@ -435,7 +435,7 @@ if (!$d->{'alias'}) {
 		if ($d->{'gid'} && $st[5] != $d->{'gid'} &&
 		    $st[5] != $d->{'ugid'} && $st[5] != $ainfo[3]) {
 			# GID is wrong
-			local $owner = getgrgid($st[5]);
+			my $owner = getgrgid($st[5]);
 			return &text('validate_esubdirgroup',
 				     "<tt>$sd->[0]</tt>",
 				     $owner, $d->{'group'})
@@ -470,14 +470,14 @@ return 0;
 # Backs up the server's home directory in tar format to the given file
 sub backup_dir
 {
-local ($d, $file, $opts, $homefmt, $increment, $asd, $allopts, $key, undef, $id) = @_;
-local $compression = $opts->{'compression'};
+my ($d, $file, $opts, $homefmt, $increment, $asd, $allopts, $key, undef, $id) = @_;
+my $compression = $opts->{'compression'};
 &$first_print($compression == 3 ? $text{'backup_dirzip'} :
 	      $increment == 1 || $increment >= 3 ? $text{'backup_dirtarinc'}
 					         : $text{'backup_dirtar'});
-local $out;
-local $cmd;
-local $destfile = $file;
+my $out;
+my $cmd;
+my $destfile = $file;
 if (!$homefmt) {
 	$destfile .= ".".&compression_to_suffix_inner($compression);
 	}
@@ -510,9 +510,9 @@ if ($homefmt) {
 	}
 
 # Create exclude file
-local $xtemp = &transname();
-local @xlist;
-local @ilist;
+my $xtemp = &transname();
+my @xlist;
+my @ilist;
 if ($opts->{'include'}) {
 	# Include only specific files
 	@ilist = split(/\t+/, $opts->{'exclude'});
@@ -602,8 +602,8 @@ if (&has_incremental_tar() && $increment != 2) {
 	}
 
 # Create the dest file with strict permissions
-local $qf = quotemeta($destfile);
-local $toucher = "touch $qf && chmod 600 $qf";
+my $qf = quotemeta($destfile);
+my $toucher = "touch $qf && chmod 600 $qf";
 if ($asd && $homefmt) {
 	$toucher = &command_as_user($asd->{'user'}, 0, $toucher);
 	}
@@ -611,7 +611,7 @@ if ($asd && $homefmt) {
 
 # Create the writer command. This will be run as the domain owner if this
 # is the final step of the backup process, and if the owner is doing the backup.
-local $writer = "cat >$qf";
+my $writer = "cat >$qf";
 if ($asd && $homefmt) {
 	$writer = &command_as_user($asd->{'user'}, 0, $writer);
 	}
@@ -650,7 +650,7 @@ else {
 	$cmd = &make_tar_command("cfX", "-", $xtemp, $iargs, @ilist);
 	}
 $cmd .= " | $writer";
-local $ex = &execute_command("cd ".quotemeta($d->{'home'})." && $cmd",
+my $ex = &execute_command("cd ".quotemeta($d->{'home'})." && $cmd",
 			     undef, \$out, \$out);
 &unlink_file($iflag) if ($iflag);
 &copy_source_dest($ifilecopy, $ifile) if ($ifilecopy);
@@ -682,7 +682,7 @@ else {
 # Returns HTML for the backup logs option
 sub show_backup_dir
 {
-local ($opts) = @_;
+my ($opts) = @_;
 return &ui_checkbox("dir_logs", 1, $text{'backup_dirlogs'},
 		    !$opts->{'dirnologs'})." ".
        &ui_checkbox("dir_homes", 1,
@@ -694,7 +694,7 @@ return &ui_checkbox("dir_logs", 1, $text{'backup_dirlogs'},
 # Parses the inputs for directory backup options
 sub parse_backup_dir
 {
-local %in = %{$_[0]};
+my %in = %{$_[0]};
 return { 'dirnologs' => $in{'dir_logs'} ? 0 : 1,
 	 'dirnohomes' => $in{'dir_homes'} ? 0 : 1 };
 }
@@ -703,7 +703,7 @@ return { 'dirnologs' => $in{'dir_logs'} ? 0 : 1,
 # Returns HTML for mail restore option inputs
 sub show_restore_dir
 {
-local ($opts) = @_;
+my ($opts) = @_;
 return &ui_checkbox("dir_homes", 1, $text{'restore_dirhomes'},
                     !$opts->{'dirnohomes'})."<br>\n".
        &ui_checkbox("dir_delete", 1, $text{'restore_dirdelete'},
@@ -714,7 +714,7 @@ return &ui_checkbox("dir_homes", 1, $text{'restore_dirhomes'},
 # Parses the inputs for mail backup options
 sub parse_restore_dir
 {
-local %in = %{$_[0]};
+my %in = %{$_[0]};
 return { 'dirnohomes' => !$in{'dir_homes'},
 	 'delete' => $in{'dir_delete'} };
 }
@@ -724,13 +724,13 @@ return { 'dirnohomes' => !$in{'dir_homes'},
 # Extracts the given tar file into server's home directory
 sub restore_dir
 {
-local ($d, $file, $opts, $allopts, $homefmt, $oldd, $asd, $key) = @_;
-local $srcfile = $file;
+my ($d, $file, $opts, $allopts, $homefmt, $oldd, $asd, $key) = @_;
+my $srcfile = $file;
 if (!-r $srcfile) {
 	($srcfile) = glob("$file.*");
 	}
 
-local $cf = &compression_format($srcfile, $key);
+my $cf = &compression_format($srcfile, $key);
 &$first_print($cf == 4 ? $text{'restore_dirzip'}
 	    	       : $text{'restore_dirtar'});
 
@@ -759,14 +759,14 @@ if ($osize && $config{'home_quotas'}) {
 		}
 	}
 
-local $iflag = "$d->{'home'}/.incremental";
+my $iflag = "$d->{'home'}/.incremental";
 &unlink_file($iflag);
 if (defined(&set_php_wrappers_writable)) {
 	&set_php_wrappers_writable($d, 1, 1);
 	}
 
 # Create exclude file, to skip local system-specific files
-local $xtemp = &transname();
+my $xtemp = &transname();
 &open_tempfile(XTEMP, ">$xtemp");
 my @exc = ( "cgi-bin/lang",	# Used by AWstats, and created locally .. so
 	    "cgi-bin/lib",	# no need to include in restore.
@@ -784,9 +784,9 @@ foreach my $e (@exc) {
 &close_tempfile(XTEMP);
 
 # Check if Apache logs were links before the restore
-local $alog = "$d->{'home'}/logs/access_log";
-local $elog = "$d->{'home'}/logs/error_log";
-local ($aloglink, $eloglink);
+my $alog = "$d->{'home'}/logs/access_log";
+my $elog = "$d->{'home'}/logs/error_log";
+my ($aloglink, $eloglink);
 if ($d->{'web'}) {
 	$aloglink = readlink($alog);
 	$eloglink = readlink($elog);
@@ -794,19 +794,19 @@ if ($d->{'web'}) {
 
 # If home dir is missing (perhaps due to deletion of /home), re-create it
 if (!-e $d->{'home'}) {
-	local $uinfo;
+	my $uinfo;
 	if ($d->{'unix'} || $d->{'parent'}) {
-		local @users = &list_all_users();
+		my @users = &list_all_users();
 		($uinfo) = grep { $_->{'user'} eq $d->{'user'} } @users;
 		}
 	&create_domain_home_directory($d, $uinfo);
 	}
 
-local $outfile = &transname();
-local $errfile = &transname();
-local $q = quotemeta($srcfile);
-local $qh = quotemeta($d->{'home'});
-local $catter;
+my $outfile = &transname();
+my $errfile = &transname();
+my $q = quotemeta($srcfile);
+my $qh = quotemeta($d->{'home'});
+my $catter;
 if ($key && $homefmt) {
 	$catter = &backup_decryption_command($key)." ".$q;
 	}
@@ -820,20 +820,20 @@ else {
 if ($cf == 4) {
 	# Unzip command does un-compression and un-archiving
 	# XXX ZIP doesn't support excludes of paths :-(
-	local $unzip = &has_command("unzip") || "unzip";
-	local $unzipcmd = quotemeta($unzip)." -o $q";
+	my $unzip = &has_command("unzip") || "unzip";
+	my $unzipcmd = quotemeta($unzip)." -o $q";
 	if ($asd) {
 		$unzipcmd = &command_as_user($d->{'user'}, 0, $unzipcmd);
 		}
 	&execute_command("cd $qh && $unzipcmd", undef, $outfile, $outfile);
 	}
 else {
-	local $comp = $cf == 1 ? &get_gunzip_command()." -c" :
+	my $comp = $cf == 1 ? &get_gunzip_command()." -c" :
 		      $cf == 2 ? "uncompress -c" :
 		      $cf == 3 ? &get_bunzip2_command()." -c" :
 		      $cf == 6 ? &get_unzstd_command() : "cat";
-	local $tarcmd = &make_tar_command("xvfX", "-", $xtemp);
-	local $reader = $catter." | ".$comp;
+	my $tarcmd = &make_tar_command("xvfX", "-", $xtemp);
+	my $reader = $catter." | ".$comp;
 	if ($asd) {
 		# Run extraction as the domain owner for untrusted/as-owner
 		# restores, matching the ZIP restore privilege boundary.
@@ -841,15 +841,15 @@ else {
 		}
 	&execute_command("cd $qh && $reader | $tarcmd", undef, $outfile,$errfile);
 	}
-local $ex = $?;
-local $out = &read_file_contents($outfile);
+my $ex = $?;
+my $out = &read_file_contents($outfile);
 $out =~ s/\\([0-7]+)/chr(oct($1))/ge;
-local $err = &read_file_contents($errfile);
+my $err = &read_file_contents($errfile);
 &enable_quotas($d);
 if ($ex) {
 	# Errors about utime in the tar extract are ignored when running
 	# as the domain owner
-	local $failout = $cf == 4 ? $out : $err;
+	my $failout = $cf == 4 ? $out : $err;
 	&$second_print(&text('backup_dirtarfailed',
 			     "<pre>".&html_escape($failout)."</pre>"));
 	return 0;
@@ -886,11 +886,11 @@ else {
 	&clear_incremental_files($d);
 
 	# Check if logs are links now .. if not, we need to move the files
-	local $new_aloglink = readlink($alog);
-	local $new_eloglink = readlink($elog);
+	my $new_aloglink = readlink($alog);
+	my $new_eloglink = readlink($elog);
 	if ($d->{'web'} && !$d->{'subdom'} && !$d->{'alias'}) {
-		local $new_alog = &get_website_log($d, 0);
-		local $new_elog = &get_website_log($d, 1);
+		my $new_alog = &get_website_log($d, 0);
+		my $new_elog = &get_website_log($d, 1);
 		if ($aloglink && !$new_aloglink) {
 			&system_logged("mv ".quotemeta($alog)." ".
 					     quotemeta($new_alog));
@@ -969,12 +969,12 @@ else {
 # the homes directory which is used by mail users
 sub set_home_ownership
 {
-local ($d) = @_;
-local $hd = $config{'homes_dir'};
+my ($d) = @_;
+my $hd = $config{'homes_dir'};
 $hd =~ s/^\.\///;
-local @users = grep { $_->{'unix'} && !$_->{'webowner'} }
+my @users = grep { $_->{'unix'} && !$_->{'webowner'} }
 		    &list_domain_users($d, 1, 1, 1, 1);
-local $gid = $d->{'gid'} || $d->{'ugid'};
+my $gid = $d->{'gid'} || $d->{'ugid'};
 foreach my $sd ($d, &get_domain_by("parent", $d->{'id'})) {
 	if (defined(&set_php_wrappers_writable)) {
 		&set_php_wrappers_writable($sd, 1);
@@ -1053,10 +1053,10 @@ return @changed_files;
 # Set the owners of all directories under ~/homes to their mailbox users
 sub set_mailbox_homes_ownership
 {
-local ($d) = @_;
-local $hd = $config{'homes_dir'};
+my ($d) = @_;
+my $hd = $config{'homes_dir'};
 $hd =~ s/^\.\///;
-local $homes = "$d->{'home'}/$hd";
+my $homes = "$d->{'home'}/$hd";
 foreach my $user (&list_domain_users($d, 1, 1, 1, 1)) {
 	if (&is_under_directory($homes, $user->{'home'}) &&
 	    !$user->{'webowner'} && $user->{'home'}) {
@@ -1095,9 +1095,9 @@ return @rv;
 # Creates the temporary files directory for a domain, and returns the path
 sub create_server_tmp
 {
-local ($d) = @_;
+my ($d) = @_;
 if ($d->{'dir'}) {
-	local $tmp = "$d->{'home'}/tmp";
+	my $tmp = "$d->{'home'}/tmp";
 	if (!-d $tmp) {
 		&make_dir_as_domain_user($d, $tmp, 0750, 1);
 		}
@@ -1113,7 +1113,7 @@ else {
 # Outputs HTML for editing directory-related template options
 sub show_template_dir
 {
-local ($tmpl) = @_;
+my ($tmpl) = @_;
 
 # The skeleton files directory
 print &ui_table_row(&hlink($text{'tmpl_skel'}, "template_skel"),
@@ -1151,7 +1151,7 @@ print &ui_table_row(&hlink($text{'tmpl_exclude'}, "template_exclude"),
 # Updates directory-related template options from %in
 sub parse_template_dir
 {
-local ($tmpl) = @_;
+my ($tmpl) = @_;
 
 # Save skeleton directory
 $tmpl->{'skel'} = &parse_none_def("skel");
@@ -1178,11 +1178,11 @@ else {
 # Copy default content files to the domain's HTML directory
 sub create_index_content
 {
-local ($d, $content, $over) = @_;
+my ($d, $content, $over) = @_;
 
 # Remove any existing index.* files that might be used instead
-local $dest = &public_html_dir($d);
-local @indexes = grep { -f $_ } glob("$dest/index.*");
+my $dest = &public_html_dir($d);
+my @indexes = grep { -f $_ } glob("$dest/index.*");
 if ($over) {
 	if (@indexes) {
 		&unlink_file(@indexes);
@@ -1249,7 +1249,7 @@ while(@srcs) {
 # Returns 1 if the domain's home dir is on a remote server
 sub remote_dir
 {
-local ($d) = @_;
+my ($d) = @_;
 my ($home_mtab, $home_fstab) = &mount_point($d->{'home'});
 my $tab = $home_mtab || $home_fstab;
 return $tab && $tab->[1] =~ /^[a-z0-9\.\_\-]+:/i ? $tab->[1] : undef;

--- a/feature-dns.pl
+++ b/feature-dns.pl
@@ -212,14 +212,14 @@ elsif (!$dnsparent) {
 		}
 
 	# Also notify slave servers, unless already added
-	local @slaves = &get_default_domain_slaves($d);
+	my @slaves = &get_default_domain_slaves($d);
 	if (@slaves && !$tmpl->{'namedconf_no_also_notify'}) {
-		local ($also) = grep { $_->{'name'} eq 'also-notify' }
+		my ($also) = grep { $_->{'name'} eq 'also-notify' }
 				     @{$dir->{'members'}};
 		if (!$also) {
 			$also = { 'name' => 'also-notify',
 				  'type' => 1 };
-			local @also;
+			my @also;
 			foreach my $s (@slaves) {
 				push(@also,
 				     { 'name' => &to_ipaddress($s->{'host'}) });
@@ -238,7 +238,7 @@ elsif (!$dnsparent) {
 		}
 
 	# Allow only localhost and slaves to transfer
-	local @trans = ( { 'name' => '127.0.0.1' },
+	my @trans = ( { 'name' => '127.0.0.1' },
 			 { 'name' => 'localnets' }, );
 	foreach my $s (@slaves) {
 		push(@trans, { 'name' => &to_ipaddress($s->{'host'}) });
@@ -261,7 +261,7 @@ elsif (!$dnsparent) {
 		}
 	my %donetrans;
 	@trans = grep { $_->{'name'} && !$donetrans{$_->{'name'}}++ } @trans;
-	local ($trans) = grep { $_->{'name'} eq 'allow-transfer' }
+	my ($trans) = grep { $_->{'name'} eq 'allow-transfer' }
 			      @{$dir->{'members'}};
 	if (!$trans && !$tmpl->{'namedconf_no_allow_transfer'}) {
 		$trans = { 'name' => 'allow-transfer',
@@ -270,16 +270,16 @@ elsif (!$dnsparent) {
 		push(@{$dir->{'members'}}, $trans);
 		}
 
-	local $pconf;
-	local $indent = 0;
-	local $addfile = &remote_foreign_call($r, "bind8", "add_to_file");
+	my $pconf;
+	my $indent = 0;
+	my $addfile = &remote_foreign_call($r, "bind8", "add_to_file");
 	if ($tmpl->{'dns_view'}) {
 		# Adding inside a view. This may use named.conf, or an include
 		# file references inside the view, if any
 		$pconf = &remote_foreign_call($r, "bind8", "get_config_parent");
-		local $view = &get_bind_view($conf, $tmpl->{'dns_view'});
+		my $view = &get_bind_view($conf, $tmpl->{'dns_view'});
 		if ($view) {
-			local $addfileok;
+			my $addfileok;
 			if ($rbconfig->{'zones_file'} &&
 			    $view->{'file'} ne $rbconfig->{'zones_file'}) {
 				# BIND module config asks for a file .. make
@@ -325,10 +325,10 @@ elsif (!$dnsparent) {
 	# is a sub-domain, as they don't have their own domain. Also not
 	# possible if target uses another domain's zone file to store its
 	# records.
-	local $copyfromalias = &copy_alias_records($d);
+	my $copyfromalias = &copy_alias_records($d);
 
 	# Create the records file
-	local $rootfile = &remote_foreign_call($r, "bind8", "make_chroot", $file);
+	my $rootfile = &remote_foreign_call($r, "bind8", "make_chroot", $file);
 	if (!-d $rootfile) {
 		&remote_foreign_call($r, "bind8", "unlink_logged", $rootfile);
 		}
@@ -357,10 +357,10 @@ elsif (!$dnsparent) {
 		}
 
 	# Create on slave servers
-	local $myip = $rbconfig->{'this_ip'} ||
+	my $myip = $rbconfig->{'this_ip'} ||
 		      &to_ipaddress(&get_system_hostname());
 	if (@slaves && !$d->{'noslaves'}) {
-		local $slaves = join(" ", map { $_->{'nsname'} ||
+		my $slaves = join(" ", map { $_->{'nsname'} ||
 						$_->{'host'} } @slaves);
 		&create_zone_on_slaves($d, $slaves);
 		}
@@ -389,7 +389,7 @@ else {
 		}
 	$d->{'dns_submode'} = 1;	# So we know how this was done
 	$d->{'dns_subof'} = $dnsparent->{'id'};
-	local ($already) = grep { $_->{'name'} eq $d->{'dom'}."." }
+	my ($already) = grep { $_->{'name'} eq $d->{'dom'}."." }
 				grep { $_->{'type'} eq 'A' } @$recs;
 	if ($already) {
 		# A record with the same name as the sub-domain exists .. we
@@ -421,7 +421,7 @@ $slave_error = $_[0];
 # Delete a domain from the BIND config
 sub delete_dns
 {
-local ($d) = @_;
+my ($d) = @_;
 &require_bind();
 if ($d->{'dns_cloud'} && !$d->{'dns_submode'}) {
 	# Delete from cloud DNS provider
@@ -450,7 +450,7 @@ elsif ($d->{'provision_dns'}) {
 	# Delete from provisioning server
 	&$first_print($text{'delete_bind_provision'});
 	if ($d->{'provision_dns_host'}) {
-		local $info = { 'domain' => $d->{'dom'},
+		my $info = { 'domain' => $d->{'dom'},
 				'host' => $d->{'provision_dns_host'} };
 		my ($ok, $msg) = &provision_api_call(
 			"unprovision-dns-zone", $info, 0);
@@ -476,7 +476,7 @@ elsif (!$d->{'dns_submode'}) {
 		&$first_print(&text('delete_bindremote', $r->{'host'}));
 		}
 	&obtain_lock_dns($d, 1);
-	local $z = &get_bind_zone($d->{'dom'}, undef, $d);
+	my $z = &get_bind_zone($d->{'dom'}, undef, $d);
 	if ($z) {
 		# Delete DS records in parent
 		&delete_parent_dnssec_ds_records($d);
@@ -493,9 +493,9 @@ elsif (!$d->{'dns_submode'}) {
 			}
 
 		# Delete the records file
-		local $file = &bind8::find("file", $z->{'members'});
+		my $file = &bind8::find("file", $z->{'members'});
 		if ($file) {
-			local $zonefile = &remote_foreign_call($r, "bind8",
+			my $zonefile = &remote_foreign_call($r, "bind8",
 				"make_chroot", $file->{'values'}->[0]);
 			&remote_foreign_call($r, "bind8", "unlink_logged",
 					     $zonefile,
@@ -525,7 +525,7 @@ elsif (!$d->{'dns_submode'}) {
 	}
 else {
 	# Delete records from parent zone
-	local $dnsparent = &get_domain($d->{'dns_subof'});
+	my $dnsparent = &get_domain($d->{'dns_subof'});
 	if (!$dnsparent) {
 		&$second_print($text{'delete_ebindsub'});
 		return;
@@ -533,13 +533,13 @@ else {
 	&$first_print(&text('delete_bindsub', $dnsparent->{'dom'}));
 	&obtain_lock_dns($dnsparent);
 	&delete_parent_dnssec_ds_records($d);
-	local ($recs, $file) = &get_domain_dns_records_and_file($dnsparent);
+	my ($recs, $file) = &get_domain_dns_records_and_file($dnsparent);
 	if (!$file) {
 		&$second_print(&text('save_nobind2', $recs));
 		return;
 		}
 	&pre_records_change($dnsparent);
-	local $withdot = $d->{'dom'}.".";
+	my $withdot = $d->{'dom'}.".";
 	foreach $r (@$recs) {
 		# Don't delete if outside sub-domain
 		next if ($r->{'name'} !~ /\Q$withdot\E$/);
@@ -612,16 +612,16 @@ return 1;
 # Copy all DNS records to a new domain
 sub clone_dns
 {
-local ($d, $oldd) = @_;
+my ($d, $oldd) = @_;
 &$first_print($text{'clone_dns'});
 if ($d->{'dns_submode'}) {
 	# Record cloning not needed for DNS sub-domains
 	&$second_print($text{'clone_dnssub'});
 	return 1;
 	}
-local ($orecs, $ofile) = &get_domain_dns_records_and_file($oldd);
-local ($recs, $file) = &get_domain_dns_records_and_file($d);
-local @dnskeys = grep { $_->{'type'} eq 'DNSKEY' } @$recs;
+my ($orecs, $ofile) = &get_domain_dns_records_and_file($oldd);
+my ($recs, $file) = &get_domain_dns_records_and_file($d);
+my @dnskeys = grep { $_->{'type'} eq 'DNSKEY' } @$recs;
 if (!$orecs) {
 	&$second_print($text{'clone_dnsold'});
 	return 0;
@@ -648,20 +648,20 @@ foreach my $r (@$orecs) {
 	&create_dns_record($recs, $file, $nr);
 	}
 &modify_records_domain_name($recs, $file, $oldd->{'dom'}, $d->{'dom'});
-local $oldip = $oldd->{'dns_ip'} || $oldd->{'ip'};
-local $newip = $d->{'dns_ip'} || $d->{'ip'};
+my $oldip = $oldd->{'dns_ip'} || $oldd->{'ip'};
+my $newip = $d->{'dns_ip'} || $d->{'ip'};
 if ($oldip ne $newip) {
 	&modify_records_ip_address($recs, $file, $oldip, $newip);
 	}
-local $oldip6 = $oldd->{'dns_ip6'} || $oldd->{'ip6'};
-local $newip6 = $d->{'dns_ip6'} || $d->{'ip6'};
+my $oldip6 = $oldd->{'dns_ip6'} || $oldd->{'ip6'};
+my $newip6 = $d->{'dns_ip6'} || $d->{'ip6'};
 if ($oldip6 && $oldip6 ne $newip6) {
 	&modify_records_ip_address($recs, $file, $oldip6, $newip6);
 	}
 
 # Find and delete sub-domain records, plus any DNSSEC records (since we need
 # to re-sign the zone)
-local @sublist = grep { $_->{'id'} ne $oldd->{'id'} &&
+my @sublist = grep { $_->{'id'} ne $oldd->{'id'} &&
 			$_->{'id'} ne $d->{'id'} &&
 			$_->{'dom'} =~ /\.\Q$oldd->{'dom'}\E$/ }
 		      &list_domains();
@@ -767,16 +767,16 @@ $d->{'dns_slave'} = join(" ", &unique(@oldslaves, @newslaves));
 # Delete a zone on all slave servers, from the dns_slave key. May print messages
 sub delete_zone_on_slaves
 {
-local ($d, $slaveslist) = @_;
-local $oldd = { %$d };
-local @delslaves = $slaveslist ? split(/\s+/, $slaveslist)
+my ($d, $slaveslist) = @_;
+my $oldd = { %$d };
+my @delslaves = $slaveslist ? split(/\s+/, $slaveslist)
 			       : split(/\s+/, $d->{'dns_slave'});
 &require_bind();
 if (@delslaves) {
 	# Delete from slave servers
 	&$first_print(&text('delete_bindslave', join(" ", @delslaves)));
-	local $tmpl = &get_template($d->{'template'});
-	local @slaveerrs = &bind8::delete_on_slaves(
+	my $tmpl = &get_template($d->{'template'});
+	my @slaveerrs = &bind8::delete_on_slaves(
 			$d->{'dom'}, \@delslaves,
 			$d->{'dns_view'} || $tmpl->{'dns_view'});
 	if (@slaveerrs) {
@@ -1303,12 +1303,12 @@ return $rv;
 # with quoting if needed
 sub join_record_values
 {
-local ($r, $oneline) = @_;
-local $j = join("", @{$r->{'values'}});
+my ($r, $oneline) = @_;
+my $j = join("", @{$r->{'values'}});
 if ($r->{'type'} eq 'SOA' && !$oneline) {
 	# Multiliple lines, with brackets
-	local $v = $r->{'values'};
-	local $sep = "\n\t\t\t";
+	my $v = $r->{'values'};
+	my $sep = "\n\t\t\t";
 	return "$v->[0] $v->[1] ($sep$v->[2]$sep$v->[3]".
 	       "$sep$v->[4]$sep$v->[5]$sep$v->[6] )";
 	}
@@ -1321,7 +1321,7 @@ elsif (($r->{'type'} eq 'TXT' || $r->{'type'} eq 'SPF') &&
 	}
 else {
 	# All one one line
-	local @rv;
+	my @rv;
 	foreach my $v (@{$r->{'values'}}) {
 		push(@rv, $v =~ /\s|\(|;/ || $r->{'type'} eq 'TXT' ?
 				"\"$v\"" : $v);
@@ -1334,12 +1334,12 @@ else {
 # Split a TXT record at 255 char boundaries
 sub split_long_txt_record
 {
-local ($str, $nobrackets) = @_;
+my ($str, $nobrackets) = @_;
 $str =~ s/^"//;
 $str =~ s/"$//;
-local @rv;
+my @rv;
 while($str) {
-	local $first = substr($str, 0, 255);
+	my $first = substr($str, 0, 255);
 	$str = substr($str, 255);
 	push(@rv, $first);
 	}
@@ -1355,7 +1355,7 @@ sub create_mail_records
 my ($recs, $file, $d, $ip, $ip6) = @_;
 my $tmpl = &get_template($d->{'template'});
 my $proxied = $tmpl->{'dns_cloud_proxy'};
-local $withdot = $d->{'dom'}.".";
+my $withdot = $d->{'dom'}.".";
 my $r = { 'name' => "mail.$withdot",
 	  'type' => "A",
 	  'proxied' => $proxied == 1 ? 1 : 0,
@@ -1379,11 +1379,11 @@ if ($d->{'ip6'} && $ip6) {
 # Adds MX records to a DNS domain
 sub create_mx_records
 {
-local ($recs, $file, $d, $ip, $ip6) = @_;
-local $withdot = $d->{'dom'}.".";
+my ($recs, $file, $d, $ip, $ip6) = @_;
+my $withdot = $d->{'dom'}.".";
 
 # MX for this system
-local $mxname = $tmpl->{'dns_mx'} && $tmpl->{'dns_mx'} ne 'none' ?
+my $mxname = $tmpl->{'dns_mx'} && $tmpl->{'dns_mx'} ne 'none' ?
 			$tmpl->{'dns_mx'}."." : "mail.$withdot";
 $mxname = &substitute_domain_template($mxname, $d);
 my $r = { 'name' => $withdot,
@@ -1395,12 +1395,12 @@ my ($already) = grep { $_->{'name'} eq $r->{'name'} &&
 
 # Add MX records for slaves, if enabled
 if (!$config{'secmx_nodns'}) {
-	local %ids = map { $_, 1 }
+	my %ids = map { $_, 1 }
 		split(/\s+/, $d->{'mx_servers'});
-	local @servers = grep { $ids{$_->{'id'}} } &list_mx_servers();
-	local $n = 10;
+	my @servers = grep { $ids{$_->{'id'}} } &list_mx_servers();
+	my $n = 10;
 	foreach my $s (@servers) {
-		local $mxhost = ($s->{'mxname'} || $s->{'host'}).".";
+		my $mxhost = ($s->{'mxname'} || $s->{'host'}).".";
 		my $r = { 'name' => $withdot,
 			  'type' => "MX",
 			  'values' => [ $n, $mxhost ] };
@@ -1416,14 +1416,14 @@ if (!$config{'secmx_nodns'}) {
 # Adds to a records file the needed records for some domain
 sub create_standard_records
 {
-local ($recs, $file, $d, $ip) = @_;
+my ($recs, $file, $d, $ip) = @_;
 my $tmpl = &get_template($d->{'template'});
 my $proxied = $tmpl->{'dns_cloud_proxy'};
 &require_bind();
-local $rootfile = &bind8::make_chroot($file);
-local $master = &get_master_nameserver($tmpl, $d);
-local $soa = &get_default_soa_record($d, $master);
-local @created_ns;
+my $rootfile = &bind8::make_chroot($file);
+my $master = &get_master_nameserver($tmpl, $d);
+my $soa = &get_default_soa_record($d, $master);
+my @created_ns;
 
 # Extract custom records from the template
 my @tmplrecs;
@@ -1489,14 +1489,14 @@ if (!$tmpl->{'dns_replace'} || $d->{'dns_submode'}) {
 			if ($tmpl->{'dns_prins'}) {
 				push(@created_ns, $master);
 				}
-			local $slave;
-			local @slaves = &get_default_domain_slaves($d);
+			my $slave;
+			my @slaves = &get_default_domain_slaves($d);
 			foreach $slave (@slaves) {
-				local @bn = $slave->{'nsname'} ?
+				my @bn = $slave->{'nsname'} ?
 					( $slave->{'nsname'} ) :
 					gethostbyname($slave->{'host'});
 				if ($bn[0]) {
-					local $full = $bn[0].".";
+					my $full = $bn[0].".";
 					push(@created_ns, $full);
 					}
 				}
@@ -1550,23 +1550,23 @@ if (!$tmpl->{'dns_replace'} || $d->{'dns_submode'}) {
 		}
 	
 	# Work out which records are already in the file
-	local $rd = $d;
+	my $rd = $d;
 	if ($d->{'dns_submode'}) {
 		$rd = &get_domain($d->{'dns_subof'});
 		}
-	local %already = map { $_->{'name'}, $_ }
+	my %already = map { $_->{'name'}, $_ }
 			     grep { $_->{'type'} eq 'A' } @$recs;
 
 	# Work out which records to add
-	local $withdot = $d->{'dom'}.".";
-	local @addrecs = split(/\s+/, $tmpl->{'dns_records'});
+	my $withdot = $d->{'dom'}.".";
+	my @addrecs = split(/\s+/, $tmpl->{'dns_records'});
 	if ($d->{'dns_initial_records'}) {
 		@addrecs = split(/\s+/, $d->{'dns_initial_records'});
 		}
 	if (!@addrecs || $addrecs[0] eq 'none') {
 		@addrecs = @default_automatic_dns_records;
 		}
-	local %addrecs = map { $_ eq "@" ? $withdot : $_.".".$withdot, 1 }
+	my %addrecs = map { $_ eq "@" ? $withdot : $_.".".$withdot, 1 }
 			     @addrecs;
 	delete($addrescs{'noneselected'});
 
@@ -1601,7 +1601,7 @@ if (!$tmpl->{'dns_replace'} || $d->{'dns_submode'}) {
 
 	# Add the localhost record - yes, I know it's lame, but some
 	# registrars require it!
-	local $n = "localhost.$withdot";
+	my $n = "localhost.$withdot";
 	if (!$already{$n} && $addrecs{$n}) {
 		&create_dns_record($recs, $file,
 			{ 'name' => $n,
@@ -1638,7 +1638,7 @@ if (!$tmpl->{'dns_replace'} || $d->{'dns_submode'}) {
 	# Add SPF record for domain, if defined and if it's not a sub-domain
 	if ($tmpl->{'dns_spf'} ne "none" &&
 	    !$d->{'dns_submode'} && !$d->{'nodnsspf'}) {
-		local $str = &bind8::join_spf(&default_domain_spf($d));
+		my $str = &bind8::join_spf(&default_domain_spf($d));
 		&create_dns_record($recs, $file,
 			{ 'name' => $withdot, type => 'TXT',
 			  'values' => [ $str ] });
@@ -1652,7 +1652,7 @@ if (!$tmpl->{'dns_replace'} || $d->{'dns_submode'}) {
 	# Add DMARC record for domain, if defined and if it's not a sub-domain
 	if ($tmpl->{'dns_dmarc'} ne "none" &&
 	    !$d->{'dns_submode'} && !$d->{'nodnsdmarc'}) {
-		local $str = &bind8::join_dmarc(&default_domain_dmarc($d));
+		my $str = &bind8::join_dmarc(&default_domain_dmarc($d));
 		&create_dns_record($recs, $file,
 			{ 'name' => "_dmarc.".$withdot, type => 'TXT',
 			  'values' => [ $str ] });
@@ -1700,33 +1700,33 @@ return $soa;
 # For a domain that is an alias, sync records from its target
 sub sync_alias_records
 {
-local ($recs, $file, $d, $ip, $ip6, $diff) = @_;
-local $tmpl = &get_template($d->{'template'});
-local $aliasd = &get_domain($d->{'alias'});
-local ($aliasrecs, $aliasfile) = &get_domain_dns_records_and_file($aliasd);
+my ($recs, $file, $d, $ip, $ip6, $diff) = @_;
+my $tmpl = &get_template($d->{'template'});
+my $aliasd = &get_domain($d->{'alias'});
+my ($aliasrecs, $aliasfile) = &get_domain_dns_records_and_file($aliasd);
 $aliasfile || return "No zone file for alias target $aliasd->{'dom'} found";
 @$aliasrecs || return "No records for alias target $aliasd->{'dom'} found";
-local $olddom = $aliasd->{'dom'};
-local $dom = $d->{'dom'};
-local $oldip = $aliasd->{'dns_ip'} || $aliasd->{'ip'};
-local $oldip6 = $aliasd->{'dns_ip6'} || $aliasd->{'ip6'};
+my $olddom = $aliasd->{'dom'};
+my $dom = $d->{'dom'};
+my $oldip = $aliasd->{'dns_ip'} || $aliasd->{'ip'};
+my $oldip6 = $aliasd->{'dns_ip6'} || $aliasd->{'ip6'};
 
 # Find sub-domains of the source, and sub-domains of this alias
-local @sublist = grep { $_->{'dns'} &&
+my @sublist = grep { $_->{'dns'} &&
 			$_->{'id'} ne $aliasd->{'id'} &&
 			$_->{'dom'} =~ /\.\Q$aliasd->{'dom'}\E$/ }
 		      &list_domains();
-local @sublist2 = grep { $_->{'dns'} &&
+my @sublist2 = grep { $_->{'dns'} &&
 			 $_->{'id'} ne $d->{'id'} &&
 			 $_->{'dom'} =~ /\.\Q$d->{'dom'}\E$/ }
 		       &list_domains();
 
 # Find records we already have
-local %already;
+my %already;
 foreach my $r (@$recs) {
 	$already{&dns_record_key($r, 1)}++;
 	}
-local %keep;
+my %keep;
 
 # Build list of master nameservers
 my %tmplns;
@@ -1735,9 +1735,9 @@ $tmplns{$master} = 1;
 foreach my $ns (&get_slave_nameservers($d)) {
 	$tmplns{$ns} = 1;
 	}
-local @slaves = &get_default_domain_slaves($d);
+my @slaves = &get_default_domain_slaves($d);
 foreach my $slave (@slaves) {
-	local @bn = $slave->{'nsname'} ?
+	my @bn = $slave->{'nsname'} ?
 		( $slave->{'nsname'} ) :
 		gethostbyname($slave->{'host'});
 	$tmplns{$bn[0]."."} = 1 if ($bn[0]);
@@ -1895,12 +1895,12 @@ return @rv;
 # Adds the webmail and admin DNS records, if requested in the template
 sub add_webmail_dns_records
 {
-local ($d, $force) = @_;
-local $tmpl = &get_template($d->{'template'});
+my ($d, $force) = @_;
+my $tmpl = &get_template($d->{'template'});
 &pre_records_change($d);
-local ($recs, $file) = &get_domain_dns_records_and_file($d);
+my ($recs, $file) = &get_domain_dns_records_and_file($d);
 return 0 if (!$file);
-local $count = &add_webmail_dns_records_to_file($d, $tmpl, $file, $recs,
+my $count = &add_webmail_dns_records_to_file($d, $tmpl, $file, $recs,
 						undef, $force);
 if ($count) {
 	&post_records_change($d, $recs, $file);
@@ -1918,12 +1918,12 @@ return $count;
 # in the template
 sub add_webmail_dns_records_to_file
 {
-local ($d, $tmpl, $file, $recs, $already, $force) = @_;
-local $count = 0;
-local $ip = $d->{'dns_ip'} || $d->{'ip'};
+my ($d, $tmpl, $file, $recs, $already, $force) = @_;
+my $count = 0;
+my $ip = $d->{'dns_ip'} || $d->{'ip'};
 my $proxied = $tmpl->{'dns_cloud_proxy'};
 foreach my $r ('webmail', 'admin') {
-	local $n = "$r.$d->{'dom'}.";
+	my $n = "$r.$d->{'dom'}.";
 	if (($tmpl->{'web_'.$r} || $force) && (!$already || !$already->{$n})) {
 		my $r = { 'name' => $n,
 			  'type' => 'A',
@@ -1941,14 +1941,14 @@ return $count;
 # Remove the webmail and admin DNS records
 sub remove_webmail_dns_records
 {
-local ($d) = @_;
+my ($d) = @_;
 &pre_records_change($d);
-local ($recs, $file) = &get_domain_dns_records_and_file($d);
+my ($recs, $file) = &get_domain_dns_records_and_file($d);
 return 0 if (!$file);
-local $count = 0;
+my $count = 0;
 foreach my $r (reverse('webmail', 'admin')) {
-	local $n = "$r.$d->{'dom'}.";
-	local ($rec) = grep { $_->{'name'} eq $n } @$recs;
+	my $n = "$r.$d->{'dom'}.";
+	my ($rec) = grep { $_->{'name'} eq $n } @$recs;
 	if ($rec) {
 		&delete_dns_record($recs, $rec->{'file'}, $rec);
 		$count++;
@@ -1969,7 +1969,7 @@ return $count;
 # AAAA record with the v6 address.
 sub add_ip6_records
 {
-local ($d, $recs, $file) = @_;
+my ($d, $recs, $file) = @_;
 &require_bind();
 if (!$file) {
 	($recs, $file) = &get_domain_dns_records_and_file($d);
@@ -1977,7 +1977,7 @@ if (!$file) {
 return 0 if (!$file);
 
 # Work out which AAAA records we already have
-local %already;
+my %already;
 foreach my $r (@$recs) {
 	if ($r->{'type'} eq 'AAAA' &&
 	    ($r->{'values'}->[0] eq $d->{'ip6'} ||
@@ -2034,7 +2034,7 @@ return $count;
 # Delete all AAAA records whose value is the domain's IP6 address
 sub remove_ip6_records
 {
-local ($d, $file, $recs) = @_;
+my ($d, $file, $recs) = @_;
 &require_bind();
 my $withdot = $d->{'dom'}.".";
 foreach my $r (@$recs) {
@@ -2055,14 +2055,14 @@ foreach my $r (@delrecs) {
 # IP address. Used in conjuction with save_domain_web_star.
 sub save_domain_matchall_record
 {
-local ($d, $star) = @_;
+my ($d, $star) = @_;
 my $tmpl = &get_template($d->{'template'});
 &pre_records_change($d);
-local ($recs, $file) = &get_domain_dns_records_and_file($d);
+my ($recs, $file) = &get_domain_dns_records_and_file($d);
 return 0 if (!$file);
-local $withstar = "*.".$d->{'dom'}.".";
-local ($r) = grep { $_->{'name'} eq $withstar } @$recs;
-local $any = 0;
+my $withstar = "*.".$d->{'dom'}.".";
+my ($r) = grep { $_->{'name'} eq $withstar } @$recs;
+my $any = 0;
 if ($star && !$r) {
 	# Need to add
 	my $ip = $d->{'dns_ip'} || $d->{'ip'};
@@ -2093,9 +2093,9 @@ return $any;
 # Check for the DNS domain and records file
 sub validate_dns
 {
-local ($d, $recs, $recsonly) = @_;
+my ($d, $recs, $recsonly) = @_;
 my $r = &require_bind($d);
-local $file;
+my $file;
 if ($d->{'dns_submode'}) {
 	# For a sub-domain, don't complain if parent is disabled
 	my $parent = &get_domain($d->{'dns_subof'});
@@ -2117,7 +2117,7 @@ if (!$recs) {
 		}
 	}
 return &text('validate_ednsfile', "<tt>$d->{'dom'}</tt>") if (!@$recs);
-local $absfile;
+my $absfile;
 if (!$d->{'provision_dns'} && !$d->{'dns_cloud'} &&
     !$d->{'dns_remote'} && $file) {
 	# Make sure file exists
@@ -2128,9 +2128,9 @@ if (!$d->{'provision_dns'} && !$d->{'dns_cloud'} &&
 	}
 if (!$d->{'provision_dns'} && !$d->{'dns_cloud'} && !$d->{'dns_submode'}) {
 	# Make sure it is a master
-	local $zone = &get_bind_zone($d->{'dom'}, undef, $d);
+	my $zone = &get_bind_zone($d->{'dom'}, undef, $d);
 	return &text('validate_edns', "<tt>$d->{'dom'}</tt>") if (!$zone);
-	local $type = &bind8::find_value("type", $zone->{'members'});
+	my $type = &bind8::find_value("type", $zone->{'members'});
 	return &text('validate_ednsnotype', "<tt>$d->{'dom'}</tt>") if (!$type);
 	return &text('validate_ednstype', "<tt>$d->{'dom'}</tt>",
 	     	     "<tt>$type</tt>", "<tt>master</tt>")
@@ -2156,9 +2156,9 @@ if ($d->{'dns_submode'}) {
 	$recs = [ grep { $_->{'name'} eq $d->{'dom'}.'.' ||
 			 $_->{'name'} =~ /\.\Q$d->{'dom'}\E\.$/ } @$recs ];
 	}
-local %got;
-local $ip = $d->{'dns_ip'} || $d->{'ip'};
-local $ip6 = $d->{'dns_ip6'} || $d->{'ip6'};
+my %got;
+my $ip = $d->{'dns_ip'} || $d->{'ip'};
+my $ip6 = $d->{'dns_ip6'} || $d->{'ip6'};
 foreach my $r (@$recs) {
 	$got{uc($r->{'type'})}++;
 	}
@@ -2189,20 +2189,20 @@ if (&domain_has_website($d)) {
 	}
 
 # If domain has email, make sure MX record points to this system
-local $prov = &get_domain_cloud_mail_provider($d, $d->{'cloud_mail_id'});
+my $prov = &get_domain_cloud_mail_provider($d, $d->{'cloud_mail_id'});
 if ($d->{'mail'} && $config{'mx_validate'} && !$prov) {
-	local @mxs = grep { $_->{'name'} eq $d->{'dom'}.'.' &&
+	my @mxs = grep { $_->{'name'} eq $d->{'dom'}.'.' &&
 			    $_->{'type'} eq 'MX' } @$recs;
-	local $defip = &get_default_ip();
-	local %inuse = &interface_ip_addresses();
+	my $defip = &get_default_ip();
+	my %inuse = &interface_ip_addresses();
 	if (@mxs) {
-		local $found;
-		local @mxips;
+		my $found;
+		my @mxips;
 		foreach my $mx (@mxs) {
-			local $mxh = $mx->{'values'}->[1];
+			my $mxh = $mx->{'values'}->[1];
 			$mxh .= ".".$d->{'dom'} if ($mxh !~ /\.$/);
 			$mxh =~ s/\.$//;
-			local $ip = &to_ipaddress($mxh);
+			my $ip = &to_ipaddress($mxh);
 			if ($ip && ($ip eq $d->{'ip'} ||
 				    $ip eq $d->{'dns_ip'} ||
 				    $ip eq $d->{'ip6'} ||
@@ -2212,7 +2212,7 @@ if ($d->{'mail'} && $config{'mx_validate'} && !$prov) {
 				$found = $ip;
 				last;
 				}
-			local ($arec) = grep { $_->{'name'} eq $mxh."." &&
+			my ($arec) = grep { $_->{'name'} eq $mxh."." &&
 					       $_->{'type'} eq 'A' } @$recs;
 			if ($arec) {
 				$ip = $arec->{'values'}->[0];
@@ -2238,7 +2238,7 @@ if (!$d->{'dns_submode'}) {
 	$got{'NS'} || $d->{'dns_cloud'} || return $text{'validate_ednsns2'};
 	foreach my $ns (map { $_->{'values'}->[0] }
 			    grep { $_->{'type'} eq 'NS' } @$recs) {
-		local ($arec) = grep { $_->{'name'} eq $ns &&
+		my ($arec) = grep { $_->{'name'} eq $ns &&
 				       ($_->{'type'} eq 'A' ||
 					$_->{'type'} eq 'AAAA') } @$recs;
 		$arec || &to_ipaddress($ns) || &to_ip6address($ns) ||
@@ -2250,9 +2250,9 @@ return join("<br>\n", @recerrs) if (@recerrs);
 # If possible, run named-checkzone
 if (defined(&bind8::supports_check_zone) && &bind8::supports_check_zone() &&
     !$d->{'provision_dns'} && !$d->{'dns_cloud'} && !$d->{'dns_submode'}) {
-	local $z = &get_bind_zone($d->{'dom'}, undef, $d);
+	my $z = &get_bind_zone($d->{'dom'}, undef, $d);
 	if ($z) {
-		local @errs = &remote_foreign_call(
+		my @errs = &remote_foreign_call(
 			$r, "bind8", "check_zone_records", $z);
 		if (@errs) {
 			return &text('validate_ednscheck',
@@ -2342,11 +2342,11 @@ return [ ];
 # Re-names this domain in named.conf with the .disabled suffix
 sub disable_dns
 {
-local ($d) = @_;
+my ($d) = @_;
 if ($d->{'provision_dns'}) {
 	# Lock on provisioning server
 	&$first_print($text{'disable_bind_provision'});
-	local $info = { 'domain' => $d->{'dom'},
+	my $info = { 'domain' => $d->{'dom'},
 			'host' => $d->{'provision_dns_host'},
 			'disable' => '' };
 	my ($ok, $msg) = &provision_api_call("modify-dns-zone", $info, 0);
@@ -2392,11 +2392,11 @@ else {
 		}
 	&obtain_lock_dns($d, 1);
 	my $r = &require_bind($d);
-	local $z = &get_bind_zone($d->{'dom'}, undef, $d);
-	local $ok;
+	my $z = &get_bind_zone($d->{'dom'}, undef, $d);
+	my $ok;
 	if ($z) {
-		local ($recs, $file) = &get_domain_dns_records_and_file($d);
-		local $rootfile = &remote_foreign_call(
+		my ($recs, $file) = &get_domain_dns_records_and_file($d);
+		my $rootfile = &remote_foreign_call(
 			$r, "bind8", "make_chroot", $z->{'file'});
 		$z->{'value'} = $z->{'values'}->[0] = $d->{'dom'}.".disabled";
 		my $pconf = &remote_foreign_call($r, "bind8",
@@ -2440,11 +2440,11 @@ else {
 # Re-names this domain in named.conf to remove the .disabled suffix
 sub enable_dns
 {
-local ($d) = @_;
+my ($d) = @_;
 if ($d->{'provision_dns'}) {
 	# Unlock on provisioning server
 	&$first_print($text{'enable_bind_provision'});
-	local $info = { 'domain' => $d->{'dom'},
+	my $info = { 'domain' => $d->{'dom'},
 			'host' => $d->{'provision_dns_host'},
 			'enable' => '' };
 	my ($ok, $msg) = &provision_api_call("modify-dns-zone", $info, 0);
@@ -2490,11 +2490,11 @@ else {
 		}
 	&obtain_lock_dns($d, 1);
 	my $r = &require_bind($d);
-	local $z = &get_bind_zone($d->{'dom'}, undef, $d);
-	local $ok;
+	my $z = &get_bind_zone($d->{'dom'}, undef, $d);
+	my $ok;
 	if ($z) {
-		local ($recs, $file) = &get_domain_dns_records_and_file($d);
-		local $rootfile = &remote_foreign_call(
+		my ($recs, $file) = &get_domain_dns_records_and_file($d);
+		my $rootfile = &remote_foreign_call(
 			$r, "bind8", "make_chroot", $z->{'file'});
 		$z->{'value'} = $z->{'values'}->[0] = $d->{'dom'};
 		my $pconf = &remote_foreign_call($r, "bind8",
@@ -2544,12 +2544,12 @@ sub get_bind_zone
 my ($name, $conf, $d) = @_;
 my $r = &require_bind($d);
 $conf ||= &remote_foreign_call($r, "bind8", "get_config");
-local @zones = &bind8::find("zone", $conf);
-local ($v, $z);
+my @zones = &bind8::find("zone", $conf);
+my ($v, $z);
 foreach $v (&bind8::find("view", $conf)) {
 	push(@zones, &bind8::find("zone", $v->{'members'}));
 	}
-local ($z) = grep { lc($_->{'value'}) eq lc($name) ||
+my ($z) = grep { lc($_->{'value'}) eq lc($name) ||
 		    lc($_->{'value'}) eq lc($name.".disabled") } @zones;
 return $z;
 }
@@ -2558,11 +2558,11 @@ return $z;
 # Signal BIND to re-load its configuration
 sub restart_bind
 {
-local ($d) = @_;
+my ($d) = @_;
 if ($d && $d->{'dns_subof'}) {
 	$d = &get_domain($d->{'dns_subof'});
 	}
-local $p = $d ? $d->{'provision_dns'} || $d->{'dns_cloud'}
+my $p = $d ? $d->{'provision_dns'} || $d->{'dns_cloud'}
 	      : $config{'provision_dns'} || &default_dns_cloud();
 if ($p) {
 	# Hosted on a provisioning server, so nothing to do
@@ -2575,9 +2575,9 @@ else {
 	&$first_print($text{'setup_bindpid'});
 	}
 my $r = &require_bind($d);
-local $bindlock = "$module_config_directory/bind-restart";
+my $bindlock = "$module_config_directory/bind-restart";
 &lock_file($bindlock);
-local $pid = &get_bind_pid($d);
+my $pid = &get_bind_pid($d);
 if ($pid) {
 	my $err = &remote_foreign_call($r, "bind8", "restart_bind");
 	if ($err) {
@@ -2593,11 +2593,11 @@ else {
 	$rv = 0;
 	}
 
-local @shosts = split(/\s+/, $d->{'dns_slave'});
+my @shosts = split(/\s+/, $d->{'dns_slave'});
 if (&bind8::list_slave_servers() && @shosts) {
 	# Re-start on slaves too
 	&$first_print(&text('setup_bindslavepids'));
-	local @slaveerrs = &bind8::restart_on_slaves(\@shosts);
+	my @slaveerrs = &bind8::restart_on_slaves(\@shosts);
 	if (@slaveerrs) {
 		&$second_print($text{'setup_bindeslave'});
 		foreach $sr (@slaveerrs) {
@@ -2619,7 +2619,7 @@ return $rv;
 # Tell BIND to reload the DNS records in some zone, using rndc / ndc if possible
 sub reload_bind_records
 {
-local ($d) = @_;
+my ($d) = @_;
 if ($d->{'dns_submode'}) {
 	# Reload in parent, which might be cloud hosted
 	$d = &get_domain($d->{'dns_subof'});
@@ -2629,12 +2629,12 @@ if ($d->{'provision_dns'} || $d->{'dns_cloud'}) {
 	return undef;
 	}
 my $r = &require_bind($d);
-local $err = &remote_foreign_call($r, "bind8", "restart_zone",
+my $err = &remote_foreign_call($r, "bind8", "restart_zone",
 				  $d->{'dom'}, $d->{'dns_view'});
 return undef if (!$err);
 &push_all_print();
 &set_all_null_print();
-local $rv = &restart_bind($d);
+my $rv = &restart_bind($d);
 &pop_all_print();
 return $rv;
 }
@@ -2700,7 +2700,7 @@ sub get_bind_pid
 {
 my ($d) = @_;
 my $r = &require_bind($r);
-local $pidfile = &remote_foreign_call($r, "bind8", "get_pid_file");
+my $pidfile = &remote_foreign_call($r, "bind8", "get_pid_file");
 $pidfile = &remote_foreign_call($r, "bind8", "make_chroot", $pidfile, 1);
 return &remote_foreign_call($r, "bind8", "check_pid_file", $pidfile);
 }
@@ -3023,8 +3023,8 @@ return 1;
 # Update the IP address in all DNS records
 sub modify_records_ip_address
 {
-local ($recs, $fn, $oldip, $newip, $dname) = @_;
-local $count = 0;
+my ($recs, $fn, $oldip, $newip, $dname) = @_;
+my $count = 0;
 foreach my $r (@$recs) {
 	my $changed = 0;
 	if ($dname && $r->{'name'} !~ /\.\Q$dname\E\.$/i &&
@@ -3057,7 +3057,7 @@ return $count;
 # Change the domain name in DNS record names and values
 sub modify_records_domain_name
 {
-local ($recs, $fn, $olddom, $newdom) = @_;
+my ($recs, $fn, $olddom, $newdom) = @_;
 foreach my $r (@$recs) {
 	next if (!$r->{'name'});	# TTL or generator
 	if ($r->{'realname'} eq '@' || $r->{'name'} eq $olddom.".") {
@@ -3100,11 +3100,11 @@ foreach my $r (@$recs) {
 # Returns the view object for the view to add domains to
 sub get_bind_view
 {
-local ($conf, $vname) = @_;
+my ($conf, $vname) = @_;
 &require_bind();
 $conf ||= &bind8::get_config();
-local @views = &bind8::find("view", $conf);
-local ($view) = grep { $_->{'values'}->[0] eq $vname } @views;
+my @views = &bind8::find("view", $conf);
+my ($view) = grep { $_->{'values'}->[0] eq $vname } @views;
 return $view;
 }
 
@@ -3126,14 +3126,14 @@ return ( );
 
 sub startstop_dns
 {
-local ($typestatus) = @_;
+my ($typestatus) = @_;
 if (&is_dns_remote()) {
 	# Cannot start or stop when remote
 	return ();
 	}
-local $bpid = defined($typestatus{'bind8'}) ?
+my $bpid = defined($typestatus{'bind8'}) ?
 		$typestatus{'bind8'} == 1 : &get_bind_pid();
-local @links = ( { 'link' => '/bind8/',
+my @links = ( { 'link' => '/bind8/',
 		   'desc' => $text{'index_bmanage'},
 		   'manage' => 1 } );
 if ($bpid && kill(0, $bpid)) {
@@ -3169,16 +3169,16 @@ return &bind8::stop_bind();
 # Outputs HTML for editing BIND related template options
 sub show_template_dns
 {
-local ($tmpl) = @_;
+my ($tmpl) = @_;
 &require_bind();
-local ($conf, @views);
+my ($conf, @views);
 if (!&is_dns_remote()) {
 	$conf = &bind8::get_config();
 	@views = &bind8::find("view", $conf);
 	}
 
 # DNS records
-local $ndi = &none_def_input("dns", $tmpl->{'dns'}, $text{'tmpl_dnsbelow'}, 0,
+my $ndi = &none_def_input("dns", $tmpl->{'dns'}, $text{'tmpl_dnsbelow'}, 0,
 			     0, $text{'tmpl_dnsnone'},
 			     [ "dns", "bind_replace" ]);
 print &ui_table_row(&hlink($text{'tmpl_dns'}, "template_dns"),
@@ -3202,7 +3202,7 @@ print &ui_table_row(&hlink($text{'tmpl_dnsrecords'}, "template_dns_records"),
 	&ui_grid_table(\@grid, scalar(@grid)));
 
 # Default TTL
-local $tmode = $tmpl->{'dns_ttl'} eq 'none' ? 0 :
+my $tmode = $tmpl->{'dns_ttl'} eq 'none' ? 0 :
 	       $tmpl->{'dns_ttl'} eq 'skip' ? 1 : 2;
 print &ui_table_row(&hlink($text{'tmpl_dnsttl'}, "template_dns_ttl"),
 	&ui_radio("dns_ttl_def", $tmpl->{'dns_ttl'} eq '' ? 0 :
@@ -3284,7 +3284,7 @@ print &ui_table_row(&hlink($text{'tmpl_dns_cloud_proxy'},
 		    [ 2, $text{'tmpl_dns_cloud_proxy2'} ] ]));
 
 # Create on slave DNS servers
-local @slaves = &bind8::list_slave_servers();
+my @slaves = &bind8::list_slave_servers();
 if (@slaves) {
 	print &ui_table_hr();
 
@@ -3449,7 +3449,7 @@ if (!&is_dns_remote()) {
 # Updates BIND related template options from %in
 sub parse_template_dns
 {
-local ($tmpl) = @_;
+my ($tmpl) = @_;
 
 # Save DNS settings
 $tmpl->{'dns'} = &parse_none_def("dns");
@@ -3459,14 +3459,14 @@ if ($in{"dns_mode"} == 2) {
 	$tmpl->{'dns_replace'} = $in{'bind_replace'};
 
 	&require_bind();
-	local $fakeip = "1.2.3.4";
-	local $fakedom = "foo.com";
-	local $recs = &substitute_virtualmin_template(
+	my $fakeip = "1.2.3.4";
+	my $fakedom = "foo.com";
+	my $recs = &substitute_virtualmin_template(
 			join("\n", split(/\t+/, $in{'dns'}))."\n",
 			{ 'ip' => $fakeip,
 			  'dom' => $fakedom,
 		 	  'web' => 1, });
-	local @recs = &text_to_dns_records($recs, "example.com");
+	my @recs = &text_to_dns_records($recs, "example.com");
 	foreach $r (@recs) {
 		$soa++ if ($r->{'name'} eq $fakedom."." &&
 			   $r->{'type'} eq "SOA");
@@ -3515,7 +3515,7 @@ if ($in{"dns_mode"} != 1) {
 
 	# Save additional nameservers
 	$in{'dnsns'} =~ s/\r//g;
-	local @ns = split(/\n+/, $in{'dnsns'});
+	my @ns = split(/\n+/, $in{'dnsns'});
 	foreach my $n (@ns) {
 		&check_ipaddress($n) && &error(&text('newdns_ensip', $n));
 		$n =~ /\$/ || &to_ipaddress($n) || &to_ip6address($n) ||
@@ -3598,7 +3598,7 @@ if (!&is_dns_remote()) {
 	$tmpl->{'namedconf'} = &parse_none_def("namedconf");
 	if ($in{'namedconf_mode'} == 2) {
 		# Make sure the directives are valid
-		local @recs = &text_to_named_conf($tmpl->{'namedconf'});
+		my @recs = &text_to_named_conf($tmpl->{'namedconf'});
 		if ($tmpl->{'namedconf'} =~ /\S/ && !@recs) {
 			&error($text{'newdns_enamedconf'});
 			}
@@ -3625,9 +3625,9 @@ if (!&is_dns_remote()) {
 # Returns the SPF object for a domain from its DNS records, or undef.
 sub get_domain_spf
 {
-local ($d) = @_;
+my ($d) = @_;
 &require_bind();
-local @recs = &get_domain_dns_records($d);
+my @recs = &get_domain_dns_records($d);
 foreach my $r (@recs) {
 	if (($r->{'type'} eq 'SPF' ||
 	     $r->{'type'} eq 'TXT' && $r->{'values'}->[0] =~ /^v=spf1/) &&
@@ -3642,26 +3642,26 @@ return undef;
 # Updates/creates/deletes a domain's SPF record.
 sub save_domain_spf
 {
-local ($d, $spf) = @_;
+my ($d, $spf) = @_;
 &require_bind();
-local ($recs, $file) = &get_domain_dns_records_and_file($d);
+my ($recs, $file) = &get_domain_dns_records_and_file($d);
 if (!$file) {
 	# Zone not found!
 	return;
 	}
-local @types = map { $_->{'type'} }
+my @types = map { $_->{'type'} }
 		   grep { $_->{'values'}->[0] =~ /^v=spf/ &&
 			  $_->{'name'} eq $d->{'dom'}.'.' } @$recs;
 if (!@types) {
 	@types = $bind8::config{'spf_record'} ? ( "SPF", "TXT" ) : ( "SPF" );
 	}
-local $bump = 0;
+my $bump = 0;
 &pre_records_change($d);
 foreach my $t (&unique(@types)) {
-	local ($r) = grep { $_->{'type'} eq $t &&
+	my ($r) = grep { $_->{'type'} eq $t &&
 			    $_->{'values'}->[0] =~ /^v=spf/ &&
 			    $_->{'name'} eq $d->{'dom'}.'.' } @$recs;
-	local $str = $spf ? &bind8::join_spf($spf) : undef;
+	my $str = $spf ? &bind8::join_spf($spf) : undef;
 	if ($r && $spf) {
 		# Update record
 		$r->{'values'} = [ $str ];
@@ -3768,9 +3768,9 @@ foreach my $d (grep { $_->{'dns'} } &list_domains()) {
 # Returns the DMARC object for a domain from its DNS records, or undef.
 sub get_domain_dmarc
 {
-local ($d) = @_;
+my ($d) = @_;
 &require_bind();
-local @recs = &get_domain_dns_records($d);
+my @recs = &get_domain_dns_records($d);
 foreach my $r (@recs) {
 	if (($r->{'type'} eq 'DMARC' || $r->{'type'} eq 'TXT') &&
 	    lc($r->{'name'}) eq '_dmarc.'.$d->{'dom'}.'.') {
@@ -3784,20 +3784,20 @@ return undef;
 # Updates/creates/deletes a domain's SPF record.
 sub save_domain_dmarc
 {
-local ($d, $dmarc) = @_;
+my ($d, $dmarc) = @_;
 &require_bind();
 &pre_records_change($d);
-local ($recs, $file) = &get_domain_dns_records_and_file($d);
+my ($recs, $file) = &get_domain_dns_records_and_file($d);
 if (!$file) {
 	# Domain not found!
 	return "DNS zone not found!";
 	}
-local $bump = 0;
-local ($r) = grep { ($_->{'type'} eq 'TXT' ||
+my $bump = 0;
+my ($r) = grep { ($_->{'type'} eq 'TXT' ||
 		     $_->{'type'} eq 'DMARC') &&
 		    $_->{'values'}->[0] =~ /^v=DMARC1/i &&
 		    lc($_->{'name'}) eq '_dmarc.'.$d->{'dom'}.'.' } @$recs;
-local $str = $dmarc ? &bind8::join_dmarc($dmarc) : undef;
+my $str = $dmarc ? &bind8::join_dmarc($dmarc) : undef;
 if ($r && $dmarc) {
 	# Update record
 	$r->{'values'} = [ $str ];
@@ -3845,8 +3845,8 @@ return $d->{'domain_dmarc_enabled'};
 # be found.
 sub get_domain_dns_records
 {
-local ($d) = @_;
-local ($recs, $file) = &get_domain_dns_records_and_file($d);
+my ($d) = @_;
+my ($recs, $file) = &get_domain_dns_records_and_file($d);
 return ( ) if (!$file);
 return @$recs;
 }
@@ -3855,7 +3855,7 @@ return @$recs;
 # Returns the chroot-relative path to a domain's DNS records
 sub get_domain_dns_file
 {
-local ($d) = @_;
+my ($d) = @_;
 if ($d->{'provision_dns'}) {
 	&error("get_domain_dns_file($d->{'dom'}) cannot be called ".
 	       "for cloudmin services domains");
@@ -3877,7 +3877,7 @@ my $r = &require_bind($d);
 my $z;
 if ($d->{'dns_submode'}) {
 	# Records are in super-domain
-	local $parent = &get_domain($d->{'dns_subof'});
+	my $parent = &get_domain($d->{'dns_subof'});
 	$z = &get_bind_zone($parent->{'dom'}, undef, $parent);
 	}
 else {
@@ -3895,10 +3895,10 @@ return $file->{'values'}->[0];
 # For a provisioned domain, this may be a local temp file.
 sub get_domain_dns_records_and_file
 {
-local ($d, $force) = @_;
+my ($d, $force) = @_;
 if ($d->{'dns_submode'}) {
 	# Records are in the parent domain, so just call this same method for it
-	local $parent = &get_domain($d->{'dns_subof'});
+	my $parent = &get_domain($d->{'dns_subof'});
 	return &get_domain_dns_records_and_file($parent);
 	}
 my $cid = $d->{'id'};
@@ -3910,15 +3910,15 @@ if (defined($domain_dns_records_cache{$cid}) && !$force) {
 local $bind8::config{'short_names'} = 0;
 
 # Create a temp file for writing downloaded records
-local ($temp, $abstemp);
+my ($temp, $abstemp);
 if ($d->{'dns_cloud'} || $d->{'provision_dns'} || $d->{'dns_remote'}) {
 	$temp = &transname();
 	$abstemp = $temp;
-	local $chroot = &bind8::get_chroot();
+	my $chroot = &bind8::get_chroot();
 	if ($chroot && $chroot ne "/") {
 		# Actual temp file needs to be under chroot dir
 		$abstemp = &bind8::make_chroot($temp);
-		local $absdir = $abstemp;
+		my $absdir = $abstemp;
 		$absdir =~ s/\/[^\/]+$//;
 		if (!-d $absdir) {
 			&make_dir($absdir, 0755, 1);
@@ -3943,7 +3943,7 @@ if ($d->{'dns_cloud'}) {
 	$cloud || return ("Cloud provider $ctype does not exist!");
 	my ($ok, $recs) = &$gfunc($d, $info);
 	return (&text('save_ereaddnscloud', $cloud->{'desc'}, $recs)) if (!$ok);
-	local $lnum = 0;
+	my $lnum = 0;
 	foreach my $rec (@$recs) {
 		&bind8::create_record($temp, $rec->{'name'},
 			$rec->{'ttl'}, $rec->{'class'}, $rec->{'type'},
@@ -3963,7 +3963,7 @@ elsif ($d->{'provision_dns'}) {
 	# Fetch from cloudmin services and write to temp file. The underlying
 	# BIND module API must be used here, because we need to write to an
 	# actual file.
-	local $info = { 'domain' => $d->{'dom'},
+	my $info = { 'domain' => $d->{'dom'},
 			'host' => $d->{'provision_dns_host'} };
 	my ($ok, $msg) = &provision_api_call(
 		"list-dns-records", $info, 1);
@@ -3971,10 +3971,10 @@ elsif ($d->{'provision_dns'}) {
 		return ("Failed to fetch DNS records from provisioning ".
 			"server : $msg");
 		}
-	local @recs;
-	local $lnum = 0;
+	my @recs;
+	my $lnum = 0;
 	foreach my $r (@$msg) {
-		local $rec;
+		my $rec;
 		if ($r->{'name'} eq '$ttl') {
 			$rec = { 'defttl' => $r->{'values'}->{'value'}->[0] };
 			&bind8::create_defttl($temp, $rec->{'defttl'});
@@ -4022,15 +4022,15 @@ elsif ($d->{'dns_remote'}) {
 	if ($@) {
 		return ($@);
 		}
-	local @recs = &bind8::read_zone_file($temp, $d->{'dom'}, undef, 0, 1);
+	my @recs = &bind8::read_zone_file($temp, $d->{'dom'}, undef, 0, 1);
 	&set_record_ids(\@recs);
 	@rv = (\@recs, $temp);
 	}
 else {
 	# Find local file
-	local $file = &get_domain_dns_file($d);
+	my $file = &get_domain_dns_file($d);
 	return ("No zone file found for $d->{'dom'}") if (!$file);
-	local @recs = &bind8::read_zone_file($file, $d->{'dom'});
+	my @recs = &bind8::read_zone_file($file, $d->{'dom'});
 	&set_record_ids(\@recs);
 	@rv = (\@recs, $file);
 	}
@@ -4051,7 +4051,7 @@ delete($domain_dns_records_cache{$cid});
 # Sets the ID field on a bunch of DNS records
 sub set_record_ids
 {
-local ($recs) = @_;
+my ($recs) = @_;
 foreach my $r (@$recs) {
 	if ($r->{'defttl'}) {
 		$r->{'id'} = join("/", '$ttl', $r->{'defttl'});
@@ -4154,11 +4154,11 @@ return $nr;
 # Returns a default SPF object for a domain, based on its template
 sub default_domain_spf
 {
-local ($d) = @_;
-local $tmpl = &get_template($d->{'template'});
-local $defip = &get_default_ip();
-local $defip6 = &get_default_ip6();
-local $spf = { 'a' => 1, 'mx' => 1,
+my ($d) = @_;
+my $tmpl = &get_template($d->{'template'});
+my $defip = &get_default_ip();
+my $defip6 = &get_default_ip6();
+my $spf = { 'a' => 1, 'mx' => 1,
 	       'a:' => [ $d->{'dom'} ],
 	       'ip4:' => [ ],
 	       'ip6:' => [ ] };
@@ -4168,7 +4168,7 @@ if ($defip ne "127.0.0.1" && !$tmpl->{'dns_spfonly'}) {
 if ($defip6 && !$tmpl->{'dns_spfonly'}) {
 	push(@{$spf->{'ip6:'}}, $defip6);
 	}
-local $hosts = &substitute_domain_template($tmpl->{'dns_spfhosts'}, $d);
+my $hosts = &substitute_domain_template($tmpl->{'dns_spfhosts'}, $d);
 foreach my $h (split(/\s+/, $hosts)) {
 	if (&check_ipaddress($h) ||
 	    $h =~ /^(\S+)\// && &check_ipaddress("$1")) {
@@ -4182,7 +4182,7 @@ foreach my $h (split(/\s+/, $hosts)) {
 		push(@{$spf->{'a:'}}, $h);
 		}
 	}
-local $includes = &substitute_domain_template($tmpl->{'dns_spfincludes'}, $d);
+my $includes = &substitute_domain_template($tmpl->{'dns_spfincludes'}, $d);
 foreach my $i (split(/\s+/, $includes)) {
 	push(@{$spf->{'include:'}}, $i);
 	}
@@ -4225,14 +4225,14 @@ return $spf;
 # Returns a default DMARC object for a domain, based on its template
 sub default_domain_dmarc
 {
-local ($d) = @_;
-local $tmpl = &get_template($d->{'template'});
-local $pm = 'mailto:postmaster@'.$d->{'dom'};
-local $dmarc = { 'p' => $tmpl->{'dns_dmarcp'} || 'none',
+my ($d) = @_;
+my $tmpl = &get_template($d->{'template'});
+my $pm = 'mailto:postmaster@'.$d->{'dom'};
+my $dmarc = { 'p' => $tmpl->{'dns_dmarcp'} || 'none',
 		 'pct' => $tmpl->{'dns_dmarcpct'} || '100',
 	       };
 foreach my $r ('ruf', 'rua') {
-	local $v = $tmpl->{'dns_dmarc'.$r};
+	my $v = $tmpl->{'dns_dmarc'.$r};
 	next if ($v eq "skip");
 	if ($v && $v ne "none") {
 		$dmarc->{$r} = &substitute_domain_template($v, $d);
@@ -4288,7 +4288,7 @@ return @recs;
 # if necessary
 sub pre_records_change
 {
-local ($d) = @_;
+my ($d) = @_;
 
 # Freeze the zone, so that updates to dynamic zones work
 if (!$d->{'provision_dns'} && !$d->{'dns_cloud'}) {
@@ -4304,7 +4304,7 @@ if (!$d->{'provision_dns'} && !$d->{'dns_cloud'}) {
 # Should be called after pre_records_change, but only if nothing was changed
 sub after_records_change
 {
-local ($d) = @_;
+my ($d) = @_;
 if (!$d->{'provision_dns'} && !$d->{'dns_cloud'}) {
 	my $z = &bind8::get_zone_name($d->{'dom'}, 'any');
 	if ($z && defined(&bind8::after_editing)) {
@@ -4318,7 +4318,7 @@ if (!$d->{'provision_dns'} && !$d->{'dns_cloud'}) {
 # and possibly re-sign and upload to a remote server
 sub post_records_change
 {
-local ($d, $recs, $fn) = @_;
+my ($d, $recs, $fn) = @_;
 if ($d->{'dns_submode'}) {
 	# Apply change in the parent zone, which is actually connected to the
 	# cloud DNS provider
@@ -4338,7 +4338,7 @@ if ($rds && &can_domain_dnssec($d) && !$d->{'dns_remote'}) {
 
 if ($d->{'provision_dns'}) {
 	# Upload records to provisioning server
-	local $info = { 'domain' => $d->{'dom'},
+	my $info = { 'domain' => $d->{'dom'},
 			'replace' => '',
 			'host' => $d->{'provision_dns_host'} };
 	$info->{'record'} = [ &records_to_text($d, $recs) ];
@@ -4349,8 +4349,8 @@ if ($d->{'provision_dns'}) {
 	}
 elsif ($d->{'dns_cloud'}) {
 	# Upload records to cloud DNS provider
-	local $ctype = $d->{'dns_cloud'};
-	local $info = { 'domain' => $d->{'dom'},
+	my $ctype = $d->{'dns_cloud'};
+	my $info = { 'domain' => $d->{'dom'},
 	                'id' => $d->{'dns_cloud_id'},
 	                'location' => $d->{'dns_cloud_location'},
 	                'recs' => $recs };
@@ -4385,7 +4385,7 @@ elsif ($d->{'dns_remote'}) {
 
 # If this domain has aliases, re-create their DNS records too
 if (!$d->{'subdom'} && !$d->{'dns_submode'}) {
-	local @aliases = grep { $_->{'dns'} && !$_->{'dns_submode'} &&
+	my @aliases = grep { $_->{'dns'} && !$_->{'dns_submode'} &&
 				!$_->{'aliasdns'} }
 			      &get_domain_by("alias", $d->{'id'});
 	foreach my $ad (@aliases) {
@@ -4436,8 +4436,8 @@ return undef;
 # Given a list of record hashes, return text-format equivalents for an API call
 sub records_to_text
 {
-local ($d, $recs) = @_;
-local @rv;
+my ($d, $recs) = @_;
+my @rv;
 &require_bind();
 foreach my $r (@$recs) {
 	next if ($r->{'type'} eq 'NS' &&	# Exclude NS for domain
@@ -4463,7 +4463,7 @@ return @rv;
 # Returns 1 if some domain's DNS zone is under a given parent's DNS zone
 sub under_parent_domain
 {
-local ($d, $parent) = @_;
+my ($d, $parent) = @_;
 if (!$parent && $d->{'parent'}) {
 	$parent = &get_domain($d->{'parent'});
 	}
@@ -4477,7 +4477,7 @@ return 0;
 # Returns 1 if some DNS record can be edited.
 sub can_edit_record
 {
-local ($r, $d) = @_;
+my ($r, $d) = @_;
 if ($r->{'type'} eq 'NS' &&
     $r->{'name'} eq $d->{'dom'}.'.' &&
     $d->{'provision_dns'}) {
@@ -4507,7 +4507,7 @@ return 1;
 # Returns 1 if some DNS record can be removed.
 sub can_delete_record
 {
-local ($r, $d) = @_;
+my ($r, $d) = @_;
 if ($r->{'type'} eq 'NS' &&
     $r->{'name'} eq $d->{'dom'}.'.' &&
     $d->{'provision_dns'}) {
@@ -4527,7 +4527,7 @@ sub copy_alias_records
 {
 my ($d) = @_;
 if ($d->{'alias'} && !$d->{'aliasdns'}) {
-	local $target = &get_domain($d->{'alias'});
+	my $target = &get_domain($d->{'alias'});
 	if ($target && !$target->{'subdom'} &&
 	    !$target->{'dns_submode'}) {
 		return 1;
@@ -4548,7 +4548,7 @@ return 0;
 #   func - Validation function ref for value
 sub list_dns_record_types
 {
-local ($d) = @_;
+my ($d) = @_;
 return ( { 'type' => 'A',
 	   'desc' => $text{'records_typea'},
 	   'domain' => 1,
@@ -4733,8 +4733,8 @@ my ($d, $recs) = @_;
 if (!$recs) {
 	($recs) = &get_domain_dns_records_and_file($d);
 	}
-local $withdot = $d->{'dom'}.".";
-local ($dnskey) = grep { $_->{'type'} eq 'DNSKEY' &&
+my $withdot = $d->{'dom'}.".";
+my ($dnskey) = grep { $_->{'type'} eq 'DNSKEY' &&
 			 $_->{'name'} eq $withdot } @$recs;
 return $dnskey ? 1 : 0;
 }
@@ -5030,24 +5030,24 @@ if ($parent && !$d->{'dns_submode'}) {
 # the bind8 module's format
 sub get_domain_dnssec_ds_records
 {
-local ($d) = @_;
+my ($d) = @_;
 &require_bind();
-local $withdot = $d->{'dom'}.".";
-local ($recs, $file) = &get_domain_dns_records_and_file($d);
+my $withdot = $d->{'dom'}.".";
+my ($recs, $file) = &get_domain_dns_records_and_file($d);
 ref($recs) || return $recs;
-local ($dnskey) = grep { $_->{'type'} eq 'DNSKEY' &&
+my ($dnskey) = grep { $_->{'type'} eq 'DNSKEY' &&
 			 $_->{'name'} eq $withdot } @$recs;
 $dnskey || return "No DNSKEY record found for $withdot";
 &has_command("dnssec-dsfromkey") ||
 	return "The dnssec-dsfromkey command was not found";
 $file = &bind8::make_chroot($file);
-local $dstemp = &transname();
-local $out = &backquote_command("dnssec-dsfromkey -f ".quotemeta($file)." ".
+my $dstemp = &transname();
+my $out = &backquote_command("dnssec-dsfromkey -f ".quotemeta($file)." ".
 				quotemeta($d->{'dom'})." 2>&1 >$dstemp");
 if ($?) {
 	return "dnssec-dsfromkey failed : $out";
 	}
-local @dsrecs = &bind8::read_zone_file($dstemp, $d->{'dom'}, undef, undef, 1);
+my @dsrecs = &bind8::read_zone_file($dstemp, $d->{'dom'}, undef, undef, 1);
 &unlink_file($dstemp);
 @dsrecs = grep { $_->{'type'} eq 'DS' } @dsrecs;
 @dsrecs || return "No DS records generated!";
@@ -5983,7 +5983,7 @@ return undef if ($d->{'alias'} && !$d->{'aliasdns'});
 my $temp = &transname();
 local $bind8::config{'auto_chroot'} = undef;
 local $bind8::config{'chroot'} = undef;
-local $defrecs = [ ];
+my $defrecs = [ ];
 &create_standard_records($defrecs, $temp, $d, $d->{'dns_ip'} || $d->{'ip'});
 
 # Compare with the actual records

--- a/feature-mail.pl
+++ b/feature-mail.pl
@@ -110,12 +110,12 @@ elsif ($mail_system == 2) {
 # Returns just virtusers for some domain
 sub list_domain_aliases
 {
-local ($d, $ignore_plugins) = @_;
+my ($d, $ignore_plugins) = @_;
 &require_mail();
-local ($u, %foruser);
+my ($u, %foruser);
 # Filter out aliases that point to users
 foreach $u (&list_domain_users($d, 0, 1, 1, 1)) {
-	local $pop3 = &remove_userdom($u->{'user'}, $d);
+	my $pop3 = &remove_userdom($u->{'user'}, $d);
 	$foruser{$pop3."\@".$d->{'dom'}} = $u->{'user'};
 	if ($mail_system == 0 && $u->{'user'} =~ /\@/) {
 		# Special case for Postfix @ users
@@ -126,8 +126,8 @@ foreach $u (&list_domain_users($d, 0, 1, 1, 1)) {
 if ($d->{'mail'}) {
 	$foruser{$d->{'user'}."\@".$d->{'dom'}} = $d->{'user'};
 	}
-local @virts = &list_virtusers();
-local %ignore;
+my @virts = &list_virtusers();
+my %ignore;
 if ($ignore_plugins) {
 	# Get a list to ignore from each plugin
 	foreach my $f (&list_feature_plugins()) {
@@ -160,17 +160,17 @@ return grep { $_->{'from'} =~ /\@(\S+)$/ && lc($1) eq lc($d->{'dom'}) &&
 # Adds a domain to the list of those accepted by the mail system
 sub setup_mail
 {
-local ($d, $noaliases, $leave_dns) = @_;
+my ($d, $noaliases, $leave_dns) = @_;
 &$first_print($text{'setup_doms'});
 &obtain_lock_mail($d);
 &complete_domain($d);
 &require_mail();
-local $tmpl = &get_template($d->{'template'});
+my $tmpl = &get_template($d->{'template'});
 if ($mail_system == 1) {
 	# Just add to sendmail local domains file
-	local $conf = &sendmail::get_sendmailcf();
-	local $cwfile;
-	local @dlist = &sendmail::get_file_or_config($conf, "w", undef,
+	my $conf = &sendmail::get_sendmailcf();
+	my $cwfile;
+	my @dlist = &sendmail::get_file_or_config($conf, "w", undef,
 						     \$cwfile);
 	&lock_file($cwfile) if ($cwfile);
 	&lock_file($sendmail::config{'sendmail_cf'});
@@ -189,11 +189,11 @@ elsif ($mail_system == 0) {
 	}
 elsif ($mail_system == 2) {
 	# Add to qmail rcpthosts file and virtualdomains file
-	local $rlist = &qmailadmin::list_control_file("rcpthosts");
+	my $rlist = &qmailadmin::list_control_file("rcpthosts");
 	push(@$rlist, $d->{'dom'});
 	&qmailadmin::save_control_file("rcpthosts", $rlist);
 
-	local $virtmap = { 'domain' => $d->{'dom'},
+	my $virtmap = { 'domain' => $d->{'dom'},
 			   'prepend' => $d->{'prefix'}.'pfx' };
 	&qmailadmin::create_virt($virtmap);
 	if (!$no_restart_mail) {
@@ -205,13 +205,13 @@ elsif ($mail_system == 2) {
 
 # Create any aliases specified in the template, if missing
 if (!$noaliases && !$d->{'no_tmpl_aliases'}) {
-	local %gotvirt;
+	my %gotvirt;
 	foreach my $v (&list_virtusers()) {
 		$gotvirt{$v->{'from'}} = $v;
 		}
 	if ($d->{'alias'}) {
 		# Alias all mail to this domain to a different domain
-		local $aliasdom = &get_domain($d->{'alias'});
+		my $aliasdom = &get_domain($d->{'alias'});
 		if ($supports_aliascopy && !$d->{'aliasmail'}) {
 			$d->{'aliascopy'} = $tmpl->{'aliascopy'};
 			}
@@ -236,10 +236,10 @@ if (!$noaliases && !$d->{'no_tmpl_aliases'}) {
 	elsif ($tmpl->{'dom_aliases'} && $tmpl->{'dom_aliases'} ne "none") {
 		# Setup aliases from this domain based on the template
 		&$first_print($text{'setup_domaliases'});
-		local @aliases = split(/\t+/, $tmpl->{'dom_aliases'});
-		local ($a, %acreate);
+		my @aliases = split(/\t+/, $tmpl->{'dom_aliases'});
+		my ($a, %acreate);
 		foreach $a (@aliases) {
-			local ($from, $to) = split(/=/, $a, 2);
+			my ($from, $to) = split(/=/, $a, 2);
 			$to = &substitute_domain_template($to, $d);
 			$from = $from eq "*" ? "\@$d->{'dom'}" : "$from\@$d->{'dom'}";
 			if ($acreate{$from}) {
@@ -259,7 +259,7 @@ if (!$noaliases && !$d->{'no_tmpl_aliases'}) {
 		    $mail_system != 0) {
 			# Add bounce alias, if there isn't one yet, and if
 			# we are not running Postfix.
-			local $v = { 'from' => "\@$d->{'dom'}",
+			my $v = { 'from' => "\@$d->{'dom'}",
 				     'to' => [ 'BOUNCE' ] };
 			&create_virtuser($v);
 			$gotvirt{'@'.$d->{'dom'}}++;
@@ -337,17 +337,17 @@ return 1;
 # Removes a domain from the list of those accepted by the mail system
 sub delete_mail
 {
-local ($d, $preserve, $leave_aliases, $leave_dns) = @_;
+my ($d, $preserve, $leave_aliases, $leave_dns) = @_;
 
 &$first_print($text{'delete_doms'});
 &obtain_lock_mail($d);
 &require_mail();
 
-local $isalias = $d->{'alias'} && !$d->{'aliasmail'};
+my $isalias = $d->{'alias'} && !$d->{'aliasmail'};
 if ($isalias && !$d->{'aliascopy'}) {
         # Remove whole-domain alias for alias domains
-        local @virts = &list_virtusers();
-        local ($catchall) = grep { lc($_->{'from'}) eq '@'.$d->{'dom'} }
+        my @virts = &list_virtusers();
+        my ($catchall) = grep { lc($_->{'from'}) eq '@'.$d->{'dom'} }
 				 @virts;
         if ($catchall) {
                 &delete_virtuser($catchall);
@@ -360,9 +360,9 @@ elsif ($isalias && $d->{'aliascopy'}) {
 
 if ($mail_system == 1) {
 	# Delete domain from sendmail local domains file
-	local $conf = &sendmail::get_sendmailcf();
-	local $cwfile;
-	local @dlist = &sendmail::get_file_or_config($conf, "w", undef,
+	my $conf = &sendmail::get_sendmailcf();
+	my $cwfile;
+	my @dlist = &sendmail::get_file_or_config($conf, "w", undef,
 						     \$cwfile);
 	&lock_file($cwfile) if ($cwfile);
 	&lock_file($sendmail::config{'sendmail_cf'});
@@ -372,8 +372,8 @@ if ($mail_system == 1) {
 	&unlock_file($cwfile) if ($cwfile);
 
 	# Also delete from generics domain file or list
-	local $cgfile;
-	local @dlist = &sendmail::get_file_or_config($conf, "G", undef,
+	my $cgfile;
+	my @dlist = &sendmail::get_file_or_config($conf, "G", undef,
                                                      \$cgfile);
 	if (&indexof($d->{'dom'}, @dlist) >= 0) {
 		&lock_file($cgfile) if ($cgfile);
@@ -391,17 +391,17 @@ if ($mail_system == 1) {
 	}
 elsif ($mail_system == 0) {
 	# Delete the special postfix virtuser
-	local @virts = &list_virtusers();
-	local ($lv) = grep { lc($_->{'from'}) eq $d->{'dom'} } @virts;
+	my @virts = &list_virtusers();
+	my ($lv) = grep { lc($_->{'from'}) eq $d->{'dom'} } @virts;
 	if ($lv) {
 		&delete_virtuser($lv);
 		}
 
 	# Remove from mydestination, unless the domain is the hostname
 	if ($d->{'dom'} ne &get_system_hostname(0, 1)) {
-		local @md = split(/[, ]+/,
+		my @md = split(/[, ]+/,
 			  lc(&postfix::get_current_value("mydestination")));
-		local $idx = &indexof($d->{'dom'}, @md);
+		my $idx = &indexof($d->{'dom'}, @md);
 		if ($idx >= 0) {
 			# Delete old-style entry too
 			&lock_file($postfix::config{'postfix_config_file'});
@@ -418,15 +418,15 @@ elsif ($mail_system == 0) {
 	}
 elsif ($mail_system == 2) {
 	# Delete domain from qmail locals file, rcpthosts file and virtuals
-	local $dlist = &qmailadmin::list_control_file("locals");
+	my $dlist = &qmailadmin::list_control_file("locals");
 	$dlist = [ grep { lc($_) ne $d->{'dom'} } @$dlist ];
 	&qmailadmin::save_control_file("locals", $dlist);
 
-	local $rlist = &qmailadmin::list_control_file("rcpthosts");
+	my $rlist = &qmailadmin::list_control_file("rcpthosts");
 	$rlist = [ grep { lc($_) ne $d->{'dom'} } @$rlist ];
 	&qmailadmin::save_control_file("rcpthosts", $rlist);
 
-	local ($virtmap) = grep { lc($_->{'domain'}) eq $d->{'dom'} &&
+	my ($virtmap) = grep { lc($_->{'domain'}) eq $d->{'dom'} &&
 				  !$_->{'user'} } &qmailadmin::list_virts();
 	&qmailadmin::delete_virt($virtmap) if ($virtmap);
 	if (!$no_restart_mail) {
@@ -443,7 +443,7 @@ if (!$leave_aliases) {
 	# server is being deleted, as aliases will be already removed in the
 	# function delete_virtual_server.
 	&$first_print($text{'delete_aliases'});
-	local @deleted;
+	my @deleted;
 	foreach my $v (&list_virtusers()) {
 		if ($v->{'from'} =~ /\@(\S+)$/ &&
 		    $1 eq $d->{'dom'}) {
@@ -459,13 +459,13 @@ if (!$leave_aliases) {
 
 # Remove BCC address
 if ($supports_bcc) {
-	local $bcc = &get_domain_sender_bcc($d);
+	my $bcc = &get_domain_sender_bcc($d);
 	if ($bcc) {
 		&save_domain_sender_bcc($d, undef);
 		}
 	}
 if ($supports_bcc == 2) {
-	local $bcc = &get_domain_recipient_bcc($d);
+	my $bcc = &get_domain_recipient_bcc($d);
 	if ($bcc) {
 		&save_domain_recipient_bcc($d, undef);
 		}
@@ -529,7 +529,7 @@ return 1;
 # Copy all mail aliases and mailboxes from the old domain to the new one
 sub clone_mail
 {
-local ($d, $oldd) = @_;
+my ($d, $oldd) = @_;
 &$first_print($text{'clone_mail2'});
 if ($d->{'alias'} && !$d->{'aliasmail'}) {
 	&$second_print($text{'clone_mailalias'});
@@ -539,13 +539,13 @@ if ($d->{'alias'} && !$d->{'aliasmail'}) {
 &obtain_lock_cron($d);
 
 # Clone all users
-local $ucount = 0;
-local $hb = "$d->{'home'}/$config{'homes_dir'}";
-local $mail_under_home = &mail_under_home();
+my $ucount = 0;
+my $hb = "$d->{'home'}/$config{'homes_dir'}";
+my $mail_under_home = &mail_under_home();
 foreach my $u (&list_domain_users($oldd, 1, 0, 0, 0)) {
-	local $newu = { %$u };
-	local $as = &guess_append_style($u->{'user'}, $oldd);
-	local $ushort = &remove_userdom($u->{'user'}, $oldd);
+	my $newu = { %$u };
+	my $as = &guess_append_style($u->{'user'}, $oldd);
+	my $ushort = &remove_userdom($u->{'user'}, $oldd);
 	$newu->{'user'} = &userdom_name($ushort, $d, $as);
 	if ($u->{'uid'} == $d->{'uid'}) {
 		# Web management user, so same UID as new domain
@@ -553,7 +553,7 @@ foreach my $u (&list_domain_users($oldd, 1, 0, 0, 0)) {
 		}
 	else {
 		# Allocate UID
-		local %taken;
+		my %taken;
 		&build_taken(\%taken);
 		$newu->{'uid'} = &allocate_uid(\%taken);
 		}
@@ -567,11 +567,11 @@ foreach my $u (&list_domain_users($oldd, 1, 0, 0, 0)) {
 		}
 
 	# Fix database access list
-	local @newdbs;
+	my @newdbs;
 	foreach my $db (@{$newu->{'dbs'}}) {
-		local $newprefix = &fix_database_name($d->{'prefix'},
+		my $newprefix = &fix_database_name($d->{'prefix'},
 						      $db->{'type'});
-		local $oldprefix = &fix_database_name($oldd->{'prefix'},
+		my $oldprefix = &fix_database_name($oldd->{'prefix'},
 						      $db->{'type'});
 		if ($db->{'name'} eq $oldd->{'db'}) {
 			# Use new main DB
@@ -588,7 +588,7 @@ foreach my $u (&list_domain_users($oldd, 1, 0, 0, 0)) {
 	$newu->{'dbs'} = \@newdbs;
 
 	# Fix email forwarding destinations
-	local @to;
+	my @to;
 	foreach my $t (@{$newu->{'to'}}) {
 		push(@to, &fix_cloned_alias($t, $u->{'user'}, $oldd, $d));
 		}
@@ -606,9 +606,9 @@ foreach my $u (&list_domain_users($oldd, 1, 0, 0, 0)) {
 
 	# Clone mail files under /var/mail , if needed
 	if ($mail_under_home) {
-		local $oldmf = &user_mail_file($u);
-		local $newmf = &user_mail_file($newu);
-		local @st = stat($newmf);
+		my $oldmf = &user_mail_file($u);
+		my $newmf = &user_mail_file($newu);
+		my @st = stat($newmf);
 		if (@st && -r $oldmf) {
 			&copy_source_dest($oldmf, $newmf);
 			&set_ownership_permissions(
@@ -625,15 +625,15 @@ foreach my $u (&list_domain_users($oldd, 1, 0, 0, 0)) {
 
 # Clone all aliases
 &$first_print($text{'clone_mail1'});
-local %already = map { $_->{'from'}, $_ } &list_domain_aliases($d, 0);
-local $acount = 0;
+my %already = map { $_->{'from'}, $_ } &list_domain_aliases($d, 0);
+my $acount = 0;
 foreach my $a (&list_domain_aliases($oldd, 1)) {
-	local ($mailbox, $dom) = split(/\@/, $a->{'from'});
-	local @to;
+	my ($mailbox, $dom) = split(/\@/, $a->{'from'});
+	my @to;
 	foreach my $t (@{$a->{'to'}}) {
 		push(@to, &fix_cloned_alias($t, $a->{'from'}, $oldd, $d));
 		}
-	local $newa = { 'from' => $mailbox."\@".$d->{'dom'},
+	my $newa = { 'from' => $mailbox."\@".$d->{'dom'},
 			'cmt' => $a->{'cmt'},
 			'to' => \@to };
 	if (!$already{$newa->{'from'}}) {
@@ -654,8 +654,8 @@ return 1;
 # fix_cloned_alias(dest, from, &old-domain, &domain)
 sub fix_cloned_alias
 {
-local ($t, $from, $oldd, $d) = @_;
-local ($atype, $adest) = &alias_type($t, $from);
+my ($t, $from, $oldd, $d) = @_;
+my ($atype, $adest) = &alias_type($t, $from);
 if ($atype == 1) {
 	$t =~ s/\@\Q$oldd->{'dom'}\E$/\@$d->{'dom'}/;
 	}
@@ -664,10 +664,10 @@ elsif ($atype == 2 || $atype == 3 || $atype == 4 ||
 	$t =~ s/\Q$oldd->{'home'}\E/$d->{'home'}/g;
 	if ($atype == 5) {
 		# Change domain name and ID in autoreply files
-		local ($oldatype, $oldadest) = &alias_type($t, $from);
+		my ($oldatype, $oldadest) = &alias_type($t, $from);
 		$t =~ s/\@\Q$oldd->{'dom'}\E/\@$d->{'dom'}/g;
 		$t =~ s/\Q$oldd->{'id'}\E/$d->{'id'}/g;
-		local ($newatype, $newadest) = &alias_type($t, $from);
+		my ($newatype, $newadest) = &alias_type($t, $from);
 		if ($oldadest ne $newadest) {
 			&rename_logged($oldadest, $newadest);
 			}
@@ -1026,11 +1026,11 @@ while($our_unix_locks--) {
 # alias or user.
 sub fix_alias_when_renaming
 {
-local ($virt, $dom, $olddom) = @_;
-local $changed = 0;
-local @newto = ( );
+my ($virt, $dom, $olddom) = @_;
+my $changed = 0;
+my @newto = ( );
 foreach my $ot (@{$virt->{'to'}}) {
-	local $t = $ot;
+	my $t = $ot;
 	if ($t =~ /^(\S*)\@(\S+)$/ &&
 	    lc($2) eq $olddom->{'dom'}) {
 		# Destination is an address in the
@@ -1050,7 +1050,7 @@ foreach my $ot (@{$virt->{'to'}}) {
 
 	# Change home directory references, for auto-
 	# reply files.
-	local $type = &alias_type($t);
+	my $type = &alias_type($t);
 	if ($type == 5) {
 		$t =~ s/\Q$olddom->{'home'}\E/$dom->{'home'}/g;
 		$t =~ s/\Q$olddom->{'dom'}\E /$dom->{'dom'} /g;
@@ -1067,18 +1067,18 @@ return $changed;
 # this domain, or if mail users have incorrect permissions.
 sub validate_mail
 {
-local ($d) = @_;
+my ($d) = @_;
 
 # Check if this server is receiving email
 return &text('validate_email', "<tt>$d->{'dom'}</tt>")
 	if (!&is_local_domain($d->{'dom'}) && !$d->{'disabled'});
 
 # Check any secondary MX servers
-local %ids = map { $_, 1 } split(/\s+/, $d->{'mx_servers'});
-local @servers = grep { $ids{$_->{'id'}} } &list_mx_servers();
+my %ids = map { $_, 1 } split(/\s+/, $d->{'mx_servers'});
+my @servers = grep { $ids{$_->{'id'}} } &list_mx_servers();
 foreach my $s (@servers) {
 	next if (!$ids{$s->{'id'}});
-	local $ok = &is_one_secondary($d, $s);
+	my $ok = &is_one_secondary($d, $s);
 	if ($ok eq '0') {
 		return &text('validate_emailmx', $s->{'host'});
 		}
@@ -1088,24 +1088,24 @@ foreach my $s (@servers) {
 	}
 
 # Check mailbox permissions
-local %doneuid;
+my %doneuid;
 foreach my $user (&list_domain_users($d, 1)) {
 	if (!$user->{'webowner'} && $doneuid{$user->{'uid'}}++) {
 		return &text('validate_emailuid', $user->{'user'},
 						  $user->{'uid'});
 		}
-	local @st = stat($user->{'home'});
+	my @st = stat($user->{'home'});
 	if (!@st) {
 		return &text('validate_emailhome', $user->{'user'},
 						   $user->{'home'});
 		}
 	if ($st[4] != $user->{'uid'}) {
-		local $ru = getpwuid($st[4]) || $user->{'uid'};
+		my $ru = getpwuid($st[4]) || $user->{'uid'};
 		return &text('validate_emailhomeu',
 			$user->{'user'}, $user->{'home'}, $ru);
 		}
 	if ($st[5] != $user->{'gid'}) {
-		local $rg = getgrgid($st[5]) || $user->{'gid'};
+		my $rg = getgrgid($st[5]) || $user->{'gid'};
 		return &text('validate_emailhomeg',
 			$user->{'user'}, $user->{'home'}, $rg);
 		}
@@ -1189,12 +1189,12 @@ return 1;
 # Except for qmail, where we have to check for clash with hostname.
 sub check_mail_clash
 {
-local ($dname) = @_;
+my ($dname) = @_;
 if ($mail_system == 2) {
 	# Qmail virtualdomains don't work if the domain name is the same
 	# as the hostname
 	&require_mail();
-	local $qme = &qmailadmin::get_control_file("me");
+	my $qme = &qmailadmin::get_control_file("me");
 	$qme ||= &get_system_hostname();
 	if ($dname eq $qme) {
 		return &text('setup_qmailme', "<tt>$qme</tt>");
@@ -1207,23 +1207,23 @@ return 0;
 # Returns 1 if some domain is used for mail on this system, 0 if not
 sub is_local_domain
 {
-local $found = 0;
+my $found = 0;
 &require_mail();
 if ($mail_system == 1) {
 	# Check Sendmail local domains file
-	local $conf = &sendmail::get_sendmailcf();
-        local @dlist = &sendmail::get_file_or_config($conf, "w");
+	my $conf = &sendmail::get_sendmailcf();
+        my @dlist = &sendmail::get_file_or_config($conf, "w");
 	foreach my $d (@dlist) {
 		$found++ if (lc($d) eq lc($_[0]));
 		}
 	}
 elsif ($mail_system == 0) {
 	# Check Postfix virtusers and mydestination
-	local @virts = &list_virtusers();
-	local ($lv) = grep { lc($_->{'from'}) eq $_[0] } @virts;
+	my @virts = &list_virtusers();
+	my ($lv) = grep { lc($_->{'from'}) eq $_[0] } @virts;
 	$found++ if ($lv);
-	local @md = split(/[, ]+/,&postfix::get_current_value("mydestination"));
-	local $hostname = lc(&get_system_hostname());
+	my @md = split(/[, ]+/,&postfix::get_current_value("mydestination"));
+	my $hostname = lc(&get_system_hostname());
 	foreach my $md (@md) {
 		$found++ if (lc($md) eq lc($_[0]) ||
 			     $md eq '$myhostname' && lc($_[0]) eq $hostname);
@@ -1231,9 +1231,9 @@ elsif ($mail_system == 0) {
 	}
 elsif ($mail_system == 2) {
 	# Check qmail rcpthosts and virtualdomains files
-	local $rlist = &qmailadmin::list_control_file("rcpthosts");
+	my $rlist = &qmailadmin::list_control_file("rcpthosts");
 	@$rlist = map { lc($_) } @$rlist;
-	local ($virtmap) = grep { lc($_->{'domain'}) eq $_[0]->{'dom'} &&
+	my ($virtmap) = grep { lc($_->{'domain'}) eq $_[0]->{'dom'} &&
 				  !$_->{'user'} } &qmailadmin::list_virts();
 	$found++ if (&indexof($_[0], @$rlist) >= 0 && $virtmap);
 	}
@@ -1246,7 +1246,7 @@ return $found;
 # destinations for that alias.
 sub list_virtusers
 {
-local ($incall) = @_;
+my ($incall) = @_;
 return () if (!$config{'mail'});
 
 # Build list of unix users, to exclude aliases with same name as users
@@ -1261,7 +1261,7 @@ if (!%unix_user) {
 
 # Build a list of copy-mode alias domains, as their Sendmail and Postfix
 # virtusers shouldn't be included
-local %alias_copy;
+my %alias_copy;
 if ($supports_aliascopy && !$incall) {
 	foreach my $d (&get_domain_by("alias", "_ANY_")) {
 		if ($d->{'aliascopy'}) {
@@ -1272,17 +1272,17 @@ if ($supports_aliascopy && !$incall) {
 
 if ($mail_system == 1) {
 	# Get from sendmail
-	local @svirts = &sendmail::list_virtusers($sendmail_vfile);
-	local %aliases = map { lc($_->{'name'}), $_ }
+	my @svirts = &sendmail::list_virtusers($sendmail_vfile);
+	my %aliases = map { lc($_->{'name'}), $_ }
 			 grep { $_->{'enabled'} &&
 				(!$unix_user{$_->{'name'}} || $incall) }
 				&sendmail::list_aliases($sendmail_afiles);
-	local ($v, $a, @virts);
+	my ($v, $a, @virts);
 	foreach $v (@svirts) {
-		local %rv = ( 'virt' => $v,
+		my %rv = ( 'virt' => $v,
 			      'cmt' => $v->{'cmt'},
 			      'from' => lc($v->{'from'}) );
-		local ($mb, $dname) = split(/\@/, $rv{'from'});
+		my ($mb, $dname) = split(/\@/, $rv{'from'});
 		next if ($alias_copy{$dname});
 		if ($v->{'to'} !~ /\@/ && ($a = $aliases{lc($v->{'to'})})) {
 			# Points to an alias - use its values
@@ -1311,17 +1311,17 @@ if ($mail_system == 1) {
 	}
 elsif ($mail_system == 0) {
 	# Get from postfix
-	local $svirts = &postfix::get_maps($virtual_type);
-	local %aliases = map { lc($_->{'name'}), $_ }
+	my $svirts = &postfix::get_maps($virtual_type);
+	my %aliases = map { lc($_->{'name'}), $_ }
 			 grep { $_->{'enabled'} &&
 				(!$unix_user{$_->{'name'}} || $incall) }
 			      &$postfix_list_aliases($postfix_afiles);
-	local ($v, $a, @virts);
+	my ($v, $a, @virts);
 	foreach $v (@$svirts) {
-		local %rv = ( 'from' => lc($v->{'name'}),
+		my %rv = ( 'from' => lc($v->{'name'}),
 			      'cmt' => $v->{'cmt'},
 			      'virt' => $v );
-		local ($mb, $dname) = split(/\@/, $rv{'from'});
+		my ($mb, $dname) = split(/\@/, $rv{'from'});
 		next if ($alias_copy{$dname});
 		if ($v->{'value'} !~ /\@/ &&
 		    ($a = $aliases{lc($v->{'value'})})) {
@@ -1331,7 +1331,7 @@ elsif ($mail_system == 0) {
 		else {
 			$rv{'to'} = [ $v->{'value'} ];
 			}
-		local $t;	# postfix format for catchall forward is
+		my $t;	# postfix format for catchall forward is
 				# different from sendmail
 		foreach $t (@{$rv{'to'}}) {
 			$t =~ s/^\@(\S+)$/\%1\@$1/;
@@ -1342,13 +1342,13 @@ elsif ($mail_system == 0) {
 	}
 elsif ($mail_system == 2) {
 	# Find all qmail aliases like .qmail-group-user
-	local @virtmaps = grep { !$_->{'user'} } &qmailadmin::list_virts();
-	local @aliases = &qmailadmin::list_aliases();
-	local ($an, $v, @virts);
+	my @virtmaps = grep { !$_->{'user'} } &qmailadmin::list_virts();
+	my @aliases = &qmailadmin::list_aliases();
+	my ($an, $v, @virts);
 	foreach $an (@aliases) {
 		# Find domain in virtual maps
-		local $a = &qmailadmin::get_alias($an);
-		local $name = $a->{'name'};
+		my $a = &qmailadmin::get_alias($an);
+		my $name = $a->{'name'};
 		foreach $v (@virtmaps) {
 			if ($a->{'name'} =~ /^\Q$v->{'prepend'}\E\-(.*)$/) {
 				$name = ($1 eq "default" ? "" : $1)
@@ -1369,7 +1369,7 @@ elsif ($mail_system == 2) {
 # Virtualmin format. 
 sub qmail_to_vpopmail
 {
-local $ddir = &domain_vpopmail_dir($_[1]);
+my $ddir = &domain_vpopmail_dir($_[1]);
 if ($_[0] =~ /^\|\s*$vpopbin\/vdelivermail\s+''\s+(\S+)\@(\S+)$/) {
 	# External address
 	return $2 eq $_[1] ? $1 : "$1\@$2";
@@ -1395,7 +1395,7 @@ else {
 # vpopmail_to_qmail(alias, domain)
 sub vpopmail_to_qmail
 {
-local $ddir = &domain_vpopmail_dir($_[1]);
+my $ddir = &domain_vpopmail_dir($_[1]);
 if ($_[0] =~ /^\S+\@\S+$/) {
 	# A full email address .. just leave as is
 	return $_[0];
@@ -1468,20 +1468,20 @@ sub modify_virtuser
 {
 &require_mail();
 &execute_before_virtuser($_[0], 'MODIFY_ALIAS');
-local @to = @{$_[1]->{'to'}};
+my @to = @{$_[1]->{'to'}};
 if ($mail_system == 1) {
 	# Modify in sendmail
-	local $alias = $_[0]->{'alias'};
-	local $oldalias = $alias ? { %$alias } : undef;
-	local @smto = map { $_ eq "BOUNCE" ? "error:nouser User unknown" :
+	my $alias = $_[0]->{'alias'};
+	my $oldalias = $alias ? { %$alias } : undef;
+	my @smto = map { $_ eq "BOUNCE" ? "error:nouser User unknown" :
 			    $_ =~ /^BOUNCE\s+(.*)$/ ? "error:nouser $1" :
 			    $_ } @to;
 	$_[1]->{'from'} =~ /^(\S*)\@(\S+)$/;
-	local $an = ($1 || "default")."-".$2;
+	my $an = ($1 || "default")."-".$2;
 	if (&needs_alias(@smto) && !$alias) {
 		# Alias needs to be created and virtuser updated
-		local $clash = &check_alias_clash($an);
-		local $alias = { "name" => $an,
+		my $clash = &check_alias_clash($an);
+		my $alias = { "name" => $an,
 				 "enabled" => 1,
 				 "values" => \@smto };
 		$_[1]->{'alias'} = $alias;
@@ -1491,7 +1491,7 @@ if ($mail_system == 1) {
 			}
 		&sendmail::create_alias($alias, $sendmail_afiles);
 		&sendmail::unlock_alias_files($sendmail_afiles);
-		local $virt = { "from" => $_[1]->{'from'},
+		my $virt = { "from" => $_[1]->{'from'},
 				"to" => $an,
 				"cmt" => $_[1]->{'cmt'} };
 		&sendmail::modify_virtuser($_[0]->{'virt'}, $virt,
@@ -1507,7 +1507,7 @@ if ($mail_system == 1) {
 		if ($_[1]->{'from'} ne $_[0]->{'from'} ||
 		    $_[1]->{'cmt'} ne $_[0]->{'cmt'}) {
 			# Re-named .. need to change virtuser too
-			local $virt = { "from" => $_[1]->{'from'},
+			my $virt = { "from" => $_[1]->{'from'},
 					"to" => $an,
 					"cmt" => $_[1]->{'cmt'} };
 			&sendmail::modify_virtuser($_[0]->{'virt'}, $virt,
@@ -1519,7 +1519,7 @@ if ($mail_system == 1) {
 		}
 	else {
 		# Just update virtuser
-		local $virt = { "from" => $_[1]->{'from'},
+		my $virt = { "from" => $_[1]->{'from'},
 				"to" => $smto[0],
 				"cmt" => $_[1]->{'cmt'} };
 		&sendmail::modify_virtuser($_[0]->{'virt'}, $virt,
@@ -1530,15 +1530,15 @@ if ($mail_system == 1) {
 	}
 elsif ($mail_system == 0) {
 	# Modify in postfix file
-	local $alias = $_[0]->{'alias'};
-	local $oldalias = $alias ? { %$alias } : undef;
-	local @psto = map { $_ =~ /^BOUNCE\s+(.*)$/ ? "BOUNCE" : $_ } @to;
+	my $alias = $_[0]->{'alias'};
+	my $oldalias = $alias ? { %$alias } : undef;
+	my @psto = map { $_ =~ /^BOUNCE\s+(.*)$/ ? "BOUNCE" : $_ } @to;
 	$_[1]->{'from'} =~ /^(\S*)\@(\S+)$/;
-	local $an = ($1 || "default")."-".$2;
+	my $an = ($1 || "default")."-".$2;
 	if (&needs_alias(@psto) && !$alias) {
 		# Alias needs to be created and virtuser updated
-		local $clash = &check_alias_clash($an);
-		local $alias = { "name" => $an,
+		my $clash = &check_alias_clash($an);
+		my $alias = { "name" => $an,
 				 "enabled" => 1,
 				 "values" => \@psto };
 		$_[1]->{'alias'} = $alias;
@@ -1549,7 +1549,7 @@ elsif ($mail_system == 0) {
 		&$postfix_create_alias($alias, $postfix_afiles);
 		&postfix::unlock_alias_files($postfix_afiles);
 		&postfix::regenerate_aliases();
-		local $virt = { "name" => $_[1]->{'from'},
+		my $virt = { "name" => $_[1]->{'from'},
 				"value" => $an,
 				"cmt" => $_[1]->{'cmt'} };
 		&postfix::modify_mapping($virtual_type, $_[0]->{'virt'}, $virt);
@@ -1565,7 +1565,7 @@ elsif ($mail_system == 0) {
 		if ($_[1]->{'from'} ne $_[0]->{'from'} ||
 		    $_[1]->{'cmt'} ne $_[0]->{'cmt'}) {
 			# Re-named .. need to change virtuser too
-			local $virt = { "name" => $_[1]->{'from'},
+			my $virt = { "name" => $_[1]->{'from'},
 					"value" => $an,
 					"cmt" => $_[1]->{'cmt'} };
 			&postfix::modify_mapping($virtual_type, $_[0]->{'virt'},
@@ -1576,9 +1576,9 @@ elsif ($mail_system == 0) {
 		}
 	else {
 		# Just update virtuser
-		local $t = $psto[0];
+		my $t = $psto[0];
 		$t =~ s/^\%1\@/\@/;	# postfix format is different
-		local $virt = { "name" => $_[1]->{'from'},
+		my $virt = { "name" => $_[1]->{'from'},
 				"value" => $t,
 				"cmt" => $_[1]->{'cmt'} };
 		&postfix::modify_mapping($virtual_type, $_[0]->{'virt'}, $virt);
@@ -1589,10 +1589,10 @@ elsif ($mail_system == 0) {
 elsif ($mail_system == 2) {
 	# Just update the qmail alias
 	$_[1]->{'from'} =~ /^(\S*)\@(\S+)$/;
-	local ($box, $dom) = ($1 || "default", $2);
-	local ($virtmap) = grep { $_->{'domain'} eq $dom && !$_->{'user'} }
+	my ($box, $dom) = ($1 || "default", $2);
+	my ($virtmap) = grep { $_->{'domain'} eq $dom && !$_->{'user'} }
 			        &qmailadmin::list_virts();
-	local $alias = { 'name' => "$virtmap->{'prepend'}-$box",
+	my $alias = { 'name' => "$virtmap->{'prepend'}-$box",
 			 'values' => \@to };
 	&qmailadmin::modify_alias($_[0]->{'alias'}, $alias);
 	$_[1]->{'alias'} = $alias;
@@ -1607,20 +1607,20 @@ elsif ($mail_system == 2) {
 sub create_virtuser
 {
 &require_mail();
-local @to = @{$_[0]->{'to'}};
+my @to = @{$_[0]->{'to'}};
 &execute_before_virtuser($_[0], 'CREATE_ALIAS');
 if ($mail_system == 1) {
 	# Create in sendmail
-	local $virt;
-	local @smto = map { $_ eq "BOUNCE" ? "error:nouser User unknown" :
+	my $virt;
+	my @smto = map { $_ eq "BOUNCE" ? "error:nouser User unknown" :
 			    $_ =~ /^BOUNCE\s+(.*)$/ ? "error:nouser $1" :
 			    $_ } @to;
 	if (&needs_alias(@smto)) {
 		# Need to create an alias, named address-domain
 		$_[0]->{'from'} =~ /^(\S*)\@(\S+)$/;
-		local $an = ($1 || "default")."-".$2;
-		local $clash = &check_alias_clash($an);
-		local $alias = { "name" => $an,
+		my $an = ($1 || "default")."-".$2;
+		my $clash = &check_alias_clash($an);
+		my $alias = { "name" => $an,
 				 "enabled" => 1,
 				 "values" => \@smto };
 		$_[0]->{'alias'} = $alias;
@@ -1640,8 +1640,8 @@ if ($mail_system == 1) {
 			  "to" => $smto[0],
 			  "cmt" => $_[0]->{'cmt'} };
 		}
-	local @svirts = &sendmail::list_virtusers($sendmail_vfile);
-	local ($vclash) = grep { $_->{'from'} eq $virt->{'from'} } @svirts;
+	my @svirts = &sendmail::list_virtusers($sendmail_vfile);
+	my ($vclash) = grep { $_->{'from'} eq $virt->{'from'} } @svirts;
 	if ($vclash) {
 		# Replace clash
 		&sendmail::delete_virtuser($vclash, $sendmail_vfile,
@@ -1654,14 +1654,14 @@ if ($mail_system == 1) {
 	}
 elsif ($mail_system == 0) {
 	# Create in postfix file
-	local @psto = map { $_ =~ /^BOUNCE\s+(.*)$/ ? "BOUNCE" : $_ } @to;
-	local $virt;
+	my @psto = map { $_ =~ /^BOUNCE\s+(.*)$/ ? "BOUNCE" : $_ } @to;
+	my $virt;
 	if (&needs_alias(@psto)) {
 		# Need to create an alias, named address-domain
 		$_[0]->{'from'} =~ /^(\S*)\@(\S+)$/;
-		local $an = ($1 || "default")."-".$2;
-		local $clash = &check_alias_clash($an);
-		local $alias = { "name" => $an,
+		my $an = ($1 || "default")."-".$2;
+		my $clash = &check_alias_clash($an);
+		my $alias = { "name" => $an,
 				 "enabled" => 1,
 				 "values" => \@psto };
 		$_[0]->{'alias'} = $alias;
@@ -1678,7 +1678,7 @@ elsif ($mail_system == 0) {
 		}
 	else {
 		# A single virtuser will do
-		local $t = $psto[0];
+		my $t = $psto[0];
 		$t =~ s/^\%1\@/\@/;	# postfix format is different
 		$virt = { 'name' => $_[0]->{'from'},
 			  'value' => $t,
@@ -1691,10 +1691,10 @@ elsif ($mail_system == 0) {
 elsif ($mail_system == 2) {
 	# Create a single Qmail alias
 	$_[0]->{'from'} =~ /^(\S*)\@(\S+)$/;
-	local ($box, $dom) = ($1 || "default", $2);
-	local ($virtmap) = grep { $_->{'domain'} eq $dom && !$_->{'user'} }
+	my ($box, $dom) = ($1 || "default", $2);
+	my ($virtmap) = grep { $_->{'domain'} eq $dom && !$_->{'user'} }
 			        &qmailadmin::list_virts();
-	local $alias = { 'name' => "$virtmap->{'prepend'}-$box",
+	my $alias = { 'name' => "$virtmap->{'prepend'}-$box",
 			 'values' => \@to };
 	&qmailadmin::create_alias($alias);
 	$_[0]->{'alias'} = $alias;
@@ -1711,12 +1711,12 @@ elsif ($mail_system == 2) {
 # Returns a list of tuples containing the server object and error message.
 sub sync_secondary_virtusers
 {
-local ($d, $onlyservers, $delete) = @_;
-local @servers = $onlyservers ? @$onlyservers : &list_mx_servers();
+my ($d, $onlyservers, $delete) = @_;
+my @servers = $onlyservers ? @$onlyservers : &list_mx_servers();
 return if (!@servers);
 
 # Build list of mailboxes in the domain
-local @mailboxes;
+my @mailboxes;
 if (!$d->{'disabled'} && !$delete) {
 	foreach my $v (&list_virtusers(1)) {
 		my ($mb, $dom) = split(/\@/, $v->{'from'});
@@ -1727,7 +1727,7 @@ if (!$d->{'disabled'} && !$delete) {
 	}
 
 # Sync to each secondary
-local @rv;
+my @rv;
 &remote_error_setup(\&secondary_error_handler);
 foreach my $s (@servers) {
 	alarm(20);
@@ -1740,7 +1740,7 @@ foreach my $s (@servers) {
 			push(@rv, [ $s, $secondary_error ]);
 			}
 		else {
-			local $err = &remote_foreign_call($s, "virtual-server",
+			my $err = &remote_foreign_call($s, "virtual-server",
 				  "update_secondary_mx_virtusers", $d->{'dom'},
 				  \@mailboxes);
 			push(@rv, [ $s, $err ]);
@@ -1761,17 +1761,17 @@ return @rv;
 # This is called on the secondary MX Virtualmins.
 sub update_secondary_mx_virtusers
 {
-local ($dom, $mailboxes) = @_;
-local %mailboxes_map = map { $_, 1 } @$mailboxes;
-local $rv;
+my ($dom, $mailboxes) = @_;
+my %mailboxes_map = map { $_, 1 } @$mailboxes;
+my $rv;
 &obtain_lock_mail($dom);
 &require_mail();
 if ($mail_system == 1) {
 	# Update Sendmail access list
 	&foreign_require("sendmail", "access-lib.pl");
-	local $conf = &sendmail::get_sendmailcf();
-	local $afile = &sendmail::access_file($conf);
-	local ($adbm, $adbmtype) = &sendmail::access_dbm($conf);
+	my $conf = &sendmail::get_sendmailcf();
+	my $afile = &sendmail::access_file($conf);
+	my ($adbm, $adbmtype) = &sendmail::access_dbm($conf);
 	if (!$adbm) {
 		return $text{'mxv_eaccess'};
 		}
@@ -1779,8 +1779,8 @@ if ($mail_system == 1) {
 		return &text('mxv_eaccessfile', "<tt>$afile</tt>");
 		}
 	&lock_file($afile);
-	local @accs = &sendmail::list_access($afile);
-	local $gotdoma;
+	my @accs = &sendmail::list_access($afile);
+	my $gotdoma;
 	foreach my $a (@accs) {
 		next if ($a->{'tag'} ne 'To');
 		if ($a->{'from'} eq $dom) {
@@ -1807,10 +1807,10 @@ if ($mail_system == 1) {
 		}
 
 	# Check if relaying for this domain - will be false after deletion
-	local $cwfile;
-	local @dlist = &sendmail::get_file_or_config($conf, "R", undef,
+	my $cwfile;
+	my @dlist = &sendmail::get_file_or_config($conf, "R", undef,
                                                      \$cwfile);
-	local $relaying = &indexof(lc($dom), (map { lc($_) } @dlist)) >= 0;
+	my $relaying = &indexof(lc($dom), (map { lc($_) } @dlist)) >= 0;
 
 	# Add, update or remove domain-level rule
 	if (!$relaying && scalar(keys %mailboxes_map) == 0) {
@@ -1845,16 +1845,16 @@ if ($mail_system == 1) {
 	}
 elsif ($mail_system == 0) {
 	# Update Postfix relay_recipient_maps
-	local $rrm = &postfix::get_current_value("relay_recipient_maps");
+	my $rrm = &postfix::get_current_value("relay_recipient_maps");
 	if (!$rrm) {
 		return &text('mxv_rrm', 'relay_recipient_maps');
 		}
-	local @mapfiles = &postfix::get_maps_files($rrm);
+	my @mapfiles = &postfix::get_maps_files($rrm);
 	foreach my $f (@mapfiles) {
 		&lock_file($f);
 		}
-	local $maps = &postfix::get_maps('relay_recipient_maps');
-	local @maps_copy = @$maps;	# delete_virtuser modifies map cache
+	my $maps = &postfix::get_maps('relay_recipient_maps');
+	my @maps_copy = @$maps;	# delete_virtuser modifies map cache
 	foreach my $m (@maps_copy) {
 		my ($mbox, $mdom) = split(/\@/, $m->{'name'});
 		next if ($mdom ne $dom);
@@ -1890,9 +1890,9 @@ return $rv;
 # domain is one alias
 sub register_sync_secondary_virtuser
 {
-local ($virt) = @_;
+my ($virt) = @_;
 if ($virt->{'from'} =~ /\@(\S+)$/) {
-	local $d = &get_domain_by("dom", "$1");
+	my $d = &get_domain_by("dom", "$1");
 	if ($d) {
 		&register_post_action(\&sync_secondary_virtusers, $d);
 		}
@@ -1903,7 +1903,7 @@ if ($virt->{'from'} =~ /\@(\S+)$/) {
 sub needs_alias
 {
 return 1 if (@_ != 1);
-local $t;
+my $t;
 foreach $t (@_) {
 	return 1 if (&alias_type($t) != 1 && &alias_type($t) != 8 &&
 		     &alias_type($t) != 9);
@@ -1932,7 +1932,7 @@ elsif ($mail_system == 0) {
 	}
 elsif ($mail_system == 2) {
 	# Just look for qmail-send
-	local ($pid) = &find_byname("qmail-send");
+	my ($pid) = &find_byname("qmail-send");
 	return $pid ? 1 : 0;
 	}
 }
@@ -1942,7 +1942,7 @@ elsif ($mail_system == 2) {
 sub shutdown_mail_server
 {
 &require_mail();
-local $err;
+my $err;
 if ($mail_system == 1) {
 	# Kill or stop sendmail
 	$err = &sendmail::stop_sendmail();
@@ -1968,7 +1968,7 @@ elsif ($err) {
 sub startup_mail_server
 {
 &require_mail();
-local $err;
+my $err;
 if ($mail_system == 1) {
 	# Run the sendmail start command
 	$err = &sendmail::start_sendmail();
@@ -2011,12 +2011,12 @@ else {
 # and type (0 for mbox, 1 for maildir)
 sub create_mail_file
 {
-local ($user, $d, $nofolders) = @_;
+my ($user, $d, $nofolders) = @_;
 &require_mail();
-local $mf;
-local $md;
-local ($uid, $gid) = ($user->{'uid'}, $user->{'gid'});
-local @rv;
+my $mf;
+my $md;
+my ($uid, $gid) = ($user->{'uid'}, $user->{'gid'});
+my @rv;
 if ($mail_system == 1) {
 	# Sendmail normally uses a mail file
 	$mf = &sendmail::user_mail_file($user->{'user'});
@@ -2028,7 +2028,7 @@ if ($mail_system == 1) {
 	}
 elsif ($mail_system == 0) {
 	# Postfix user
-	local ($s, $d) = &postfix::postfix_mail_system();
+	my ($s, $d) = &postfix::postfix_mail_system();
 	if ($s == 0 || $s == 1) {
 		# A mail file
 		$mf = &postfix::postfix_mail_file($user->{'user'});
@@ -2045,7 +2045,7 @@ elsif ($mail_system == 0) {
 		}
 	elsif ($s == 2) {
 		# A mail directory
-		local @uinfo = ( $user->{'user'}, $user->{'pass'},
+		my @uinfo = ( $user->{'user'}, $user->{'pass'},
 				 $user->{'uid'}, $user->{'gid'},
 				 undef, undef, $user->{'real'},
 			         $user->{'home'}, $user->{'shell'} );
@@ -2086,7 +2086,7 @@ if ($mf) {
 elsif ($md) {
 	if (!-d $md) {
 		# Create the Maildir, owned by the user
-		local $d;
+		my $d;
 		&unlink_file($md);
 		foreach $d ($md, "$md/cur", "$md/tmp", "$md/new") {
 			&make_dir($d, 0700, 1);
@@ -2099,16 +2099,16 @@ elsif ($md) {
 if (-d $user->{'home'}) {
 	# Create Usermin ~/mail directory (if installed)
 	if (&foreign_installed("usermin")) {
-		local %uminiserv;
+		my %uminiserv;
 		&usermin::get_usermin_miniserv_config(\%uminiserv);
-		local $mod = "mailbox";
-		local %uconfig;
+		my $mod = "mailbox";
+		my %uconfig;
 		&read_file("$uminiserv{'root'}/$mod/defaultuconfig",
 			   \%uconfig);
 		&read_file("$usermin::config{'usermin_dir'}/$mod/uconfig",
 			   \%uconfig);
-		local $umd = $uconfig{'mailbox_dir'} || "mail";
-		local $umail = "$user->{'home'}/$umd";
+		my $umd = $uconfig{'mailbox_dir'} || "mail";
+		my $umail = "$user->{'home'}/$umd";
 		if (!-e $umail) {
 			&make_dir($umail, 0755);
 			&set_ownership_permissions($uid, $gid, undef, $umail);
@@ -2118,16 +2118,16 @@ if (-d $user->{'home'}) {
 
 # Create spam, virus, drafts, sent and trash Maildir sub-directories
 if ($md && $md =~ /\/Maildir$/ && !$nofolders) {
-	local @folders;
+	my @folders;
 	foreach my $n ("trash", "drafts", "sent") {
-		local $tname = $config{$n.'_folder'};
+		my $tname = $config{$n.'_folder'};
 		$tname ||= $n;
 		if ($tname ne "*") {
 			push(@folders, "$md/.$tname");
 			}
 		}
 	if ($d->{'spam'}) {
-		local ($sdmode, $sdpath) = &get_domain_spam_delivery($d);
+		my ($sdmode, $sdpath) = &get_domain_spam_delivery($d);
 		if ($sdmode == 6) {
 			push(@folders, "$md/.".($sdpath || "Junk"));
 			}
@@ -2136,7 +2136,7 @@ if ($md && $md =~ /\/Maildir$/ && !$nofolders) {
 			}
 		}
 	if ($d->{'virus'}) {
-		local ($vdmode, $vdpath) = &get_domain_virus_delivery($d);
+		my ($vdmode, $vdpath) = &get_domain_virus_delivery($d);
 		if ($vdmode == 6) {
 			push(@folders, "$md/.".($vdpath || "Virus"));
 			}
@@ -2181,7 +2181,7 @@ if ($_[0] =~ /^\//) {
 	}
 else {
 	&require_mail();
-	local $pfx = &qmailadmin::get_control_file("ldapmessagestore");
+	my $pfx = &qmailadmin::get_control_file("ldapmessagestore");
 	return $pfx."/".$_[0];
 	}
 }
@@ -2190,7 +2190,7 @@ else {
 # Chowns some mail folder to a user
 sub set_mailfolder_owner
 {
-local ($folder, $user) = @_;
+my ($folder, $user) = @_;
 &execute_command("chown -R $user->{'uid'}:$user->{'gid'} ".
 		 quotemeta($folder->{'file'}));
 }
@@ -2205,16 +2205,16 @@ sub delete_mail_file
 &foreign_require("mailboxes");
 &mailboxes::delete_user_index_files($_[0]->{'user'});
 
-local $umf = &user_mail_file($_[0]);
+my $umf = &user_mail_file($_[0]);
 if ($umf) {
 	&system_logged("rm -rf ".quotemeta($umf));
 	}
-local $noat;
+my $noat;
 if ($mail_system == 0 && $_[0]->{'user'} =~ /\@/) {
 	# Remove real file as well as link, if any
-	local $fakeuser = { %{$_[0]} };
+	my $fakeuser = { %{$_[0]} };
 	$fakeuser->{'user'} = $noat = &replace_atsign_if_exists($_[0]->{'user'});
-	local ($realumf, $realtype) = &user_mail_file($fakeuser);
+	my ($realumf, $realtype) = &user_mail_file($fakeuser);
 	if ($realumf ne $umf && $realtype == 0) {
 		&system_logged("rm -f ".quotemeta($realumf));
 		}
@@ -2222,7 +2222,7 @@ if ($mail_system == 0 && $_[0]->{'user'} =~ /\@/) {
 
 # Delete old-style mail file under /var/mail or /var/spool/mail , which
 # procmail sometimes creates
-local @extras = ( "/var/mail/$_[0]->{'user'}",
+my @extras = ( "/var/mail/$_[0]->{'user'}",
 	          "/var/spool/mail/$_[0]->{'user'}" );
 if ($noat) {
 	# Also delete files under /var/mail for username without at sign
@@ -2234,8 +2234,8 @@ if ($noat) {
 # Delete BOGUS.username.xxx files
 foreach my $e (@extras) {
 	if ($e =~ /^(.*)\/([^\/]+)$/) {
-		local ($dir, $file) = ($1, $2);
-		local @bogus = grep { -f $_ } glob("$dir/BOGUS.$file.*");
+		my ($dir, $file) = ($1, $2);
+		my @bogus = grep { -f $_ } glob("$dir/BOGUS.$file.*");
 		&unlink_file(@bogus) if (@bogus);
 		}
 	}
@@ -2243,10 +2243,10 @@ foreach my $e (@extras) {
 # Remove clamav temp files
 opendir(TEMP, "/tmp");
 foreach my $f (readdir(TEMP)) {
-	local $p = "/tmp/$f";
+	my $p = "/tmp/$f";
 	if ($f =~ /^clamav-([a-f0-9]+)$/ || $f =~ /^clamwrapper\.\d+$/ ||
 	    $f =~ /^\.spamassassin.*tmp$/) {
-		local @st = stat($p);
+		my @st = stat($p);
 		if ($st[4] == $_[0]->{'uid'} && $st[5] == $_[0]->{'gid'}) {
 			# Found one to remove
 			&unlink_file($p);
@@ -2280,20 +2280,20 @@ my ($user, $olduser) = @_;
 if (!&mail_under_home()) {
 	if ($mail_system == 1) {
 		# Just rename the Sendmail mail file (if necessary)
-		local $of = &sendmail::user_mail_file($olduser->{'user'});
-		local $nf = &sendmail::user_mail_file($user->{'user'});
+		my $of = &sendmail::user_mail_file($olduser->{'user'});
+		my $nf = &sendmail::user_mail_file($user->{'user'});
 		&rename_logged($of, $nf) if ($of ne $nf);
 		}
 	elsif ($mail_system == 0) {
 		# Find out from Postfix which file to rename (if necessary)
-		local $nf = &postfix::postfix_mail_file($user->{'user'});
-		local $of = &postfix::postfix_mail_file($olduser->{'user'});
+		my $nf = &postfix::postfix_mail_file($user->{'user'});
+		my $of = &postfix::postfix_mail_file($olduser->{'user'});
 		&rename_logged($of, $nf) if ($of ne $nf);
 		}
 	elsif ($mail_system == 2) {
 		# Just rename the Qmail mail file (if necessary)
-		local $of = &qmailadmin::user_mail_file($olduser->{'user'});
-		local $nf = &qmailadmin::user_mail_file($user->{'user'});
+		my $of = &qmailadmin::user_mail_file($olduser->{'user'});
+		my $nf = &qmailadmin::user_mail_file($user->{'user'});
 		&rename_logged($of, $nf) if ($of ne $nf);
 		}
 	}
@@ -2349,7 +2349,7 @@ if ($mail_system == 1) {
 	return !$sconfig{'mail_dir'};
 	}
 elsif ($mail_system == 0) {
-	local $s = &postfix::postfix_mail_system();
+	my $s = &postfix::postfix_mail_system();
 	return $s != 0;
 	}
 elsif ($mail_system == 2) {
@@ -2363,7 +2363,7 @@ return 0;
 sub user_mail_file
 {
 &require_mail();
-local @rv;
+my @rv;
 if (!$_[0]->{'user'} || !$_[0]->{'home'}) {
 	# User doesn't exist!
 	@rv = ( );
@@ -2375,7 +2375,7 @@ elsif ($mail_system == 1) {
 	}
 elsif ($mail_system == 0) {
 	# Find out from Postfix which file to check
-	local @pms = &postfix::postfix_mail_system();
+	my @pms = &postfix::postfix_mail_system();
 	@rv = ( &postfix::postfix_mail_file($_[0]->{'user'}),
 		$pms[0] == 2 ? 1 : 0 );
 	}
@@ -2413,7 +2413,7 @@ if ($mail_system == 1) {
 	}
 elsif ($mail_system == 0) {
 	# Need to query Postfix module for paths
-	local @s = &postfix::postfix_mail_system();
+	my @s = &postfix::postfix_mail_system();
 	$s[1] =~ s/\/$//;	# Remove / from Maildir/
 	if ($s[0] == 0) {
 		return ($s[1], 0, undef, undef);
@@ -2449,15 +2449,15 @@ return ( );
 sub mail_file_size
 {
 &require_mail();
-local $umf = &user_mail_file($_[0]);
+my $umf = &user_mail_file($_[0]);
 if (-d $umf) {
 	# Need to sum up a maildir-format directory, via a recursive search
-	local ($sz, $maxmod, $ct) = &recursive_disk_usage_mtime($umf);
+	my ($sz, $maxmod, $ct) = &recursive_disk_usage_mtime($umf);
 	return ( $sz, $umf, $maxmod, $ct );
 	}
 else {
 	# Just the size of a single mail file
-	local @st = stat($umf);
+	my @st = stat($umf);
 	return ( $st[12]*&quota_bsize("mail", 1) || $st[7], $umf, $st[9], 1 );
 	}
 }
@@ -2470,17 +2470,17 @@ else {
 # in bytes.
 sub recursive_disk_usage_mtime
 {
-local ($dir, $gid, $levels, $inodes, $exclude) = @_;
+my ($dir, $gid, $levels, $inodes, $exclude) = @_;
 $exclude = [ map { &translate_filename($_) } @$exclude ] if ($exclude);
-local $dir = &translate_filename($dir);
+my $dir = &translate_filename($dir);
 return (0, undef, 0, 0) if $exclude && grep { index($dir, $_) == 0 } @$exclude;
-local $bs = &quota_bsize("mail", 1);
+my $bs = &quota_bsize("mail", 1);
 $inodes ||= { };
 if (-l $dir) {
 	return (0, undef, 1, 0);
 	}
 elsif (!-d $dir) {
-	local @st = stat($dir);
+	my @st = stat($dir);
 	if ($inodes{$st[1]}++) {
 		# Already done this inode (ie. hard link)
 		return ( 0, undef, 0, 0 );
@@ -2493,8 +2493,8 @@ elsif (!-d $dir) {
 		}
 	}
 else {
-	local @st = stat($dir);
-	local ($rv, $rt, $ct, $dct) = (0, undef, 0, 0);
+	my @st = stat($dir);
+	my ($rv, $rt, $ct, $dct) = (0, undef, 0, 0);
 	if (!defined($gid) || $st[5] == $gid) {
 		$rv = $st[12]*$bs;
 		$rt = $st[9];
@@ -2502,11 +2502,11 @@ else {
 		}
 	if (!defined($levels) || $levels > 0) {
 		opendir(DIR, $dir);
-		local @files = readdir(DIR);
+		my @files = readdir(DIR);
 		closedir(DIR);
 		foreach my $f (@files) {
 			next if ($f eq "." || $f eq "..");
-			local ($ss, $st, $c, $dc) = &recursive_disk_usage_mtime(
+			my ($ss, $st, $c, $dc) = &recursive_disk_usage_mtime(
 				"$dir/$f", $gid,
 				defined($levels) ? $levels - 1 : undef,
 				$inodes, $exclude);
@@ -2534,7 +2534,7 @@ if ($config{'mail'}) {
 		}
 	elsif ($mail_system == 0) {
 		# Find out from postfix
-		local @s = &postfix::postfix_mail_system();
+		my @s = &postfix::postfix_mail_system();
 		if ($s[0] == 0) {
 			return $s[1];
 			}
@@ -2571,8 +2571,8 @@ sub read_mail_link
 {
 if (&foreign_available("mailboxes")) {
 	# Use mailboxes module if possible
-	local %mconfig = &foreign_config("mailboxes");
-	local %minfo = &get_module_info("mailboxes");
+	my %mconfig = &foreign_config("mailboxes");
+	my %minfo = &get_module_info("mailboxes");
 	if ($mconfig{'mail_system'} == $mail_system) {
 		# Read a Unix user's mail
 		return "../mailboxes/list_mail.cgi?user=".
@@ -2633,14 +2633,14 @@ sub check_alias_clash
 {
 &require_mail();
 if ($mail_system == 1) {
-	local @aliases = &sendmail::list_aliases($sendmail_afiles);
-	local ($clash) = grep { lc($_->{'name'}) eq lc($_[0]) &&
+	my @aliases = &sendmail::list_aliases($sendmail_afiles);
+	my ($clash) = grep { lc($_->{'name'}) eq lc($_[0]) &&
 				$_->{'enabled'} } @aliases;
 	return $clash;
 	}
 elsif ($mail_system == 0) {
-	local @aliases = &$postfix_list_aliases($postfix_afiles);
-	local ($clash) = grep { lc($_->{'name'}) eq lc($_[0]) &&
+	my @aliases = &$postfix_list_aliases($postfix_afiles);
+	my ($clash) = grep { lc($_->{'name'}) eq lc($_[0]) &&
 				$_->{'enabled'} } @aliases;
 	return $clash;
 	}
@@ -2651,8 +2651,8 @@ return undef;
 # Saves all mail aliases and mailbox users for this domain
 sub backup_mail
 {
-local ($d, $file, $opts, $homefmt, $increment, $asd, $allopts, $key) = @_;
-local $compression = $allopts->{'dir'}->{'compression'};
+my ($d, $file, $opts, $homefmt, $increment, $asd, $allopts, $key) = @_;
+my $compression = $allopts->{'dir'}->{'compression'};
 &require_mail();
 
 # Create dummy file
@@ -2668,7 +2668,7 @@ my $url = &get_user_database_url();
 # Mailman) are not included
 &$first_print($text{'backup_mailaliases'});
 &open_tempfile_as_domain_user($d, AFILE, ">${file}_aliases");
-local $a;
+my $a;
 foreach $a (&list_domain_aliases($d, 1)) {
 	&print_tempfile(AFILE, $a->{'from'},": ");
 	&print_tempfile(AFILE, join(",", @{$a->{'to'}}),"\n");
@@ -2681,7 +2681,7 @@ foreach $a (&list_domain_aliases($d, 1)) {
 # addresses.
 &$first_print($text{'backup_mailusers'});
 &open_tempfile_as_domain_user($d, UFILE, ">${file}_users");
-local $u;
+my $u;
 foreach $u (&list_domain_users($d)) {
 	&print_tempfile(UFILE, join(":", $u->{'user'}, $u->{'pass'},
 			      $u->{'webowner'} ? 'w' : $u->{'uid'}, $u->{'gid'},
@@ -2698,7 +2698,7 @@ foreach $u (&list_domain_users($d)) {
 		}
 
 	# Add databases
-	local (@dbstr, %donetype);
+	my (@dbstr, %donetype);
 	foreach my $db (@{$u->{'dbs'}}) {
 		push(@dbstr, $db->{'type'}." ".$db->{'name'});
 		$donetype{$db->{'type'}}++;
@@ -2706,7 +2706,7 @@ foreach $u (&list_domain_users($d)) {
 	&print_tempfile(UFILE, ":".(join(";", @dbstr) || "-"));
 
 	# Add database-type passwords
-	local (@passstr);
+	my (@passstr);
 	foreach my $t (keys %donetype) {
 		push(@passstr, $t." ".$u->{$t."_pass"});
 		}
@@ -2744,13 +2744,13 @@ if (-r "$quota_cache_dir/$d->{'id'}") {
 
 # Create BCC files
 if ($supports_bcc) {
-	local $bcc = &get_domain_sender_bcc($d);
+	my $bcc = &get_domain_sender_bcc($d);
 	&open_tempfile(BCC, ">".$file."_bcc");
 	&print_tempfile(BCC, $bcc,"\n");
 	&close_tempfile(BCC);
 	}
 if ($supports_bcc == 2) {
-	local $rbcc = &get_domain_recipient_bcc($d);
+	my $rbcc = &get_domain_recipient_bcc($d);
 	&open_tempfile(BCC, ">".$file."_rbcc");
 	&print_tempfile(BCC, $rbcc,"\n");
 	&close_tempfile(BCC);
@@ -2758,7 +2758,7 @@ if ($supports_bcc == 2) {
 
 # Create sender dependent file
 if ($supports_dependent) {
-	local $dependent = &get_domain_dependent($d);
+	my $dependent = &get_domain_dependent($d);
 	&open_tempfile(DEPENDENT, ">".$file."_dependent");
 	&print_tempfile(DEPENDENT, $dependent,"\n");
 	&close_tempfile(DEPENDENT);
@@ -2766,8 +2766,8 @@ if ($supports_dependent) {
 
 # Create custom DKIM key file
 if ($d->{'mail'} && !$d->{'alias'} && $config{'dkim_enabled'}) {
-	local $keyfile = &get_domain_dkim_key($d);
-	local $keyback = $file."_domdkim";
+	my $keyfile = &get_domain_dkim_key($d);
+	my $keyback = $file."_domdkim";
 	if ($keyfile) {
 		# Save the key
 		&copy_write_as_domain_user($d, $keyfile, $keyback);
@@ -2783,11 +2783,11 @@ if ($d->{'mail'} && !$d->{'alias'} && $config{'dkim_enabled'}) {
 
 if (!&mail_under_home()) {
 	# Backup actual mail files too..
-	local $mbase = &mail_system_base();
-	local @mfiles;
+	my $mbase = &mail_system_base();
+	my @mfiles;
 	&$first_print($text{'backup_mailfiles'});
 	foreach $u (&list_domain_users($d, 0, 1, 1, 1)) {
-		local $umf = &user_mail_file($u);
+		my $umf = &user_mail_file($u);
 		if ($umf =~ s/^$mbase\///) {
 			push(@mfiles, $umf) if (-r "$mbase/$umf");
 			}
@@ -2796,9 +2796,9 @@ if (!&mail_under_home()) {
 		&$second_print($text{'backup_mailfilesnone'});
 		}
 	else {
-		local $out;
-		local $temp = &transname();
-		local $out = &backquote_command(&make_archive_command(
+		my $out;
+		my $temp = &transname();
+		my $out = &backquote_command(&make_archive_command(
 			$compression, $mbase, $temp, @mfiles));
 		if ($?) {
 			&$second_print(&text('backup_mailfilesfailed',
@@ -2815,9 +2815,9 @@ if (!&mail_under_home()) {
 # Backup all user cron jobs
 &foreign_require("cron");
 &$first_print($text{'backup_mailcrons'});
-local $croncount = 0;
+my $croncount = 0;
 foreach $u (&list_domain_users($d, 1)) {
-	local $cronfile = &cron::cron_file({ 'user' => $u->{'user'} });
+	my $cronfile = &cron::cron_file({ 'user' => $u->{'user'} });
 	if (-r $cronfile) {
 		&copy_write_as_domain_user($d, $cronfile, $file."_cron_".$u->{'user'});
 		$croncount++;
@@ -2837,23 +2837,23 @@ else {
 if (&foreign_check("dovecot") && &foreign_installed("dovecot")) {
 	&foreign_require("dovecot");
 	if (my $envfile = get_dovecot_file_path('control')) {
-		local $control = $envfile;
+		my $control = $envfile;
 		&$first_print($text{'backup_mailcontrol'});
-		local @names;
+		my @names;
 		foreach $u (&list_domain_users($d, 0, 1, 1, 1)) {
 			if (-e "$control/$u->{'user'}") {
 				push(@names, $u->{'user'});
 				}
-			local $repl = &replace_atsign_if_exists($u->{'user'});
+			my $repl = &replace_atsign_if_exists($u->{'user'});
 			if ($repl ne $u->{'user'} && -e "$control/$repl") {
 				push(@names, $repl);
 				}
 			}
 		@names = &unique(@names);
 		if (@names) {
-			local $out;
-			local $temp = &transname();
-			local $out = &backquote_command(&make_archive_command(
+			my $out;
+			my $temp = &transname();
+			my $out = &backquote_command(&make_archive_command(
 				$compression, $control, $temp, @names)." 2>&1");
 			if ($?) {
 				&$second_print(&text('backup_emailcontrol',
@@ -2873,7 +2873,7 @@ if (&foreign_check("dovecot") && &foreign_installed("dovecot")) {
 	}
 
 # If any user's homes are outside the domain root, back them up separately
-local @homeless;
+my @homeless;
 foreach $u (&list_domain_users($d, 1)) {
 	if (-d $u->{'home'} &&
 	    !&is_under_directory($d->{'home'}, $u->{'home'})) {
@@ -2883,10 +2883,10 @@ foreach $u (&list_domain_users($d, 1)) {
 if (@homeless) {
 	&$first_print(&text('backup_mailhomeless', scalar(@homeless)));
 	foreach my $u (@homeless) {
-		local $file = $file."_homes_".$u->{'user'};
-		local $out;
-		local $temp = &transname();
-		local $out = &backquote_command(&make_archive_command(
+		my $file = $file."_homes_".$u->{'user'};
+		my $out;
+		my $temp = &transname();
+		my $out = &backquote_command(&make_archive_command(
 			$compression, $u->{'home'}, $temp, ".")." 2>&1");
 		if ($?) {
 			&$second_print(&text('backup_mailhomefailed',
@@ -2907,8 +2907,8 @@ return 1;
 # Restore all mail aliases and mailbox users for this domain
 sub restore_mail
 {
-local ($d, $file, $opts, $allopts, $homefmt, $oldd) = @_;
-local ($u, %olduid, @errs);
+my ($d, $file, $opts, $allopts, $homefmt, $oldd) = @_;
+my ($u, %olduid, @errs);
 
 # Check if users are being stored in the same remote storage, if replicating
 my $url = &get_user_database_url();
@@ -2928,7 +2928,7 @@ if ($url && $burl && $url eq $burl && $allopts->{'repl'} &&
 if (-r $file."_plainpass") {
 	if ($opts->{'mailuser'}) {
 		# Just copy one plain password
-		local (%oldplain, %newplain);
+		my (%oldplain, %newplain);
 		&read_file($file."_plainpass", \%oldplain);
 		&read_file("$plainpass_dir/$d->{'id'}", \%newplain);
 		$newplain{$opts->{'mailuser'}} = $oldplain{$opts->{'mailuser'}};
@@ -2970,18 +2970,18 @@ else {
 		&$second_print($text{'restore_mailuserssame'});
 		}
 	}
-local %exists;
+my %exists;
 foreach $u (&list_all_users()) {
 	$exists{$u->{'name'}} = $u;
 	}
-local $foundmailuser;
+my $foundmailuser;
 local $_;
-local @users = &list_domain_users($d);
+my @users = &list_domain_users($d);
 open(UFILE, "<".$file."_users");
-local %renamedusers;
+my %renamedusers;
 while(<UFILE>) {
 	s/\r|\n//g;
-	local @user = split(/:/, $_);
+	my @user = split(/:/, $_);
 	$_ = <UFILE>;
 	s/\r|\n//g;
 	if ($opts->{'mailuser'}) {
@@ -2994,13 +2994,13 @@ while(<UFILE>) {
 			next;
 			}
 		}
-	local @to = split(/,/, $_);
+	my @to = split(/,/, $_);
 	if ($user[0] eq $d->{'user'} ||
 	    $d->{'restoreolduser'} && $user[0] eq $d->{'restoreolduser'}) {
 		# Domain owner, just update alias list
-		local ($uinfo) = grep { $_->{'user'} eq $d->{'user'} } @users;
+		my ($uinfo) = grep { $_->{'user'} eq $d->{'user'} } @users;
 		if ($uinfo) {
-			local %old = %$uinfo;
+			my %old = %$uinfo;
 			$uinfo->{'email'} = $user[7];
 			$uinfo->{'to'} = \@to;
 			&modify_user($uinfo, \%old, $d);
@@ -3008,9 +3008,9 @@ while(<UFILE>) {
 		}
 	elsif ($sameurl) {
 		# Same LDAP server, so just update alias list for this user
-		local ($uinfo) = grep { $_->{'user'} eq $user[0] } @users;
+		my ($uinfo) = grep { $_->{'user'} eq $user[0] } @users;
 		if ($uinfo) {
-			local %old = %$uinfo;
+			my %old = %$uinfo;
 			$uinfo->{'email'} = $user[7];
 			$uinfo->{'to'} = \@to;
 			&modify_user($uinfo, \%old, $d);
@@ -3018,7 +3018,7 @@ while(<UFILE>) {
 		}
 	else {
 		# Need to re-create user
-		local $uinfo = &create_initial_user($d, 0, $user[2] eq 'w');
+		my $uinfo = &create_initial_user($d, 0, $user[2] eq 'w');
 		if ($exists{$user[0]}) {
 			push(@errs, &text('restore_mailexists', $user[0]));
 			next;
@@ -3048,7 +3048,7 @@ while(<UFILE>) {
 			}
 		elsif ($allopts->{'reuid'}) {
 			# Re-allocate UID
-			local %taken;
+			my %taken;
 			&build_taken(\%taken);
 			$uinfo->{'uid'} = &allocate_uid(\%taken);
 			}
@@ -3080,7 +3080,7 @@ while(<UFILE>) {
 
 		# Restore databases
 		if ($user[10] && $user[10] ne "-") {
-			local @dbs = split(/;/, $user[10]);
+			my @dbs = split(/;/, $user[10]);
 			foreach my $db (@dbs) {
 				my ($dbtype, $dbname) = split(/\s+/, $db, 2);
 				push(@{$uinfo->{'dbs'}}, { 'type' => $dbtype,
@@ -3090,7 +3090,7 @@ while(<UFILE>) {
 
 		# Restore database passwords
 		if ($user[11] && $user[11] ne "-") {
-			local @dbpass = split(/;/, $user[11]);
+			my @dbpass = split(/;/, $user[11]);
 			foreach my $db (@dbpass) {
 				my ($dbtype, $dbpass) = split(/\s+/, $db, 2);
 				$uinfo->{$dbtype."_pass"} = $dbpass;
@@ -3137,11 +3137,11 @@ while(<UFILE>) {
 		# If the user's home is outside the domain's home, re-extract
 		# it from the backup
 		if (!&is_under_directory($d->{'home'}, $uinfo->{'home'})) {
-			local $file = $file."_homes_".$uinfo->{'user'};
+			my $file = $file."_homes_".$uinfo->{'user'};
 			if (!-d $uinfo->{'home'}) {
 				&create_user_home($uinfo, $d);
 				}
-			local $out = &backquote_command(&make_unarchive_command(
+			my $out = &backquote_command(&make_unarchive_command(
 				$uinfo->{'home'}, $file)." 2>&1");
 			}
 		}
@@ -3152,7 +3152,7 @@ close(UFILE);
 if (-r $file."_hashpass") {
 	if ($opts->{'mailuser'}) {
 		# Just copy one hash password
-		local (%oldhash, %newhash);
+		my (%oldhash, %newhash);
 		&read_file($file."_hashpass", \%oldhash);
 		&read_file("$hashpass_dir/$d->{'id'}", \%newhash);
 		foreach my $s (@hashpass_types) {
@@ -3190,7 +3190,7 @@ if (-r $file."_quota_cache") {
 if (-r $file."_nospam") {
 	if ($opts->{'mailuser'}) {
 		# Just copy one flag
-		local (%oldspam, %newspam);
+		my (%oldspam, %newspam);
 		&read_file($file."_nospam", \%oldspam);
 		&read_file("$nospam_dir/$d->{'id'}", \%newspam);
 		$newspam{$opts->{'mailuser'}} = $oldspam{$opts->{'mailuser'}};
@@ -3205,19 +3205,19 @@ if (-r $file."_nospam") {
 
 # Restore BCC files
 if ($supports_bcc && -r $file."_bcc") {
-	local $bcc = &read_file_contents($file."_bcc");
+	my $bcc = &read_file_contents($file."_bcc");
 	chop($bcc);
 	&save_domain_sender_bcc($d, $bcc);
 	}
 if ($supports_bcc == 2 && -r $file."_rbcc") {
-	local $rbcc = &read_file_contents($file."_rbcc");
+	my $rbcc = &read_file_contents($file."_rbcc");
 	chop($rbcc);
 	&save_domain_recipient_bcc($d, $rbcc);
 	}
 
 # Restore sender-dependent IP
 if ($supports_dependent && -r $file."_dependent") {
-	local $dependent = &read_file_contents($file."_dependent");
+	my $dependent = &read_file_contents($file."_dependent");
 	chop($dependent);
 	&save_domain_dependent($d, $dependent ? 1 : 0);
 	}
@@ -3255,16 +3255,16 @@ if (!$opts->{'mailuser'}) {
 	# Delete all aliases and re-create (except for those used by plugins
 	# such as mailman)
 	&$first_print($text{'restore_mailaliases'});
-	local $a;
+	my $a;
 	foreach $a (&list_domain_aliases($d, 1)) {
 		&delete_virtuser($a);
 		}
-	local %existing = map { $_->{'from'}, $_ } &list_virtusers();
+	my %existing = map { $_->{'from'}, $_ } &list_virtusers();
 	local $_;
 	open(AFILE, "<".$file."_aliases");
 	while(<AFILE>) {
 		if (/^(\S+):\s*(.*)/) {
-			local $virt = { 'from' => $1,
+			my $virt = { 'from' => $1,
 					'to' => [ split(/,/, $2) ] };
 			next if ($exists{$virt->{'from'}}++);
 			for(my $i=0; $i<@{$virt->{'to'}}; $i++) {
@@ -3299,14 +3299,14 @@ if (!$opts->{'mailuser'}) {
 
 # Get users whose mail files may need to be moved
 &foreign_require("mailboxes");
-local @users = &list_domain_users($d);
+my @users = &list_domain_users($d);
 if ($opts->{'mailuser'}) {
 	@users = grep { $_->{'user'} eq $foundmailuser } @users;
 	}
 
 if (-r $file."_files" &&
     (!$opts->{'mailuser'} || $foundmailuser)) {
-	local $xtract;
+	my $xtract;
 	if (!&mail_under_home()) {
 		# Can just extract all mail files in /var/mail
 		$xtract = &mail_system_base();
@@ -3318,7 +3318,7 @@ if (-r $file."_files" &&
 		$xtract = &transname();
 		&make_dir($xtract, 0700);
 		}
-	local $out;
+	my $out;
 	if ($opts->{'mailuser'}) {
 		# Just do one user
 		&$first_print(&text('restore_mailfiles3', $opts->{'mailuser'}));
@@ -3339,10 +3339,10 @@ if (-r $file."_files" &&
 	if (&mail_under_home()) {
 		# Move mail from /var/mail to ~/Maildir
 		foreach my $u (@users) {
-			local $path = "$xtract/$u->{'user'}";
-			local $sf = { 'type' => -d $path ? 1 : 0,
+			my $path = "$xtract/$u->{'user'}";
+			my $sf = { 'type' => -d $path ? 1 : 0,
 				      'file' => $path };
-			local ($df) =
+			my ($df) =
 				&mailboxes::list_user_folders($u->{'user'});
 			if ($df) {
 				&mailboxes::mailbox_empty_folder($df);
@@ -3355,11 +3355,11 @@ if (-r $file."_files" &&
 elsif (!&mail_under_home()) {
 	# If the users have ~/Maildir directories and no mail files
 	# at the new locations (typically /var/mail), move them over
-	local $doneprint;
+	my $doneprint;
 	foreach my $u (@users) {
-		local ($df) = &mailboxes::list_user_folders($u->{'user'});
+		my ($df) = &mailboxes::list_user_folders($u->{'user'});
 		next if (-e $df->{'file'});
-		local $sf;
+		my $sf;
 		if (-d "$u->{'home'}/Maildir") {
 			$sf = { 'type' => 1,
 				'file' => "$u->{'home'}/Maildir" };
@@ -3385,18 +3385,18 @@ elsif (!&mail_under_home()) {
 
 # Check if the location for additional folders differs between systems,
 # and if so copy them across
-local %mconfig = &foreign_config("mailboxes");
-local $newdir = $mconfig{'mail_usermin'};
-local $olddir = $d->{'backup_mail_folders'};
+my %mconfig = &foreign_config("mailboxes");
+my $newdir = $mconfig{'mail_usermin'};
+my $olddir = $d->{'backup_mail_folders'};
 if ($newdir && $olddir && $newdir ne $olddir && @users) {
 	# Need to migrate, such as when moving from a system using ~/mail/mbox
 	# to ~/Maildir/.dir
 	&$first_print(&text('restore_mailmove2'));
 	foreach my $u (@users) {
 		local $mailboxes::config{'mail_usermin'} = $olddir;
-		local @folders = &mailboxes::list_user_folders($u->{'user'});
-		local $newbase = "$u->{'home'}/$newdir";
-		local $oldbase = "$u->{'home'}/$olddir";
+		my @folders = &mailboxes::list_user_folders($u->{'user'});
+		my $newbase = "$u->{'home'}/$newdir";
+		my $oldbase = "$u->{'home'}/$olddir";
 		if (!-e $newbase) {
 			# Create folders dir
 			&make_dir($newbase, 0755);
@@ -3406,11 +3406,11 @@ if ($newdir && $olddir && $newdir ne $olddir && @users) {
 		foreach my $oldf (@folders) {
 			next if (!&is_under_directory("$u->{'home'}/$olddir",
 						      $oldf->{'file'}));
-			local $newf = { };
-			local $oldname = $oldf->{'file'};
+			my $newf = { };
+			my $oldname = $oldf->{'file'};
 			next if ($oldname eq $oldbase);	  # Skip inbox
 			$oldname =~ s/^\Q$oldbase\E\///;  # Get folder name,
-			local $oldnameorig = $oldname;
+			my $oldnameorig = $oldname;
 			$oldname =~ s/^\.//;		  # with no dots before
 			$oldname =~ s/\/\./\//;		  # path elements
 			if ($newdir eq "Maildir") {
@@ -3456,7 +3456,7 @@ if (-r $file."_cron") {
 	&foreign_require("cron");
 	foreach $u (&list_domain_users($d, 1)) {
 		next if ($opts->{'mailuser'} && $u->{'user'} ne $foundmailuser);
-		local $cf = $file."_cron_".$u->{'user'};
+		my $cf = $file."_cron_".$u->{'user'};
 		$cf = "/dev/null" if (!-r $cf);
 		&copy_source_dest($cf, $cron::cron_temp_file);
 		&cron::copy_crontab($u->{'user'});
@@ -3470,18 +3470,18 @@ if (-r $file."_control" && &foreign_check("dovecot") &&
 	&foreign_require("dovecot");
 	if (my $envfile = get_dovecot_file_path('control')) {
 		# Local dovecot specifies a control file location
-		local $control = $envfile;
+		my $control = $envfile;
 		&$first_print($text{'restore_mailcontrol'});
-		local @onefiles;
+		my @onefiles;
 		if ($opts->{'mailuser'}) {
 			# Limit extract to one user
 			push(@onefiles, $opts->{'mailuser'});
-			local $at = &replace_atsign_if_exists($opts->{'mailuser'});
+			my $at = &replace_atsign_if_exists($opts->{'mailuser'});
 			if ($at ne $opts->{'mailuser'}) {
 				push(@onefiles, $at);
 				}
 			}
-		local $out = &backquote_command(&make_unarchive_command(
+		my $out = &backquote_command(&make_unarchive_command(
 			$control, $file."_control", @onefiles)." 2>&1");
 		if ($?) {
 			&$second_print(&text('restore_emailcontrol', $out));
@@ -3501,7 +3501,7 @@ if (-r $file."_control" && &foreign_check("dovecot") &&
 	}
 
 # Set mailbox user home directory permissions
-local $hb = "$d->{'home'}/$config{'homes_dir'}";
+my $hb = "$d->{'home'}/$config{'homes_dir'}";
 foreach $u (&list_domain_users($d, 1)) {
 	if (-d $u->{'home'} && &is_under_directory($hb, $u->{'home'}) &&
 	    (!$opts->{'mailuser'} || $u->{'user'} eq $foundmailuser)) {
@@ -3550,13 +3550,13 @@ sub check_clash
 {
 &require_mail();
 return 0 if (!$config{'mail'});
-local @virts = &list_virtusers();
-local ($clash) = grep { $_->{'from'} eq $_[0]."\@".$_[1] } @virts;
+my @virts = &list_virtusers();
+my ($clash) = grep { $_->{'from'} eq $_[0]."\@".$_[1] } @virts;
 return 1 if ($clash);
 if ($mail_system == 1) {
 	# Check for a Sendmail alias with the same name as the user
-	local @aliases = &sendmail::list_aliases($sendmail_afiles);
-	local $an = $_[0] ? "$_[0]-$_[1]" : "default-$_[1]";
+	my @aliases = &sendmail::list_aliases($sendmail_afiles);
+	my $an = $_[0] ? "$_[0]-$_[1]" : "default-$_[1]";
 	($clash) = grep { ($config{'alias_clash'} &&
 			   $_[0] && $_->{'name'} eq $_[0]) ||
 			  $_->{'name'} eq $an } @aliases;
@@ -3564,8 +3564,8 @@ if ($mail_system == 1) {
 	}
 elsif ($mail_system == 0) {
 	# Check for a Postfix alias with the same name as the user
-	local @aliases = &$postfix_list_aliases($postfix_afiles);
-	local $an = $_[0] ? "$_[0]-$_[1]" : "default-$_[1]";
+	my @aliases = &$postfix_list_aliases($postfix_afiles);
+	my $an = $_[0] ? "$_[0]-$_[1]" : "default-$_[1]";
 	($clash) = grep { ($config{'alias_clash'} &&
 			   $_[0] && $_->{'name'} eq $_[0]) ||
 			  $_->{'name'} eq $an } @aliases;
@@ -3573,7 +3573,7 @@ elsif ($mail_system == 0) {
 	}
 elsif ($mail_system == 2) {
 	# Check for a Qmail .qmail file with the same name as the user
-	local @aliases = &qmailadmin::list_aliases();
+	my @aliases = &qmailadmin::list_aliases();
 	($clash) = grep { $config{'alias_clash'} && $_[0] && $_ eq $_[0] }
 			@aliases;
 	return 2 if ($clash);
@@ -3608,7 +3608,7 @@ if ($_[0]->{'alias'} && !$_[0]->{'aliasmail'}) {
 	}
 elsif ($_[0]->{'parent'}) {
 	# If this is a sub-domain, then the parent needs a Unix user
-	local $parent = &get_domain($_[0]->{'parent'});
+	my $parent = &get_domain($_[0]->{'parent'});
 	return $parent->{'unix'} ? undef : $text{'setup_edepmail'};
 	}
 else {
@@ -3622,7 +3622,7 @@ else {
 sub check_anti_depends_mail
 {
 if (!$_[0]->{'mail'}) {
-	local @aliases = &get_domain_by("alias", $_[0]->{'id'});
+	my @aliases = &get_domain_by("alias", $_[0]->{'id'});
 	foreach my $s (@aliases) {
 		return &text('setup_edepmailalias', $s->{'dom'})
 			if ($s->{'mail'});
@@ -3634,7 +3634,7 @@ return undef;
 # mail_system_name([num])
 sub mail_system_name
 {
-local $num = defined($_[0]) ? $_[0] : $mail_system;
+my $num = defined($_[0]) ? $_[0] : $mail_system;
 return $text{'mail_system_'.$num} || "???";
 }
 
@@ -3658,24 +3658,24 @@ else {
 # hash reference of start times.
 sub bandwidth_all_mail
 {
-local ($doms, $starts, $bws) = @_;
+my ($doms, $starts, $bws) = @_;
 
 # Find the minimum last activity time
-local $start_now = time();
-local $min_ltime = $start_now+24*60*60;
+my $start_now = time();
+my $min_ltime = $start_now+24*60*60;
 foreach my $lt (values %$starts) {
 	$min_ltime = $lt if ($lt && $lt < $min_ltime);
 	}
-local %max_ltime = %$starts;
+my %max_ltime = %$starts;
 
 # Find the mail log
-local %max_updated;
-local $maillog = $config{'bw_maillog'};
+my %max_updated;
+my $maillog = $config{'bw_maillog'};
 $maillog = &get_mail_log($min_ltime) if ($maillog eq "auto");
 return $starts if (!$maillog);
 
 # Build a map from domain names to objects, and from Unix usernames to objects
-local (%maildoms, %mailusers);
+my (%maildoms, %mailusers);
 foreach my $d (@$doms) {
 	$maildoms{$d->{'dom'}} = $d;
 	foreach my $md (split(/\s+/, $d->{'bw_maildoms'})) {
@@ -3687,18 +3687,18 @@ foreach my $d (@$doms) {
 		if($config{'bw_mail_all'}){ $maildoms{$user->{'user'}} = $d; }
 		}
 	}
-local $myhostname = &get_system_hostname();
+my $myhostname = &get_system_hostname();
 
-local $f;
+my $f;
 foreach $f ($config{'bw_maillog_rotated'} ?
 	    &all_log_files($maillog, $min_ltime) : ( $maillog )) {
 	local $_;
 	&open_uncompress_file(LOG, $f);
 
 	# Scan the log, looking for entries for various mail systems
-	local (%sizes, %fromdoms);
-	local $now = time();
-	local @tm = localtime($now);
+	my (%sizes, %fromdoms);
+	my $now = time();
+	my @tm = localtime($now);
 	while(<LOG>) {
 		# Sendmail / postfix formats
 		s/\r|\n//g;
@@ -3709,8 +3709,8 @@ foreach $f ($config{'bw_maillog_rotated'} ?
 		if ($config{'bw_mail_all'} && /^(\S+)\s+(\d+)\s+(\d+):(\d+):(\d+)\s+(\S+)\s+(\S+):\s+(\S+):\s+uid=(\S+)\s+from=(\S+)/) {
 			# The initial Sending Uid: line that contains the user id and user for sending from scripts
 			# Will not work if not running php as cgi
-			local ($id, $uid, $fromuser) = ($8, $9, $10);
-			local $md = $maildoms{$uid};
+			my ($id, $uid, $fromuser) = ($8, $9, $10);
+			my $md = $maildoms{$uid};
 			if ($md && $config{'bw_mail_all'}) {
 				# Mail is from a local user. If it is to a non-
 				# local domain, we will count it in the next block
@@ -3719,8 +3719,8 @@ foreach $f ($config{'bw_maillog_rotated'} ?
 			}
 		elsif ($config{'bw_mail_all'} && /^(\S+)\s+(\d+)\s+(\d+):(\d+):(\d+)\s+(\S+)\s+(\S+):\s+(\S+):\s+client=(\S+),\s+sasl_method=(\S+),\s+sasl_username=(\S+)/) {
 			# The initial Authenticated Sending User: line that contains the user logged in sending from sasl_authentication
-			local ($id, $fromuser) = ($8, $11);
-			local $md = $maildoms{$fromuser};
+			my ($id, $fromuser) = ($8, $11);
+			my $md = $maildoms{$fromuser};
 			if ($md && !$fromdoms{$id} && $config{'bw_mail_all'}) {
 				# Mail is from a local authenticated user. If it is to a non-
 				# local domain, we will count it in the next block
@@ -3730,12 +3730,12 @@ foreach $f ($config{'bw_maillog_rotated'} ?
 		
 		elsif (/^(\S+)\s+(\d+)\s+(\d+):(\d+):(\d+)\s+(\S+)\s+(\S+):\s+(\S+):\s+from=(\S+),\s+size=(\d+)/) {
 			# The initial From: line that contains the size
-			local ($id, $size, $fromuser) = ($8, $10, $9);
+			my ($id, $size, $fromuser) = ($8, $10, $9);
 			$sizes{$id} = $size;
 			$fromuser =~ s/^<(.*)>/$1/;
                         $fromuser =~ s/,$//;
-			local ($mb, $dom) = split(/\@/, $fromuser);
-			local $md = $maildoms{$dom};
+			my ($mb, $dom) = split(/\@/, $fromuser);
+			my $md = $maildoms{$dom};
 			if (!$md && $dom eq $myhostname) {
 				# Check for mail from local user@hostname
 				$md = $mailusers{$mb};
@@ -3755,7 +3755,7 @@ foreach $f ($config{'bw_maillog_rotated'} ?
 			# A To: line that has the local recipient.
 			# The date doesn't have the year, so we need to try
 			# the day and month for this year and last year.
-			local $ltime;
+			my $ltime;
 			eval { $ltime = timelocal($5, $4, $3, $2,
 			    $apache_mmap{lc($1)}, $tm[5]); };
 			if (!$ltime || $ltime > $now+(24*60*60)) {
@@ -3763,17 +3763,17 @@ foreach $f ($config{'bw_maillog_rotated'} ?
 				eval { $ltime = timelocal($5, $4, $3, $2,
 				     $apache_mmap{lc($1)}, $tm[5]-1); };
 				}
-			local $user = $11 || $9;
+			my $user = $11 || $9;
 			if($config{'bw_mail_all'}){
-				local $user = $11;
-				local $id = $8;
+				my $user = $11;
+				my $id = $8;
 			}
-			local $sz = $sizes{$8};
-			local $fd = $fromdoms{$8};
+			my $sz = $sizes{$8};
+			my $fd = $fromdoms{$8};
 			$user =~ s/^<(.*)>/$1/;
 			$user =~ s/,$//;
-			local ($mb, $dom) = split(/\@/, $user);
-			local $md = $maildoms{$dom};
+			my ($mb, $dom) = split(/\@/, $user);
+			my $md = $maildoms{$dom};
 			if ($md && $fd && !$config{'bw_nomailout'} && $config{'bw_mail_all'}) {
 				# To a local domain - add the size to the 
 				# sending domain's usage once for local deliveries
@@ -3785,7 +3785,7 @@ foreach $f ($config{'bw_maillog_rotated'} ?
 					}
 				if ($ltime > $starts->{$fd->{'id'}} && $sz && !$lc{$id}) {
 					# New enough to record
-					local $day =
+					my $day =
 					    int($ltime / (24*60*60));
 					$bws->{$fd->{'id'}}->
 						{"mail_".$day} += $sz;
@@ -3803,7 +3803,7 @@ foreach $f ($config{'bw_maillog_rotated'} ?
 					}
 				if ($ltime > $starts->{$md->{'id'}} && $sz) {
 					# New enough to record
-					local $day =
+					my $day =
 					    int($ltime / (24*60*60));
 					$bws->{$md->{'id'}}->
 						{"mail_".$day} += $sz;
@@ -3820,7 +3820,7 @@ foreach $f ($config{'bw_maillog_rotated'} ?
 					}
 				if ($ltime > $starts->{$fd->{'id'}} && $sz) {
 					# New enough to record
-					local $day =
+					my $day =
 					    int($ltime / (24*60*60));
 					$bws->{$fd->{'id'}}->
 						{"mail_".$day} += $sz;
@@ -3829,16 +3829,16 @@ foreach $f ($config{'bw_maillog_rotated'} ?
 			}
 		elsif ($config{'bw_mail_all'} && !/status=(deferred|bounced)/ && /^(\S+)\s+(\d+)\s+(\d+):(\d+):(\d+)\s+(\S+)\s+(\S+):\s+(\S+):\s+to=(\S+),(.+\s?=sent)?/) {
 			# A To: line that has the off-site recipient
-			local $ltime = timelocal($5, $4, $3, $2,
+			my $ltime = timelocal($5, $4, $3, $2,
 			    $apache_mmap{lc($1)}, $tm[5]);
 			if ($ltime > $now+(24*60*60)) {
 				# Must have been last year!
 				$ltime = timelocal($5, $4, $3, $2,
 				     $apache_mmap{lc($1)}, $tm[5]-1);
 				}
-			local $id = $8;
-			local $sz = $sizes{$8};
-			local $fd = $fromdoms{$8};
+			my $id = $8;
+			my $sz = $sizes{$8};
+			my $fd = $fromdoms{$8};
 			if ($fd && !$config{'bw_nomailout'} && $config{'bw_mail_all'}) {
 				# From a local domain, but to an off-site
 				# domain - add the size to the sender's usage
@@ -3850,7 +3850,7 @@ foreach $f ($config{'bw_maillog_rotated'} ?
 					}
 				if ($ltime > $starts->{$fd->{'id'}} && $sz) {
 					# New enough to record
-					local $day =
+					my $day =
 					    int($ltime / (24*60*60));
 					$bws->{$fd->{'id'}}->
 						{"mail_".$day} += $sz;
@@ -3867,12 +3867,12 @@ foreach $f ($config{'bw_maillog_rotated'} ?
 		elsif (/^\@(\S+)\s+starting\s+delivery\s+(\S+):\s+msg\s+(\S+)\s+to\s+local\s+(\S+)/ ||
 		       /(\d+\.\d+)\s+starting\s+delivery\s+(\S+):\s+msg\s+(\S+)\s+to\s+local\s+(\S+)/) {
 			# To: line with actual address
-			local $sz = $sizes{$3};
-			local $user = $4;
-			local $ltime = &tai64_time($1);
+			my $sz = $sizes{$3};
+			my $user = $4;
+			my $ltime = &tai64_time($1);
 			$user =~ s/^<(.*)>/$1/;
-			local ($mb, $dom) = split(/\@/, $user);
-			local $md = $maildoms{$dom};
+			my ($mb, $dom) = split(/\@/, $user);
+			my $md = $maildoms{$dom};
 			if ($md) {
 				if ($ltime > $max_ltime{$md->{'id'}}) {
 					# Update most recent seen time for
@@ -3882,7 +3882,7 @@ foreach $f ($config{'bw_maillog_rotated'} ?
 					}
 				if ($ltime > $starts->{$md->{'id'}} && $sz) {
 					# To a user in this domain
-					local $day =
+					my $day =
 					    int($ltime / (24*60*60));
 					$bws->{$md->{'id'}}->
 						{"mail_".$day} += $sz;
@@ -3893,7 +3893,7 @@ foreach $f ($config{'bw_maillog_rotated'} ?
 
 		# Dovecot byte counts
 		elsif (/^(\S+)\s+(\d+)\s+(\d+):(\d+):(\d+)\s+(\S+)\s+(\S+):\s+(IMAP|POP3)\((\S+)\).*(bytes=(\d+)\/(\d+)|retr=(\d+)\/(\d+))/) {
-			local $ltime;
+			my $ltime;
 			eval { $ltime = timelocal($5, $4, $3, $2,
 			    $apache_mmap{lc($1)}, $tm[5]); };
 			if (!$ltime || $ltime > $now+(24*60*60)) {
@@ -3901,9 +3901,9 @@ foreach $f ($config{'bw_maillog_rotated'} ?
 				eval { $ltime = timelocal($5, $4, $3, $2,
 				     $apache_mmap{lc($1)}, $tm[5]-1); };
 				}
-			local $user = $9;
-			local $sz = $11 + $12 || $14;
-			local $md = $mailusers{$user};
+			my $user = $9;
+			my $sz = $11 + $12 || $14;
+			my $md = $mailusers{$user};
 			if ($md) {
 				if ($ltime > $max_ltime{$md->{'id'}}) {
 					# Update most recent seen time for
@@ -3913,7 +3913,7 @@ foreach $f ($config{'bw_maillog_rotated'} ?
 					}
 				if ($ltime > $starts->{$md->{'id'}} && $sz) {
 					# New enough to record
-					local $day =
+					my $day =
 					    int($ltime / (24*60*60));
 					$bws->{$md->{'id'}}->
 						{"mail_".$day} += $sz;
@@ -3953,10 +3953,10 @@ sub sysinfo_mail
 &require_mail();
 if ($mail_system == 0) {
 	# Postfix
-	local $prog = -x "/usr/lib/sendmail" ? "/usr/lib/sendmail" :
+	my $prog = -x "/usr/lib/sendmail" ? "/usr/lib/sendmail" :
 			&has_command("sendmail");
 	if (!$postfix::postfix_version) {
-		local $out = &backquote_command("$postfix::config{'postfix_config_command'} mail_version 2>&1", 1);
+		my $out = &backquote_command("$postfix::config{'postfix_config_command'} mail_version 2>&1", 1);
 		$postfix_version = $1 if ($out =~ /mail_version\s*=\s*(.*)/);
 		}
 	return ( [ $text{'sysinfo_postfix'}, $postfix::postfix_version ],
@@ -3964,7 +3964,7 @@ if ($mail_system == 0) {
 	}
 elsif ($mail_system == 1) {
 	# Sendmail
-	local $ever = &sendmail::get_sendmail_version();
+	my $ever = &sendmail::get_sendmail_version();
 	return ( [ $text{'sysinfo_sendmail'}, $ever ],
 		 [ $text{'sysinfo_mailprog'},
 			$sendmail::config{'sendmail_path'}." -t" ] );
@@ -3991,12 +3991,12 @@ sub mail_system_has_procmail
 &require_mail();
 if ($mail_system == 0) {
 	# Check postfix delivery command
-	local $cmd = &postfix::get_real_value("mailbox_command");
+	my $cmd = &postfix::get_real_value("mailbox_command");
 	return $cmd =~ /procmail/;
 	}
 elsif ($mail_system == 1) {
 	# See if sendmail's local mailer is procmail
-	local $conf = &sendmail::get_sendmailcf();
+	my $conf = &sendmail::get_sendmailcf();
 	foreach my $m (&sendmail::find_type("M", $conf)) {
 		if ($m->{'value'} =~ /^local.*procmail/) {
 			return 1;
@@ -4006,7 +4006,7 @@ elsif ($mail_system == 1) {
 	}
 elsif ($mail_system == 2) {
 	# Check Qmail rc script for use of procmail as default delivery
-	local $got;
+	my $got;
 	local $_;
 	open(RC, "<$qmailadmin::config{'qmail_dir'}/rc");
 	while(<RC>) {
@@ -4028,13 +4028,13 @@ my $maxage = $starttime ? time() - $starttime : undef;
 if (&foreign_installed("syslog")) {
 	# Try syslog first
 	&foreign_require("syslog");
-	local $conf = &syslog::get_config();
+	my $conf = &syslog::get_config();
 	foreach my $c (@$conf) {
 		next if (!$c->{'active'});
 		next if (!$c->{'file'});
 		next if ($c->{'file'} =~ /^\/dev\//);
 		foreach my $s (@{$c->{'sel'}}) {
-			local ($fac,$level) = split(/\./, $s);
+			my ($fac,$level) = split(/\./, $s);
 			return $c->{'file'} if ($fac =~ /mail/ &&
 						$level !~ /none|error/);
 			}
@@ -4044,9 +4044,9 @@ elsif (&foreign_installed("syslog-ng")) {
 	# Try syslog-ng (by looking for a d_mail destination, or any dest
 	# with mail in the name)
 	&foreign_require("syslog-ng");
-	local $conf = &syslog_ng::get_config();
-	local @dests = &syslog_ng::find("destination", $conf);
-	local ($dest) = grep { $_->{'name'} eq 'd_mail' } @dests;
+	my $conf = &syslog_ng::get_config();
+	my @dests = &syslog_ng::find("destination", $conf);
+	my ($dest) = grep { $_->{'name'} eq 'd_mail' } @dests;
 	if (!$dest) {
 		($dest) = grep { $_->{'name'} =~ /mail/ } @dests;
 		}
@@ -4070,13 +4070,13 @@ return undef;
 
 sub startstop_mail
 {
-local ($typestatus) = @_;
-local $msn = $mail_system == 0 ? "postfix" :
+my ($typestatus) = @_;
+my $msn = $mail_system == 0 ? "postfix" :
 	     $mail_system == 6 ? "exim" :
 	     $mail_system == 1 ? "sendmail" : "qmailadmin";
-local $ms = $text{'mail_system_'.$mail_system};
-local @rv;
-local @links;
+my $ms = $text{'mail_system_'.$mail_system};
+my @rv;
+my @links;
 push(@links, { 'link' => "/$msn/",
 	       'desc' => $text{'index_mmanage'},
 	       'manage' => 1 });
@@ -4108,7 +4108,7 @@ else {
 if (&foreign_installed("dovecot")) {
 	# Add status for Dovecot
 	&foreign_require("dovecot");
-	local @dlinks;
+	my @dlinks;
 	push(@dlinks, { 'link' => "/dovecot/",
 		        'desc' => $text{'index_dmanage'},
 		        'manage' => 1 });
@@ -4271,7 +4271,7 @@ return &usermin::stop_usermin();
 # Returns undef if this system can be a secondary MX, or an error message if not
 sub check_secondary_mx
 {
-local $ms = $mail_system;
+my $ms = $mail_system;
 if (!$config{'mail'}) {
 	return $text{'newmxs_email'};
 	}
@@ -4294,13 +4294,13 @@ else {
 # success, or an error message on failure.
 sub setup_secondary_mx
 {
-local ($dom) = @_;
+my ($dom) = @_;
 &require_mail();
 if ($mail_system == 1) {
 	# Just add to sendmail relay domains file
-	local $conf = &sendmail::get_sendmailcf();
-	local $cwfile;
-	local @dlist = &sendmail::get_file_or_config($conf, "R", undef,
+	my $conf = &sendmail::get_sendmailcf();
+	my $cwfile;
+	my @dlist = &sendmail::get_file_or_config($conf, "R", undef,
 						     \$cwfile);
 	if (&indexoflc($dom, @dlist) >= 0) {
 		return $text{'newmxs_already'};
@@ -4315,11 +4315,11 @@ if ($mail_system == 1) {
 	}
 elsif ($mail_system == 0) {
 	# Add to Postfix relay domains
-	local @rd = split(/[, ]+/,
+	my @rd = split(/[, ]+/,
 			&postfix::get_real_value("relay_domains"));
 	if ($rd[0] =~ /:/) {
 		# Actually in a map
-		local $rmaps = &postfix::get_maps("relay_domains");
+		my $rmaps = &postfix::get_maps("relay_domains");
 		@rds = map { $_->{'name'} } @$rmaps;
 		}
 	if (&indexoflc($dom, @rd) >= 0) {
@@ -4340,7 +4340,7 @@ elsif ($mail_system == 0) {
 		}
 
 	# Ensure that relay_recipient_maps is configured
-	local $rrm = &postfix::get_current_value("relay_recipient_maps");
+	my $rrm = &postfix::get_current_value("relay_recipient_maps");
 	if (!$rrm) {
 		my $cdir = $postfix::config{'postfix_config_file'};
 		$cdir =~ s/\/[^\/]+$//;
@@ -4354,7 +4354,7 @@ elsif ($mail_system == 0) {
 	}
 elsif ($mail_system == 2) {
 	# Add to Qmail rcpthosts file
-	local $rlist = &qmailadmin::list_control_file("rcpthosts");
+	my $rlist = &qmailadmin::list_control_file("rcpthosts");
 	if (&indexof(lc($dom), (map { lc($_) } @$rlist)) >= 0) {
 		return $text{'newmxs_already'};
 		}
@@ -4369,15 +4369,15 @@ return undef;
 # an error message or undef.
 sub delete_secondary_mx
 {
-local ($dom) = @_;
+my ($dom) = @_;
 &require_mail();
 if ($mail_system == 1) {
 	# Just remove from sendmail relay domains file
-	local $conf = &sendmail::get_sendmailcf();
-	local $cwfile;
-	local @dlist = &sendmail::get_file_or_config($conf, "R", undef,
+	my $conf = &sendmail::get_sendmailcf();
+	my $cwfile;
+	my @dlist = &sendmail::get_file_or_config($conf, "R", undef,
 						     \$cwfile);
-	local $idx = &indexof(lc($dom), (map { lc($_) } @dlist));
+	my $idx = &indexof(lc($dom), (map { lc($_) } @dlist));
 	if ($idx < 0) {
 		return $text{'newmxs_missing'};
 		}
@@ -4391,13 +4391,13 @@ if ($mail_system == 1) {
 	}
 elsif ($mail_system == 0) {
 	# Add to Postfix relay domains
-	local @rd = split(/[, ]+/,
+	my @rd = split(/[, ]+/,
 			&postfix::get_current_value("relay_domains"));
-	local $idx = &indexoflc($dom, @rd);
+	my $idx = &indexoflc($dom, @rd);
 	if ($rd[0] =~ /:/ && $idx < 0) {
 		# Actually in a map
-		local $rmaps = &postfix::get_maps("relay_domains");
-		local ($m) = grep { $_->{'name'} eq $dom } @$rmaps;
+		my $rmaps = &postfix::get_maps("relay_domains");
+		my ($m) = grep { $_->{'name'} eq $dom } @$rmaps;
 		if ($m) {
 			&postfix::delete_mapping("relay_domains", $m);
 			&postfix::regenerate_any_table("relay_domains");
@@ -4419,8 +4419,8 @@ elsif ($mail_system == 0) {
 	}
 elsif ($mail_system == 2) {
 	# Add to Qmail rcpthosts file
-	local $rlist = &qmailadmin::list_control_file("rcpthosts");
-	local $idx = &indexof(lc($dom), (map { lc($_) } @$rlist));
+	my $rlist = &qmailadmin::list_control_file("rcpthosts");
+	my $idx = &indexof(lc($dom), (map { lc($_) } @$rlist));
 	if ($idx < 0) {
 		return $text{'newmxs_missing'};
 		}
@@ -4434,27 +4434,27 @@ return undef;
 # Returns 1 if this server is a secondary MX for the given domain
 sub is_secondary_mx
 {
-local ($dom) = @_;
+my ($dom) = @_;
 &require_mail();
 if ($mail_system == 1) {
 	# Check sendmail relay domains file
-	local $conf = &sendmail::get_sendmailcf();
-	local $cwfile;
-	local @dlist = &sendmail::get_file_or_config($conf, "R", undef,
+	my $conf = &sendmail::get_sendmailcf();
+	my $cwfile;
+	my @dlist = &sendmail::get_file_or_config($conf, "R", undef,
 						     \$cwfile);
-	local $idx = &indexof(lc($dom), (map { lc($_) } @dlist));
+	my $idx = &indexof(lc($dom), (map { lc($_) } @dlist));
 	return $idx < 0 ? 0 : 1;
 	}
 elsif ($mail_system == 0) {
 	# Add to Postfix relay domains
-	local @rd = split(/[, ]+/,&postfix::get_current_value("relay_domains"));
-	local $idx = &indexof(lc($dom), (map { lc($_) } @rd));
+	my @rd = split(/[, ]+/,&postfix::get_current_value("relay_domains"));
+	my $idx = &indexof(lc($dom), (map { lc($_) } @rd));
 	return $idx < 0 ? 0 : 1;
 	}
 elsif ($mail_system == 2) {
 	# Add to Qmail rcpthosts file
-	local $rlist = &qmailadmin::list_control_file("rcpthosts");
-	local $idx = &indexof(lc($dom), (map { lc($_) } @$rlist));
+	my $rlist = &qmailadmin::list_control_file("rcpthosts");
+	my $idx = &indexof(lc($dom), (map { lc($_) } @$rlist));
 	return $idx < 0 ? 0 : 1;
 	}
 return 0;
@@ -4469,16 +4469,16 @@ $secondary_error = join("", @_);
 # Add this domain to all secondary MX servers
 sub setup_on_secondaries
 {
-local ($d) = @_;
-local @servers = &list_mx_servers();
+my ($d) = @_;
+my @servers = &list_mx_servers();
 return if (!@servers);
-local @okservers;
+my @okservers;
 &$first_print(&text('setup_mxs',
 	join(", ", map { "<tt>".($_->{'mxname'} || $_->{'host'})."</tt>" }
 		       @servers)));
-local @errs;
+my @errs;
 foreach my $s (@servers) {
-	local $err = &setup_one_secondary($d, $s);
+	my $err = &setup_one_secondary($d, $s);
 	if ($err) {
 		push(@errs, "$s->{'host'} : $err");
 		}
@@ -4522,7 +4522,7 @@ else {
 # an error message on failure.
 sub setup_one_secondary
 {
-local ($dom, $s) = @_;
+my ($dom, $s) = @_;
 &remote_error_setup(\&secondary_error_handler);
 $secondary_error = undef;
 &remote_foreign_require($s, "virtual-server", "virtual-server-lib.pl");
@@ -4530,7 +4530,7 @@ if ($secondary_error) {
 	&remote_error_setup(undef);
 	return $secondary_error;
 	}
-local $err = &remote_foreign_call($s, "virtual-server",
+my $err = &remote_foreign_call($s, "virtual-server",
 				  "setup_secondary_mx", $dom->{'dom'});
 &remote_error_setup(undef);
 return $err;
@@ -4540,16 +4540,16 @@ return $err;
 # Remove this domain from all secondary MX servers
 sub delete_on_secondaries
 {
-local ($dom) = @_;
-local %ids = map { $_, 1 } split(/\s+/, $dom->{'mx_servers'});
-local @servers = grep { $ids{$_->{'id'}} } &list_mx_servers();
+my ($dom) = @_;
+my %ids = map { $_, 1 } split(/\s+/, $dom->{'mx_servers'});
+my @servers = grep { $ids{$_->{'id'}} } &list_mx_servers();
 return if (!@servers);
 &$first_print(&text('delete_mxs',
 	join(", ", map { "<tt>".($_->{'mxname'} || $_->{'host'})."</tt>" }
 		       @servers)));
-local @errs;
+my @errs;
 foreach my $s (@servers) {
-	local $err = &delete_one_secondary($dom, $s);
+	my $err = &delete_one_secondary($dom, $s);
 	if ($err) {
 		push(@errs, "$s->{'host'} : $err");
 		}
@@ -4569,7 +4569,7 @@ delete($dom->{'mx_servers'});
 # or an error message on failure.
 sub delete_one_secondary
 {
-local ($dom, $s) = @_;
+my ($dom, $s) = @_;
 &remote_error_setup(\&secondary_error_handler);
 $secondary_error = undef;
 &remote_foreign_require($s, "virtual-server", "virtual-server-lib.pl");
@@ -4577,7 +4577,7 @@ if ($secondary_error) {
 	&remote_error_setup(undef);
 	return $secondary_error;
 	}
-local $err = &remote_foreign_call($s, "virtual-server",
+my $err = &remote_foreign_call($s, "virtual-server",
 				  "delete_secondary_mx", $dom->{'dom'});
 &remote_error_setup(undef);
 return $err;
@@ -4588,7 +4588,7 @@ return $err;
 # '0' if not, or an error message
 sub is_one_secondary
 {
-local ($dom, $s) = @_;
+my ($dom, $s) = @_;
 &remote_error_setup(\&secondary_error_handler);
 $secondary_error = undef;
 &remote_foreign_require($s, "virtual-server", "virtual-server-lib.pl");
@@ -4596,7 +4596,7 @@ if ($secondary_error) {
 	&remote_error_setup(undef);
 	return $secondary_error;
 	}
-local $ok = &remote_foreign_call($s, "virtual-server",
+my $ok = &remote_foreign_call($s, "virtual-server",
 				 "is_secondary_mx", $dom->{'dom'});
 &remote_error_setup(undef);
 return $secondary_error ? $secondary_error : $ok ? 1 : 0;
@@ -4606,9 +4606,9 @@ return $secondary_error ? $secondary_error : $ok ? 1 : 0;
 # Runs any command configured to be run after an alias is changed
 sub execute_after_virtuser
 {
-local ($alias, $action) = @_;
+my ($alias, $action) = @_;
 return if (!$config{'alias_post_command'});
-local %OLDENV = %ENV;
+my %OLDENV = %ENV;
 $ENV{'ALIAS_ACTION'} = $action;
 $ENV{'ALIAS_FROM'} = $alias->{'from'};
 $ENV{'ALIAS_TO'} = join(",", @{$alias->{'to'}});
@@ -4620,14 +4620,14 @@ $ENV{'ALIAS_CMT'} = $alias->{'cmt'};
 # Runs any command configured to be run before an alias is changed
 sub execute_before_virtuser
 {
-local ($alias, $action) = @_;
+my ($alias, $action) = @_;
 return if (!$config{'alias_pre_command'});
-local %OLDENV = %ENV;
+my %OLDENV = %ENV;
 $ENV{'ALIAS_ACTION'} = $action;
 $ENV{'ALIAS_FROM'} = $alias->{'from'};
 $ENV{'ALIAS_TO'} = join(",", @{$alias->{'to'}});
 $ENV{'ALIAS_CMT'} = $alias->{'cmt'};
-local $out =&backquote_logged("($config{'alias_pre_command'}) 2>&1 </dev/null");
+my $out =&backquote_logged("($config{'alias_pre_command'}) 2>&1 </dev/null");
 if ($?) {
 	&error(&text('alias_ebefore', "<tt>$out</tt>"));
 	}
@@ -4637,7 +4637,7 @@ if ($?) {
 # Outputs HTML for editing email and mailbox related template options
 sub show_template_mail
 {
-local ($tmpl) = @_;
+my ($tmpl) = @_;
 
 # Email message for server creation
 print &ui_table_row(&hlink($text{'tmpl_mail'}, "template_mail"),
@@ -4654,9 +4654,9 @@ print &ui_table_row(&hlink($text{'tmpl_mail'}, "template_mail"),
 print &ui_table_hr();
 
 # Aliases for new users
-local @aliases = $tmpl->{'user_aliases'} eq "none" ? ( ) :
+my @aliases = $tmpl->{'user_aliases'} eq "none" ? ( ) :
 		split(/\t+/, $tmpl->{'user_aliases'});
-local @afields = map { ("type_".$_, "val_".$_) } (0..scalar(@aliases)+2);
+my @afields = map { ("type_".$_, "val_".$_) } (0..scalar(@aliases)+2);
 print &ui_table_row(&hlink($text{'tmpl_aliases'}, "template_aliases_mode"),
 	&none_def_input("aliases", $tmpl->{'user_aliases'},
 			$text{'tmpl_aliasbelow'}, 0, 0, undef,
@@ -4664,19 +4664,19 @@ print &ui_table_row(&hlink($text{'tmpl_aliases'}, "template_aliases_mode"),
 &alias_form(\@aliases, " ", undef, "user", "NEWUSER");
 
 # Aliases for new domains
-local @aliases = $tmpl->{'dom_aliases'} eq "none" ? ( ) :
+my @aliases = $tmpl->{'dom_aliases'} eq "none" ? ( ) :
 			split(/\t+/, $tmpl->{'dom_aliases'});
-local @atable;
-local $i = 0;
-local @dafields;
+my @atable;
+my $i = 0;
+my @dafields;
 foreach my $a (@aliases, undef, undef) {
-	local ($from, $to) = split(/=/, $a, 2);
+	my ($from, $to) = split(/=/, $a, 2);
 	push(@atable, [ &ui_textbox("alias_from_$i", $from, 20),
 			&ui_textbox("alias_to_$i", $to, 40) ]);
 	push(@dafields, "alias_from_$i", "alias_to_$i");
 	$i++;
 	}
-local $atable = &ui_columns_table(
+my $atable = &ui_columns_table(
 	[ $text{'tmpl_aliasfrom'}, $text{'tmpl_aliasto'} ],
 	undef,
 	\@atable,
@@ -4709,7 +4709,7 @@ if ($supports_aliascopy) {
 
 # BCC address
 if ($supports_bcc) {
-	local $mode = $tmpl->{'bccto'} eq 'none' ? 0 :
+	my $mode = $tmpl->{'bccto'} eq 'none' ? 0 :
 		      $tmpl->{'bccto'} eq '' ? 1 : 2;
 	print &ui_table_row(
                 &hlink($text{'tmpl_bccto'}, "template_bccto"),
@@ -4778,7 +4778,7 @@ print &ui_table_row(&hlink($text{'tmpl_append'}, "template_append"),
 # Updates email and mailbox related template options from %in
 sub parse_template_mail
 {
-local ($tmpl) = @_;
+my ($tmpl) = @_;
 &require_mail();
 
 # Save mail settings
@@ -4884,11 +4884,11 @@ if ($in{'append_mode'} == 2 && $in{'append'} == 6 &&
 # Called after a template is saved
 sub postsave_template_mail
 {
-local ($tmpl) = @_;
+my ($tmpl) = @_;
 
 if (!$in{'new'}) {
 	# Update the secondary group lists for all domains in this template
-	local @secdons;
+	my @secdons;
 	if ($tmpl->{'id'} == 0) {
 		@secdoms = &list_domains();
 		}
@@ -4905,7 +4905,7 @@ if (!$in{'new'}) {
 # Show the new mailbox user message template
 sub show_template_newuser
 {
-local ($tmpl) = @_;
+my ($tmpl) = @_;
 
 print &ui_table_row(&hlink($text{'tmpl_newuser'}, "template_newuser"),
 	&none_def_input("newuser", $tmpl->{'newuser_on'},
@@ -4927,7 +4927,7 @@ print &ui_table_row(&hlink($text{'tmpl_newuser'}, "template_newuser"),
 # Update the new mailbox user message template
 sub parse_template_newuser
 {
-local ($tmpl) = @_;
+my ($tmpl) = @_;
 
 $tmpl->{'newuser_on'} = $in{'newuser_mode'} == 0 ? "none" :
 		        $in{'newuser_mode'} == 1 ? "" : "yes";
@@ -4947,7 +4947,7 @@ $tmpl->{'newuser_to_reseller'} = $in{'reseller'};
 # Show the new mailbox user message template
 sub show_template_updateuser
 {
-local ($tmpl) = @_;
+my ($tmpl) = @_;
 
 print &ui_table_row(&hlink($text{'tmpl_updateuser'}, "template_updateuser"),
 	&none_def_input("updateuser", $tmpl->{'updateuser_on'},
@@ -4969,7 +4969,7 @@ print &ui_table_row(&hlink($text{'tmpl_updateuser'}, "template_updateuser"),
 # Update the new mailbox user message template
 sub parse_template_updateuser
 {
-local ($tmpl) = @_;
+my ($tmpl) = @_;
 
 $tmpl->{'updateuser_on'} = $in{'updateuser_mode'} == 0 ? "none" :
 		        $in{'updateuser_mode'} == 1 ? "" : "yes";
@@ -4995,7 +4995,7 @@ if ($mail_system == 1) {
 		   &sendmail::list_generics($sendmail_gfile);
 	}
 elsif ($mail_system == 0) {
-	local $cans = &postfix::get_maps($canonical_type);
+	my $cans = &postfix::get_maps($canonical_type);
 	return map { $_->{'name'}, $_ } @$cans;
 	}
 else {
@@ -5007,19 +5007,19 @@ else {
 # Adds an entry to the systems outgoing addresses file, if active
 sub create_generic
 {
-local ($user, $email, $norestart) = @_;
+my ($user, $email, $norestart) = @_;
 if ($mail_system == 1) {
 	# Add to Sendmail generics file
-	local $gen = { 'from' => $user, 'to' => $email };
+	my $gen = { 'from' => $user, 'to' => $email };
 	&sendmail::create_generic($gen, $sendmail_gfile,
 				  $sendmail_gdbm, $sendmail_gdbmtype);
 
 	# And generics domain list, if missing and if using a file
-	local $conf = &sendmail::get_sendmailcf();
-	local $cgfile;
-	local @dlist = &sendmail::get_file_or_config($conf, "G", undef,
+	my $conf = &sendmail::get_sendmailcf();
+	my $cgfile;
+	my @dlist = &sendmail::get_file_or_config($conf, "G", undef,
                                                      \$cgfile);
-	local ($mb, $dname) = split(/\@/, $email);
+	my ($mb, $dname) = split(/\@/, $email);
 	if (&indexof($dname, @dlist) < 0 && $cgfile) {
 		&lock_file($cgfile);
 		&lock_file($sendmail::config{'sendmail_cf'});
@@ -5032,7 +5032,7 @@ if ($mail_system == 1) {
 	}
 elsif ($mail_system == 0) {
 	# Add to Postfix generics map
-	local $gen = { 'name' => $user,
+	my $gen = { 'name' => $user,
 		       'value' => $email };
 	&create_replace_mapping($canonical_type, $gen);
 	&postfix::regenerate_canonical_table();
@@ -5043,7 +5043,7 @@ elsif ($mail_system == 0) {
 # Removes one outgoing addresses table entry
 sub delete_generic
 {
-local ($generic) = @_;
+my ($generic) = @_;
 return if ($generic->{'deleted'});
 if ($mail_system == 1) {
 	# From Sendmail generics file
@@ -5062,7 +5062,7 @@ $generic->{'deleted'} = 1;
 # Updates one outgoing addresses table entry
 sub modify_generic
 {
-local ($generic, $oldgeneric) = @_;
+my ($generic, $oldgeneric) = @_;
 if ($mail_system == 1) {
 	# In Sendmail generics file
 	&sendmail::modify_generic($oldgeneric, $generic, $sendmail_gfile,
@@ -5078,18 +5078,18 @@ elsif ($mail_system == 0) {
 # Adds or updates a virtuser to forward all email sent to this domain
 sub create_domain_forward
 {
-local ($d, $fwdto) = @_;
-local $virt = { 'from' => "\@$d->{'dom'}",
+my ($d, $fwdto) = @_;
+my $virt = { 'from' => "\@$d->{'dom'}",
 		'to' => [ $fwdto ] };
-local ($clash) = grep { $_->{'from'} eq $virt->{'from'} } &list_virtusers();
+my ($clash) = grep { $_->{'from'} eq $virt->{'from'} } &list_virtusers();
 &delete_virtuser($clash) if ($clash);
 &create_virtuser($virt);
 if ($d->{'unix'}) {
 	# Also forward domain owner's mail
-	local @users = &list_domain_users($d);
-	local ($uinfo) = grep { $_->{'user'} eq $d->{'user'}} @users;
+	my @users = &list_domain_users($d);
+	my ($uinfo) = grep { $_->{'user'} eq $d->{'user'}} @users;
 	if ($uinfo) {
-		local %old = %$uinfo;
+		my %old = %$uinfo;
 		$uinfo->{'to'} = [ $fwdto ];
 		&modify_user($uinfo, \%old, $d);
 		}
@@ -5121,17 +5121,17 @@ return $mail_system == 1 ? $sendmail_gfile :
 # Return a hash ref from domain ID to a count of aliases.
 sub count_domain_aliases
 {
-local ($ignore) = @_;
-local %rv;
+my ($ignore) = @_;
+my %rv;
 return \%rv if (!$config{'mail'});
 
 # Find local users, so we can skip aliases from user@domain -> user.domain
-local %users;
+my %users;
 foreach my $u (&list_all_users_quotas(1)) {
 	$users{$u->{'user'}} = 1;
 	}
 
-local %ignore;
+my %ignore;
 if ($ignore) {
 	# Get a list to ignore from each plugin
 	foreach my $f (&list_feature_plugins()) {
@@ -5143,15 +5143,15 @@ if ($ignore) {
 
 # Map each virtuser to a domain, except for those owned by plugins or for
 # which the destination is a user
-local %dmap = map { $_->{'dom'}, $_ } &list_domains();
+my %dmap = map { $_->{'dom'}, $_ } &list_domains();
 foreach my $v (&list_virtusers()) {
 	if (!$ignore{$v->{'from'}} && $v->{'from'} =~ /\@(\S+)$/) {
-		local $d = $dmap{$1};
+		my $d = $dmap{$1};
 		if ($d) {
 			if (@{$v->{'to'}} == 1 && $users{$v->{'to'}->[0]}) {
 				# Points to a user .. skip only if the 
 				# email addresss is for that user
-				local $user = &remove_userdom(
+				my $user = &remove_userdom(
 						$v->{'to'}->[0], $d);
 				if ($v->{'from'} eq $user."\@".$d->{'dom'}) {
 					next;
@@ -5169,13 +5169,13 @@ return \%rv;
 # Copy all virtual/virtuser entries from some source domain into the alias
 sub copy_alias_virtuals
 {
-local ($d, $aliasdom) = @_;
-local (%need, %already);
+my ($d, $aliasdom) = @_;
+my (%need, %already);
 &obtain_lock_mail($d);
 if ($mail_system == 1) {
 	# Find existing Sendmail virtusers in the alias domain
 	foreach my $virt (&sendmail::list_virtusers($sendmail_vfile)) {
-		local ($mb, $dname) = split(/\@/, $virt->{'from'});
+		my ($mb, $dname) = split(/\@/, $virt->{'from'});
 		if ($dname eq $d->{'dom'}) {
 			$already{$mb} = $virt;
 			}
@@ -5185,9 +5185,9 @@ if ($mail_system == 1) {
 			}
 		}
 	# Add those that are missing, update existing
-	local @sargs = ( $sendmail_vfile, $sendmail_vdbm, $sendmail_vdbmtype );
+	my @sargs = ( $sendmail_vfile, $sendmail_vdbm, $sendmail_vdbmtype );
 	foreach my $mb (keys %need) {
-		local $virt = $already{$mb};
+		my $virt = $already{$mb};
 		if ($virt) {
 			if ($virt->{'to'} ne $need{$mb}->{'to'}) {
 				&sendmail::modify_virtuser($virt, $need{$mb},
@@ -5206,9 +5206,9 @@ if ($mail_system == 1) {
 	}
 elsif ($mail_system == 0) {
 	# Find existing Postfix virtuals in the alias domain
-	local $alreadyvirts = &postfix::get_maps($virtual_type);
+	my $alreadyvirts = &postfix::get_maps($virtual_type);
 	foreach my $virt (@$alreadyvirts) {
-		local ($mb, $dname) = split(/\@/, $virt->{'name'});
+		my ($mb, $dname) = split(/\@/, $virt->{'name'});
 		if ($dname eq $d->{'dom'}) {
 			$already{$mb} = $virt;
 			}
@@ -5219,7 +5219,7 @@ elsif ($mail_system == 0) {
 		}
 	# Add those that are missing, update existing
 	foreach my $mb (keys %need) {
-		local $virt = $already{$mb};
+		my $virt = $already{$mb};
 		if ($virt) {
 			if ($virt->{'value'} ne $need{$mb}->{'value'}) {
 				&postfix::modify_mapping($virtual_type,
@@ -5245,12 +5245,12 @@ elsif ($mail_system == 0) {
 # alias copy mode.
 sub delete_alias_virtuals
 {
-local ($d) = @_;
+my ($d) = @_;
 &obtain_lock_mail($d);
 if ($mail_system == 1) {
 	# Remove virtusers in Sendmail
 	foreach my $virt (&sendmail::list_virtusers($sendmail_vfile)) {
-		local ($mb, $dname) = split(/\@/, $virt->{'from'});
+		my ($mb, $dname) = split(/\@/, $virt->{'from'});
 		if ($dname eq $d->{'dom'}) {
 			&sendmail::delete_virtuser($virt,
 			   $sendmail_vfile, $sendmail_vdbm, $sendmail_vdbmtype);
@@ -5259,10 +5259,10 @@ if ($mail_system == 1) {
 	}
 elsif ($mail_system == 0) {
 	# Remove Postfix virtuals
-	local $virts = &postfix::get_maps($virtual_type);
-	local @origvirts = @$virts;	# Needed as $virts gets modified!
+	my $virts = &postfix::get_maps($virtual_type);
+	my @origvirts = @$virts;	# Needed as $virts gets modified!
 	foreach my $virt (@origvirts) {
-		local ($mb, $dname) = split(/\@/, $virt->{'name'});
+		my ($mb, $dname) = split(/\@/, $virt->{'name'});
 		if ($dname eq $d->{'dom'}) {
 			&postfix::delete_mapping($virtual_type, $virt);
 			}
@@ -5277,7 +5277,7 @@ elsif ($mail_system == 0) {
 # copied virtusers in any alias domains that point to it.
 sub sync_alias_virtuals
 {
-local ($d) = @_;
+my ($d) = @_;
 foreach my $ad (&get_domain_by("alias", $d->{'id'})) {
 	if ($ad->{'aliascopy'}) {
 		&copy_alias_virtuals($ad, $d);
@@ -5290,7 +5290,7 @@ foreach my $ad (&get_domain_by("alias", $d->{'id'})) {
 # use in everyone include
 sub create_everyone_file
 {
-local ($d) = @_;
+my ($d) = @_;
 if (!-d $everyone_alias_dir) {
 	&make_dir($everyone_alias_dir, 0755);
 	}
@@ -5307,7 +5307,7 @@ foreach my $u (&list_domain_users($d, 0, 0, 1, 1)) {
 # Remove the file containing the email address of every user in a domain
 sub delete_everyone_file
 {
-local ($d) = @_;
+my ($d) = @_;
 &unlink_file("$everyone_alias_dir/$d->{'id'}");
 }
 
@@ -5316,12 +5316,12 @@ local ($d) = @_;
 # is sent. Otherwise, return undef.
 sub get_domain_sender_bcc
 {
-local ($d) = @_;
+my ($d) = @_;
 &require_mail();
 if ($config{'mail_server'} == 0 && $sender_bcc_maps) {
 	# Check Postfix config
-	local $map = &postfix::get_maps("sender_bcc_maps");
-	local ($rv) = grep { $_->{'name'} eq '@'.$d->{'dom'} } @$map;
+	my $map = &postfix::get_maps("sender_bcc_maps");
+	my ($rv) = grep { $_->{'name'} eq '@'.$d->{'dom'} } @$map;
 	return $rv ? $rv->{'value'} : undef;
 	}
 return undef;
@@ -5349,15 +5349,15 @@ return \%rv;
 # Turns on or off automatic BCCing for some domain. May call &error.
 sub save_domain_sender_bcc
 {
-local ($d, $email) = @_;
+my ($d, $email) = @_;
 &require_mail();
 if ($config{'mail_server'} == 0) {
 	$sender_bcc_maps || &error($text{'bcc_epostfix'});
-	local $map = &postfix::get_maps("sender_bcc_maps");
-        local ($rv) = grep { $_->{'name'} eq '@'.$d->{'dom'} } @$map;
+	my $map = &postfix::get_maps("sender_bcc_maps");
+        my ($rv) = grep { $_->{'name'} eq '@'.$d->{'dom'} } @$map;
 	if ($rv && $email) {
 		# Update existing
-		local $old = { %$rv };
+		my $old = { %$rv };
 		$rv->{'value'} = $email;
 		&postfix::modify_mapping("sender_bcc_maps", $old, $rv);
 		}
@@ -5383,12 +5383,12 @@ else {
 # which mail is sent. Otherwise, return undef.
 sub get_domain_recipient_bcc
 {
-local ($d) = @_;
+my ($d) = @_;
 &require_mail();
 if ($config{'mail_server'} == 0 && $recipient_bcc_maps) {
 	# Check Postfix config
-	local $map = &postfix::get_maps("recipient_bcc_maps");
-	local ($rv) = grep { $_->{'name'} eq '@'.$d->{'dom'} } @$map;
+	my $map = &postfix::get_maps("recipient_bcc_maps");
+	my ($rv) = grep { $_->{'name'} eq '@'.$d->{'dom'} } @$map;
 	return $rv ? $rv->{'value'} : undef;
 	}
 return undef;
@@ -5416,15 +5416,15 @@ return \%rv;
 # Turns on or off automatic incoming BCCing for some domain. May call &error.
 sub save_domain_recipient_bcc
 {
-local ($d, $email) = @_;
+my ($d, $email) = @_;
 &require_mail();
 if ($config{'mail_server'} == 0) {
 	$recipient_bcc_maps || &error($text{'bcc_epostfix'});
-	local $map = &postfix::get_maps("recipient_bcc_maps");
-        local ($rv) = grep { $_->{'name'} eq '@'.$d->{'dom'} } @$map;
+	my $map = &postfix::get_maps("recipient_bcc_maps");
+        my ($rv) = grep { $_->{'name'} eq '@'.$d->{'dom'} } @$map;
 	if ($rv && $email) {
 		# Update existing
-		local $old = { %$rv };
+		my $old = { %$rv };
 		$rv->{'value'} = $email;
 		&postfix::modify_mapping("recipient_bcc_maps", $old, $rv);
 		}
@@ -5450,7 +5450,7 @@ else {
 # Otherwise returns undef.
 sub get_domain_dependent
 {
-local ($d) = @_;
+my ($d) = @_;
 return undef if (!$supports_dependent);
 &require_mail();
 
@@ -5480,7 +5480,7 @@ return undef;
 # Enables or disables sender-dependent outgoing IP for the domain
 sub save_domain_dependent
 {
-local ($d, $dependent) = @_;
+my ($d, $dependent) = @_;
 return undef if (!$supports_dependent);
 &require_mail();
 
@@ -5503,8 +5503,8 @@ if (!$dependent_maps) {
 	}
 
 # Read the map file to find an entry for the domain
-local $map = &postfix::get_maps("sender_dependent_default_transport_maps");
-local ($rv) = grep { $_->{'name'} eq '@'.$d->{'dom'} } @$map;
+my $map = &postfix::get_maps("sender_dependent_default_transport_maps");
+my ($rv) = grep { $_->{'name'} eq '@'.$d->{'dom'} } @$map;
 if ($rv && !$dependent) {
 	# Need to remove
 	&postfix::delete_mapping(
@@ -5523,14 +5523,14 @@ elsif (!$rv && $dependent) {
 	}
 
 # Find the master file entry for smtp
-local $master = &postfix::get_master_config();
-local ($smtp) = grep { $_->{'name'} eq 'smtp' &&
+my $master = &postfix::get_master_config();
+my ($smtp) = grep { $_->{'name'} eq 'smtp' &&
 		       $_->{'type'} eq 'unix' &&
 		       $_->{'enabled'} } @$master;
 return "No master service named smtp found!" if (!$smtp);
 
 # Find the master file entry for this domain
-local ($m) = grep { $_->{'name'} eq 'smtp-'.$d->{'id'} && $_->{'enabled'} }
+my ($m) = grep { $_->{'name'} eq 'smtp-'.$d->{'id'} && $_->{'enabled'} }
 		  @$master;
 if ($m && !$dependent) {
 	# Need to remove
@@ -5582,20 +5582,20 @@ return undef;
 # an error message if not.
 sub check_postfix_map
 {
-local ($mapname) = @_;
+my ($mapname) = @_;
 &require_mail();
-local $tv = &postfix::get_real_value($mapname);
+my $tv = &postfix::get_real_value($mapname);
 $tv || return &text('checkmap_enone', '../postfix/');
 if (defined(&postfix::can_access_map)) {
 	# Can use new Webmin functions to check
-	local @tv = &postfix::get_maps_types_files($tv);
+	my @tv = &postfix::get_maps_types_files($tv);
 	@tv || return &text('checkmap_enone', '../postfix/');
 	foreach my $tv (@tv) {
 		if (!&postfix::supports_map_type($tv->[0])) {
 			return &text('checkmap_esupport',
 				     "$tv->[0]:$tv->[1]");
 			}
-		local $err = &postfix::can_access_map(@$tv);
+		my $err = &postfix::can_access_map(@$tv);
 		if ($err) {
 			return &text('checkmap_eaccess',
 				     "$tv->[0]:$tv->[1]", $err);
@@ -5674,9 +5674,9 @@ $main::got_lock_mail-- if ($main::got_lock_mail);
 # Returns the vpopmail directory for a domain
 sub domain_vpopmail_dir
 {
-local ($d) = @_;
-local $dname = ref($d) ? $d->{'dom'} : $d;
-local $ddir = "$config{'vpopmail_dir'}/domains/$dname";
+my ($d) = @_;
+my $dname = ref($d) ? $d->{'dom'} : $d;
+my $ddir = "$config{'vpopmail_dir'}/domains/$dname";
 if (-d $ddir) {
 	return $ddir;
 	}
@@ -5689,8 +5689,8 @@ else {
 # Returns 1 if two DNs are the same
 sub same_dn
 {
-local $dn0 = join(",", split(/,\s*/, $_[0]));
-local $dn1 = join(",", split(/,\s*/, $_[1]));
+my $dn0 = join(",", split(/,\s*/, $_[0]));
+my $dn1 = join(",", split(/,\s*/, $_[1]));
 return lc($dn0) eq lc($dn1);
 }
 
@@ -5921,7 +5921,7 @@ my ($d) = @_;
 
 sub get_autoconfig_hostname
 {
-local ($d) = @_;
+my ($d) = @_;
 return ( "autoconfig.".$d->{'dom'}, "autodiscover.".$d->{'dom'} );
 }
 
@@ -5933,18 +5933,18 @@ sub get_email_autoconfig_imap
 my ($d) = @_;
 
 # Work out IMAP server port and mode
-local $imap_host = "mail.$d->{'dom'}";
-local $imap_port = 143;
-local $imap_type = "plain";
-local $imap_ssl = "no";
-local $imap_enc = "password-cleartext";
-local $pop3_port = 110;
-local $pop3_enc = "password-cleartext";
-local $pop3_ssl = "no";
+my $imap_host = "mail.$d->{'dom'}";
+my $imap_port = 143;
+my $imap_type = "plain";
+my $imap_ssl = "no";
+my $imap_enc = "password-cleartext";
+my $pop3_port = 110;
+my $pop3_enc = "password-cleartext";
+my $pop3_ssl = "no";
 if (&foreign_installed("dovecot")) {
 	&foreign_require("dovecot");
-	local $conf = &dovecot::get_config();
-	local $sslopt = &dovecot::find("ssl_disable", $conf, 2) ?
+	my $conf = &dovecot::get_config();
+	my $sslopt = &dovecot::find("ssl_disable", $conf, 2) ?
 			"ssl_disable" : "ssl";
 	if ($sslopt eq "ssl" &&
 	    &dovecot::find_value($sslopt, $conf) ne "no") {
@@ -5985,21 +5985,21 @@ return ($imap_host, $imap_port, $imap_type, $imap_ssl, $imap_enc,
 # ssl flag (yes/no), and password encryption method.
 sub get_email_autoconfig_smtp
 {
-local ($d) = @_;
+my ($d) = @_;
 
-local $smtp_host = "mail.$d->{'dom'}";
-local $smtp_port = 25;
-local $smtp_type = "plain";
-local $smtp_ssl = "no";
-local $smtp_enc = "password-cleartext";
+my $smtp_host = "mail.$d->{'dom'}";
+my $smtp_port = 25;
+my $smtp_type = "plain";
+my $smtp_ssl = "no";
+my $smtp_enc = "password-cleartext";
 if ($mail_system == 0) {
 	# Check for Postfix submission port
 	&foreign_require("postfix");
-	local $master = postfix::get_master_config();
-	local ($submission) = grep {
+	my $master = postfix::get_master_config();
+	my ($submission) = grep {
 		$_->{'name'} =~ /^(submission|[0-9\.]+:submission)$/ &&
 		$_->{'enabled'} } @$master;
-	local ($smtps) = grep {
+	my ($smtps) = grep {
 		$_->{'name'} =~ /^(smtps|[0-9\.]+:smtps)$/ &&
 		$_->{'enabled'} } @$master;
 	if ($submission) {
@@ -6020,7 +6020,7 @@ if ($mail_system == 0) {
 elsif ($mail_system == 1) {
 	# Check for Sendmail submission port
 	&foreign_require("sendmail");
-	local $conf = &sendmail::get_sendmailcf();
+	my $conf = &sendmail::get_sendmailcf();
 	foreach my $dpo (&sendmail::find_options("DaemonPortOptions", $conf)) {
 		if ($dpo->[1] =~ /Port=(587|submission)/) {
 			$smtp_port = 587;
@@ -6124,7 +6124,7 @@ foreach my $l (@$lref) {
 	}
 
 # Sub in XML for thunderbird
-local $xml;
+my $xml;
 if ($tmpl->{'autoconfig'} && $tmpl->{'autoconfig'} ne 'none') {
 	$xml = &substitute_domain_template($tmpl->{'autoconfig'}, $d,
 					   undef, 1);
@@ -6133,7 +6133,7 @@ if ($tmpl->{'autoconfig'} && $tmpl->{'autoconfig'} ne 'none') {
 else {
 	$xml = &get_thunderbird_autoconfig_xml();
 	}
-local $idx = &indexof("_THUNDERBIRD_XML_GOES_HERE_", @$lref);
+my $idx = &indexof("_THUNDERBIRD_XML_GOES_HERE_", @$lref);
 if ($idx >= 0) {
 	splice(@$lref, $idx, 1, split(/\n/, $xml));
 	}
@@ -6147,7 +6147,7 @@ if ($tmpl->{'outlook_autoconfig'} && $tmpl->{'outlook_autoconfig'} ne 'none') {
 else {
 	$xml = &get_outlook_autoconfig_xml();
 	}
-local $idx = &indexof("_OUTLOOK_XML_GOES_HERE_", @$lref);
+my $idx = &indexof("_OUTLOOK_XML_GOES_HERE_", @$lref);
 if ($idx >= 0) {
 	splice(@$lref, $idx, 1, split(/\n/, $xml));
 	}
@@ -6582,7 +6582,7 @@ foreach my $d (@doms) {
 # set of custom MX records
 sub list_cloud_mail_providers
 {
-local ($d, $id) = @_;
+my ($d, $id) = @_;
 return ( { 'name' => 'MailShark',
 	   'url' => 'http://www.mailshark.com.au/',
 	   'mx' => [ 'jaws-in1.mailshark.com.au',
@@ -6658,10 +6658,10 @@ return ( { 'name' => 'MailShark',
 # Returns the configured provider for some domain
 sub get_domain_cloud_mail_provider
 {
-local ($d) = @_;
+my ($d) = @_;
 &require_bind();
-local @recs = &get_domain_dns_records($d);
-local %mxmap;
+my @recs = &get_domain_dns_records($d);
+my %mxmap;
 foreach my $prov (&list_cloud_mail_providers($d, $d->{'cloud_mail_id'})) {
 	foreach my $mx (@{$prov->{'mx'}}) {
 		$mxmap{$mx."."} = $prov;
@@ -6680,11 +6680,11 @@ return undef;
 # Updates the provider MX records for some domain, or clears it
 sub save_domain_cloud_mail_provider
 {
-local ($d, $prov, $id) = @_;
+my ($d, $prov, $id) = @_;
 if ($d->{'dns'}) {
 	&require_bind();
 	&obtain_lock_dns($d);
-	local ($recs, $file) = &get_domain_dns_records_and_file($d);
+	my ($recs, $file) = &get_domain_dns_records_and_file($d);
 
 	# Remove all MX records
 	foreach my $r (@$recs) {

--- a/feature-mysql.pl
+++ b/feature-mysql.pl
@@ -82,7 +82,7 @@ return &foreign_available("mysql");
 sub check_depends_mysql
 {
 return undef if (!$_[0]->{'parent'});
-local $parent = &get_domain($_[0]->{'parent'});
+my $parent = &get_domain($_[0]->{'parent'});
 return $text{'setup_edepmysql'} if (!$parent->{'mysql'});
 return undef;
 }
@@ -92,7 +92,7 @@ return undef;
 sub check_anti_depends_mysql
 {
 if (!$_[0]->{'mysql'}) {
-	local @subs = &get_domain_by("parent", $_[0]->{'id'});
+	my @subs = &get_domain_by("parent", $_[0]->{'id'});
 	foreach my $s (@subs) {
 		return $text{'setup_edepmysqlsub'} if ($s->{'mysql'});
 		}
@@ -113,7 +113,7 @@ return if (!$config{'mysql'});
 # Un-lock the MySQL config file for some domain
 sub release_lock_mysql
 {
-local ($d) = @_;
+my ($d) = @_;
 return if (!$config{'mysql'});
 &release_lock_anything($d);
 }
@@ -122,8 +122,8 @@ return if (!$config{'mysql'});
 # Returns 1 if some MySQL user or database is used by another domain
 sub check_mysql_clash
 {
-local ($d, $field, $repl) = @_;
-local @doms = grep { $_->{'mysql'} && $_->{'id'} ne $d->{'id'} }
+my ($d, $field, $repl) = @_;
+my @doms = grep { $_->{'mysql'} && $_->{'id'} ne $d->{'id'} }
 		   &list_domains();
 
 # Check for DB clash
@@ -155,15 +155,15 @@ return undef;
 # Create a new MySQL database, user and permissions
 sub setup_mysql
 {
-local ($d, $nodb) = @_;
-local $tmpl = &get_template($d->{'template'});
+my ($d, $nodb) = @_;
+my $tmpl = &get_template($d->{'template'});
 if (!$d->{'mysql_module'}) {
 	# Use the default module for this system
 	$d->{'mysql_module'} = &get_default_mysql_module();
 	}
 &require_mysql();
 $d->{'mysql_user'} = &mysql_user($d);
-local $user = $d->{'mysql_user'};
+my $user = $d->{'mysql_user'};
 
 if (!$d->{'parent'}) {
 	if ($d->{'provision_mysql'}) {
@@ -178,7 +178,7 @@ if (!$d->{'parent'}) {
 		else {
 			$info->{'pass'} = &mysql_pass($d);
 			}
-		local @hosts = &unique(map { &to_ipaddress($_) }
+		my @hosts = &unique(map { &to_ipaddress($_) }
 				  	   &get_mysql_hosts($d, 2));
 		$info->{'remote'} = \@hosts;
 		my $conns = &get_mysql_user_connections($d, 0);
@@ -235,7 +235,7 @@ if (!$d->{'parent'}) {
 		else {
 			&$first_print($text{'setup_mysqluser'});
 			}
-		local $encpass = &encrypted_mysql_pass($d);
+		my $encpass = &encrypted_mysql_pass($d);
 		foreach my $h (@hosts) {
 			# Create the user with access from each of the hosts
 			# from the template
@@ -265,7 +265,7 @@ if (!$d->{'parent'}) {
 my $ok;
 if (!$nodb && $tmpl->{'mysql_mkdb'} && !$d->{'no_mysql_db'}) {
 	# Create the one initial DB
-	local $opts = &default_mysql_creation_opts($d);
+	my $opts = &default_mysql_creation_opts($d);
 	$ok = &create_mysql_database($d, $d->{'db'}, $opts);
 	if (!$ok) {
 		# Failed, but instread of marking this whole feature as failed,
@@ -298,10 +298,10 @@ return $ok;
 # Adds an entry to the db table, with all permission columns set to Y
 sub create_mysql_db_grant
 {
-local ($d, $host, $db, $user) = @_;
-local $mod = &require_dom_mysql($d);
-local @str = &foreign_call($mod, "table_structure", $mysql::master_db, 'db');
-local ($s, @fields, @yeses);
+my ($d, $host, $db, $user) = @_;
+my $mod = &require_dom_mysql($d);
+my @str = &foreign_call($mod, "table_structure", $mysql::master_db, 'db');
+my ($s, @fields, @yeses);
 foreach $s (@str) {
 	if ($s->{'field'} =~ /_priv$/i) {
 		push(@fields, $s->{'field'});
@@ -325,7 +325,7 @@ else {
 # Removes a grant to a specific MySQL DB for a user, for all hosts
 sub delete_mysql_db_grant
 {
-local ($d, $db, $user, $host) = @_;
+my ($d, $db, $user, $host) = @_;
 my $qdb = &quote_mysql_database($db);
 
 # Get all the hosts this user or DB has access from
@@ -406,7 +406,7 @@ return map { [ $_, $dbs{$_} ] } sort { $a cmp $b } keys %dbs;
 # Delete mysql databases, the domain's mysql user and all permissions for both
 sub delete_mysql
 {
-local ($d, $preserve) = @_;
+my ($d, $preserve) = @_;
 &require_mysql();
 my @dblist = &unique(split(/\s+/, $d->{'db_mysql'}));
 my $mymod = &get_domain_mysql_module($d);
@@ -421,7 +421,7 @@ if ($preserve && &remote_mysql($d)) {
 	}
 
 # Get the domain's users, so we can remove their MySQL logins
-local @users = &list_domain_users($d, 1, 1, 1, 0);
+my @users = &list_domain_users($d, 1, 1, 1, 0);
 
 # First remove the databases
 if (@dblist) {
@@ -490,9 +490,9 @@ if ($d->{'provision_mysql'}) {
 else {
 	# Remove the main user locally
 	&$first_print($text{'delete_mysqluser'}) if (!$d->{'parent'});
-	local $user = &mysql_user($d);
-	local $tmpl = &get_template($d->{'template'});
-	local $wild = &substitute_domain_template(
+	my $user = &mysql_user($d);
+	my $tmpl = &get_template($d->{'template'});
+	my $wild = &substitute_domain_template(
 			$tmpl->{'mysql_wild'}, $d);
 	if (!$d->{'parent'}) {
 		# Delete the user and any database permissions
@@ -509,7 +509,7 @@ else {
 	foreach my $u (@users) {
 		foreach my $udb (@{$u->{'dbs'}}) {
 			if ($udb->{'type'} eq 'mysql') {
-				local $myuser =
+				my $myuser =
 					&mysql_username($u->{'user'});
 				&execute_user_deletion_sql(
 					$d, undef, $myuser, 1);
@@ -526,18 +526,18 @@ return 1;
 # Changes the mysql user's password if needed
 sub modify_mysql
 {
-local ($d, $oldd) = @_;
-local $tmpl = &get_template($d->{'template'});
+my ($d, $oldd) = @_;
+my $tmpl = &get_template($d->{'template'});
 &require_mysql();
 my $mymod = &get_domain_mysql_module($d);
-local $rv = 0;
-local $changeduser = $d->{'user'} ne $oldd->{'user'} &&
+my $rv = 0;
+my $changeduser = $d->{'user'} ne $oldd->{'user'} &&
 		     !$tmpl->{'mysql_nouser'} ? 1 : 0;
-local $olduser = &mysql_user($oldd);
-local $user = &mysql_user($d, $changeduser);
-local $oldencpass = &encrypted_mysql_pass($oldd);
-local $encpass = &encrypted_mysql_pass($d);
-local @dbnames = map { $_->{'name'} } &domain_databases($d, [ "mysql" ]);
+my $olduser = &mysql_user($oldd);
+my $user = &mysql_user($d, $changeduser);
+my $oldencpass = &encrypted_mysql_pass($oldd);
+my $encpass = &encrypted_mysql_pass($d);
+my @dbnames = map { $_->{'name'} } &domain_databases($d, [ "mysql" ]);
 
 if ($encpass ne $oldencpass && !$d->{'parent'} && !$oldd->{'parent'} &&
     (!$tmpl->{'mysql_nopass'} || $d->{'mysql_pass'})) {
@@ -591,8 +591,8 @@ if (!$d->{'parent'} && $oldd->{'parent'}) {
 	# Server has been converted to a parent .. need to create user, and
 	# change access to old DBs
 	$d->{'mysql_user'} = &mysql_user($d, 1);
-	local $user = $d->{'mysql_user'};
-	local @hosts = &get_mysql_hosts($d);
+	my $user = $d->{'mysql_user'};
+	my @hosts = &get_mysql_hosts($d);
 
 	# If hashed passwords are in use, generate a random MySQL password
 	# for the new MySQL user
@@ -612,7 +612,7 @@ if (!$d->{'parent'} && $oldd->{'parent'}) {
 		else {
 			$info->{'pass'} = &mysql_pass($d);
 			}
-		local @hosts = map { &to_ipaddress($_) } @hosts;
+		my @hosts = map { &to_ipaddress($_) } @hosts;
 		$info->{'remote'} = \@hosts;
 		my $conns = &get_mysql_user_connections($d, 0);
 		$info->{'conns'} = $conns if ($conns);
@@ -656,9 +656,9 @@ if (!$d->{'parent'} && $oldd->{'parent'}) {
 	else {
 		# Change locally
 		&$first_print($text{'setup_mysqluser'});
-		local $wild = &substitute_domain_template(
+		my $wild = &substitute_domain_template(
 				$tmpl->{'mysql_wild'}, $d);
-		local $encpass = &encrypted_mysql_pass($d);
+		my $encpass = &encrypted_mysql_pass($d);
 		foreach my $h (@hosts) {
 			&execute_user_creation_sql($d, $h, $user,
 					   $encpass, &mysql_pass($d));
@@ -825,7 +825,7 @@ if ($d->{'group'} ne $oldd->{'group'} && $tmpl->{'mysql_chgrp'}) {
 	# Unix group has changed - fix permissions on all DB files
 	&$first_print($text{'save_mysqlgroup'});
 	foreach my $db (&domain_databases($d, [ "mysql" ])) {
-		local $dd = &get_mysql_database_dir($db->{'name'});
+		my $dd = &get_mysql_database_dir($db->{'name'});
 		if ($dd) {
 			&system_logged("chgrp -R $d->{'group'} ".
 				       quotemeta($dd));
@@ -840,16 +840,16 @@ return $rv;
 # Copy all databases and their contents to a new domain
 sub clone_mysql
 {
-local ($d, $oldd) = @_;
+my ($d, $oldd) = @_;
 &$first_print($text{'clone_mysql'});
 
 # Re-create each DB with a new name
-local %dbmap;
+my %dbmap;
 my @dbs = &domain_databases($oldd, [ 'mysql' ]);
 foreach my $db (@dbs) {
-	local $newname = $db->{'name'};
-	local $newprefix = &fix_database_name($d->{'prefix'}, 'mysql');
-	local $oldprefix = &fix_database_name($oldd->{'prefix'}, 'mysql');
+	my $newname = $db->{'name'};
+	my $newprefix = &fix_database_name($d->{'prefix'}, 'mysql');
+	my $oldprefix = &fix_database_name($oldd->{'prefix'}, 'mysql');
 	if ($newname eq $oldd->{'db'} &&
 	    $oldd->{'db'} eq &database_name($oldd)) {
 		# If the DB name was the primary database for the old domain,
@@ -880,8 +880,8 @@ foreach my $db (@dbs) {
 		}
 	&push_all_print();
 	&set_all_null_print();
-	local $opts = &get_mysql_creation_opts($oldd, $db->{'name'});
-	local $ok = &create_mysql_database($d, $newname, $opts);
+	my $opts = &get_mysql_creation_opts($oldd, $db->{'name'});
+	my $ok = &create_mysql_database($d, $newname, $opts);
 	&pop_all_print();
 	if (!$ok) {
 		&$second_print(&text('clone_mysqlcreate', $newname));
@@ -936,7 +936,7 @@ if (!$d->{'parent'}) {
 # Make sure all MySQL databases exist, and that the admin user exists
 sub validate_mysql
 {
-local ($d) = @_;
+my ($d) = @_;
 my $mymod = &get_domain_mysql_module($d);
 &require_mysql();
 if ($d->{'provision_mysql'}) {
@@ -969,11 +969,11 @@ if ($d->{'provision_mysql'}) {
 	}
 else {
 	# Check locally
-	local $mod = $d->{'mysql_module'} || 'mysql';
+	my $mod = $d->{'mysql_module'} || 'mysql';
 	if (!&foreign_check($mod)) {
 		return &text('validate_emysqlmod', $mod);
 		}
-	local %got = map { $_, 1 } &list_dom_mysql_databases($d);
+	my %got = map { $_, 1 } &list_dom_mysql_databases($d);
 	foreach my $db (&domain_databases($d, [ "mysql" ])) {
 		$got{$db->{'name'}} ||
 			return &text('validate_emysql', $db->{'name'});
@@ -989,7 +989,7 @@ return undef;
 # Modifies the mysql user for this domain so that he cannot login
 sub disable_mysql
 {
-local ($d) = @_;
+my ($d) = @_;
 &require_mysql();
 if ($d->{'parent'}) {
 	&$second_print($text{'save_nomysqlpar'});
@@ -1015,7 +1015,7 @@ else {
 	# Lock locally by setting hashed password to an invalid string (or real
 	# password to a random string, only mysql 8)
 	&$first_print($text{'disable_mysqluser'});
-	local $user = &mysql_user($d);
+	my $user = &mysql_user($d);
 	if ($oldpass = &mysql_user_exists($d)) {
 		&execute_password_change_sql(
 			$d, $user, "'".("0" x 41)."'", &random_password(16));
@@ -1034,7 +1034,7 @@ else {
 # Puts back the original password for the mysql user so that he can login again
 sub enable_mysql
 {
-local ($d) = @_;
+my ($d) = @_;
 &require_mysql();
 if ($d->{'parent'}) {
 	&$second_print($text{'save_nomysqlpar'});
@@ -1061,9 +1061,9 @@ elsif ($d->{'provision_mysql'}) {
 else {
 	# Un-lock locally
 	&$first_print($text{'enable_mysql'});
-	local $user = &mysql_user($d);
+	my $user = &mysql_user($d);
 	if (&mysql_user_exists($d)) {
-		local $pass = &mysql_pass($d);
+		my $pass = &mysql_pass($d);
 		if ($pass) {
 			# Need to re-set plaintext password
 			&execute_password_change_sql(
@@ -1071,7 +1071,7 @@ else {
 			}
 		else {
 			# Can put back old hashed password
-			local $qpass = &mysql_escape(
+			my $qpass = &mysql_escape(
 				$d->{'disabled_oldmysql'});
 			&execute_password_change_sql(
 				$d, $user, "'$qpass'");
@@ -1093,8 +1093,8 @@ sub mysql_user_exists
 {
 my ($d) = @_;
 &require_mysql();
-local $user = &mysql_user($d);
-local $u;
+my $user = &mysql_user($d);
+my $u;
 eval {
 	# Try old password column first
 	local $main::error_must_die = 1;
@@ -1121,7 +1121,7 @@ return undef;
 # This can be overridden to allow a takeover of the DB.
 sub check_warnings_mysql
 {
-local ($d, $oldd) = @_;
+my ($d, $oldd) = @_;
 $d->{'mysql'} && (!$oldd || !$oldd->{'mysql'}) || return undef;
 return undef if ($repl);	# Clashes are expected in MySQL is shared
 if ($d->{'provision_mysql'}) {
@@ -1146,7 +1146,7 @@ if ($d->{'provision_mysql'}) {
 else {
 	# DB clash on local
 	&require_mysql();
-	local @dblist = &list_dom_mysql_databases($d);
+	my @dblist = &list_dom_mysql_databases($d);
 	return &text('setup_emysqldb', $d->{'db'})
 		if (&indexof($d->{'db'}, @dblist) >= 0);
 
@@ -1164,15 +1164,15 @@ return undef;
 # Dumps this domain's mysql database to a backup file
 sub backup_mysql
 {
-local ($d, $file, $opts, $homefmt, $increment, $asd, $allopts, $key) = @_;
+my ($d, $file, $opts, $homefmt, $increment, $asd, $allopts, $key) = @_;
 &require_mysql();
 my $compression = $allopts->{'dir'}->{'compression'};
 
 # Find all domain's databases
-local $tmpl = &get_template($d->{'template'});
-local $wild = &substitute_domain_template($tmpl->{'mysql_wild'}, $d);
-local @alldbs = &list_all_mysql_databases($d);
-local @dbs;
+my $tmpl = &get_template($d->{'template'});
+my $wild = &substitute_domain_template($tmpl->{'mysql_wild'}, $d);
+my @alldbs = &list_all_mysql_databases($d);
+my @dbs;
 if ($wild) {
 	$wild =~ s/\%/\.\*/g;
 	$wild =~ s/_/\./g;
@@ -1188,9 +1188,9 @@ my %exclude = map { $_, 1 } @exclude;
 
 # Create base backup file with meta-information
 &$first_print($text{'backup_mysqlinfo'});
-local @hosts = &get_mysql_allowed_hosts($d);
+my @hosts = &get_mysql_allowed_hosts($d);
 my $mymod = &get_domain_mysql_module($d);
-local %info = ( 'hosts' => join(' ', @hosts),
+my %info = ( 'hosts' => join(' ', @hosts),
 		'remote' => $mymod->{'config'}->{'host'} );
 foreach $db (@dbs) {
 	if (&foreign_defined($mymod, "get_character_set")) {
@@ -1206,11 +1206,11 @@ foreach $db (@dbs) {
 &$second_print($text{'setup_done'});
 
 # Back them all up
-local $db;
-local $ok = 1;
+my $db;
+my $ok = 1;
 foreach $db (@dbs) {
 	&$first_print(&text('backup_mysqldump', $db));
-	local $dbfile = $file."_".$db;
+	my $dbfile = $file."_".$db;
 
 	# Limit tables to those that aren't excluded
 	my %texclude = map { $_, 1 }
@@ -1263,8 +1263,8 @@ return $ok;
 # the mysql user.
 sub restore_mysql
 {
-local ($d, $file, $opts, $allopts, $homefmt, $oldd, $asd) = @_;
-local %info;
+my ($d, $file, $opts, $allopts, $homefmt, $oldd, $asd) = @_;
+my %info;
 &read_file($file, \%info);
 &require_mysql();
 
@@ -1276,7 +1276,7 @@ if (!&foreign_call($mymod, "is_mysql_running")) {
 	}
 
 # Re-grant allowed hosts from backup + local
-local @lhosts;
+my @lhosts;
 if (!$d->{'parent'} && $info{'hosts'}) {
 	&$first_print($text{'restore_mysqlgrant'});
 	@lhosts = &get_mysql_allowed_hosts($d);
@@ -1327,7 +1327,7 @@ if ($allopts->{'repl'} && $mymod->{'config'}->{'host'} && $info{'remote'} &&
 	}
 
 # For DBs that exist already, save their user lists for later restore
-local (%userdbs, %userpasses, %userplugins);
+my (%userdbs, %userpasses, %userplugins);
 foreach my $db (&domain_databases($d, [ 'mysql' ])) {
 	foreach my $u (&list_mysql_database_users($d, $db->{'name'})) {
 		if ($u->[0] ne $d->{'user'} &&
@@ -1409,7 +1409,7 @@ foreach my $db (@dbs) {
 			}
 		$db->[1] = $basefile;
 		}
-	local ($ex, $out);
+	my ($ex, $out);
 	if ($asd) {
 		# As the domain owner
 		($ex, $out) = &execute_dom_sql_file($d, $db->[0], $db->[1],
@@ -1490,9 +1490,9 @@ return $rv;
 # Returns an error message if a file doesn't look like a valid MySQL backup
 sub validate_mysql_backup
 {
-local ($dbfile) = @_;
+my ($dbfile) = @_;
 open(DBFILE, "<".$dbfile);
-local $first = <DBFILE>;
+my $first = <DBFILE>;
 close(DBFILE);
 if ($first =~ /^mysqldump:.*error/i) {
 	return $first;
@@ -1543,7 +1543,7 @@ return length($_[0]) > $mysql_user_size ?
 # actually change the database - that must be done by modify_mysql.
 sub set_mysql_pass
 {
-local ($d, $pass) = @_;
+my ($d, $pass) = @_;
 if (defined($pass)) {
 	$d->{'mysql_pass'} = $pass;
 	}
@@ -1561,7 +1561,7 @@ sub mysql_pass
 my ($d) = @_;
 if ($d->{'parent'}) {
 	# Password comes from parent domain
-	local $parent = &get_domain($d->{'parent'});
+	my $parent = &get_domain($d->{'parent'});
 	return &mysql_pass($parent);
 	}
 return $d->{'mysql_pass'} ne '' ? $d->{'mysql_pass'} : $d->{'pass'};
@@ -1590,12 +1590,12 @@ sub mysql_size
 {
 my ($d, $dbname, $sizeonly) = @_;
 &require_mysql();
-local ($size, $qsize, $count);
-local $dd = &get_mysql_database_dir($d, $dbname);
+my ($size, $qsize, $count);
+my $dd = &get_mysql_database_dir($d, $dbname);
 if ($dd) {
 	# Can check actual on-disk size
 	($size, undef, $count) = &recursive_disk_usage_mtime($dd);
-	local @dst = stat($dd);
+	my @dst = stat($dd);
 	if (&has_group_quotas() && &has_mysql_quotas() &&
             $dst[5] == $d->{'gid'}) {
 		$qsize = $size;
@@ -1617,7 +1617,7 @@ else {
 		$size = $count = undef;
 		}
 	}
-local @tables;
+my @tables;
 if (!$sizeonly) {
 	eval {
 		# Make sure DBI errors don't cause a total failure
@@ -1637,7 +1637,7 @@ return ($size, scalar(@tables), $qsize, $count);
 # Check if some MySQL database already exists
 sub check_mysql_database_clash
 {
-local ($d, $name) = @_;
+my ($d, $name) = @_;
 &require_mysql();
 if ($d->{'provision_mysql'}) {
 	# Check on provisioning server
@@ -1648,7 +1648,7 @@ if ($d->{'provision_mysql'}) {
 	}
 else {
 	# Check locally
-	local @dblist = &list_dom_mysql_databases($d);
+	my @dblist = &list_dom_mysql_databases($d);
 	return &indexof($name, @dblist) >= 0 ? 1 : 0;
 	}
 }
@@ -1657,10 +1657,10 @@ else {
 # Add one database to this domain, and grants access to it to the user
 sub create_mysql_database
 {
-local ($d, $dbname, $opts) = @_;
+my ($d, $dbname, $opts) = @_;
 &require_mysql();
 &obtain_lock_mysql($d);
-local @dbs = split(/\s+/, $d->{'db_mysql'});
+my @dbs = split(/\s+/, $d->{'db_mysql'});
 
 if ($d->{'provision_mysql'}) {
 	# Create the database on the provisioning server
@@ -1716,7 +1716,7 @@ return 1;
 # and sets file ownership so that quotas work.
 sub grant_mysql_database
 {
-local ($d, $dbname) = @_;
+my ($d, $dbname) = @_;
 &require_mysql();
 &obtain_lock_mysql($d);
 
@@ -1731,15 +1731,15 @@ if ($d->{'provision_mysql'}) {
 	}
 else {
 	# Add db entries for the user for each host
-	local @hosts = &get_mysql_hosts($d);
-	local $user = &mysql_user($d);
+	my @hosts = &get_mysql_hosts($d);
+	my $user = &mysql_user($d);
 	foreach my $h (@hosts) {
 		&create_mysql_db_grant($d, $h, $dbname, $user);
 		}
 
 	# Set group ownership of database directory, to enforce quotas
-	local $dd = &get_mysql_database_dir($d, $dbname);
-	local $tmpl = &get_template($d->{'template'});
+	my $dd = &get_mysql_database_dir($d, $dbname);
+	my $tmpl = &get_template($d->{'template'});
 	if ($tmpl->{'mysql_chgrp'} && $dd) {
 		&system_logged("chgrp -R $d->{'group'} ".quotemeta($dd));
 		&system_logged("chmod +s ".quotemeta($dd));
@@ -1752,12 +1752,12 @@ else {
 # Remove one or more MySQL database from this domain
 sub delete_mysql_database
 {
-local ($d, @dbnames) = @_;
+my ($d, @dbnames) = @_;
 &require_mysql();
 &obtain_lock_mysql($d);
-local @dbs = split(/\s+/, $d->{'db_mysql'});
-local @missing;
-local $failed = 0;
+my @dbs = split(/\s+/, $d->{'db_mysql'});
+my @missing;
+my $failed = 0;
 
 if ($d->{'provision_mysql'}) {
 	# Delete on provisioning server
@@ -1778,10 +1778,10 @@ if ($d->{'provision_mysql'}) {
 	}
 else {
 	# Delete locally
-	local @dblist = &list_dom_mysql_databases($d);
+	my @dblist = &list_dom_mysql_databases($d);
 	&$first_print(&text('delete_mysqldb', join(", ", @dbnames)));
 	foreach my $db (@dbnames) {
-		local $qdb = &quote_mysql_database($db);
+		my $qdb = &quote_mysql_database($db);
 		if (&indexof($db, @dblist) >= 0) {
 			# Drop the DB
 			&execute_dom_sql($d, 
@@ -1817,12 +1817,12 @@ if (!$failed) {
 # Also resets group permissions.
 sub revoke_mysql_database
 {
-local ($d, $dbname) = @_;
+my ($d, $dbname) = @_;
 &require_mysql();
 &obtain_lock_mysql($d);
-local @oldusers = &list_mysql_database_users($d, $dbname);
-local @users = &list_domain_users($d, 1, 1, 1, 0);
-local @unames = ( &mysql_user($d),
+my @oldusers = &list_mysql_database_users($d, $dbname);
+my @users = &list_domain_users($d, 1, 1, 1, 0);
+my @unames = ( &mysql_user($d),
 		  map { &mysql_username($_->{'user'}) } @users );
 
 # Take away MySQL permissions for users in this domain
@@ -1831,10 +1831,10 @@ foreach my $uname (@unames) {
 	}
 
 # If any users had access to this DB only, remove them too
-local $duser = &mysql_user($d);
+my $duser = &mysql_user($d);
 foreach my $up (grep { $_->[0] ne $duser } @oldusers) {
 	# XXX why is this query needed when we already know the DB?
-	local $o = &execute_dom_sql($d, $mysql::master_db, "select db from db where user = '$up->[0]'");
+	my $o = &execute_dom_sql($d, $mysql::master_db, "select db from db where user = '$up->[0]'");
 	if (!@{$o->{'data'}}) {
 		&execute_user_deletion_sql($d, undef, $up->[0]);
 		}
@@ -1842,11 +1842,11 @@ foreach my $up (grep { $_->[0] ne $duser } @oldusers) {
 
 # Fix group owner, if the DB still exists, by setting to the owner of the
 # 'mysql' database
-local $tmpl = &get_template($d->{'template'});
-local $dd = &get_mysql_database_dir($d, $dbname);
+my $tmpl = &get_template($d->{'template'});
+my $dd = &get_mysql_database_dir($d, $dbname);
 if ($tmpl->{'mysql_chgrp'} && $dd && -d $dd) {
-	local @st = stat("$dd/../mysql");
-	local $group = scalar(@st) ? $st[5] : "mysql";
+	my @st = stat("$dd/../mysql");
+	my $group = scalar(@st) ? $st[5] : "mysql";
 	&system_logged("chgrp -R $group ".quotemeta($dd));
 	}
 &release_lock_mysql($d);
@@ -1857,12 +1857,12 @@ if ($tmpl->{'mysql_chgrp'} && $dd && -d $dd) {
 # If MySQL is running remotely, this will always return undef.
 sub get_mysql_database_dir
 {
-local ($d, $db) = @_;
+my ($d, $db) = @_;
 &require_mysql();
 return undef if ($d->{'provision_mysql'});
 return undef if (!$db);
-local $mymod = &require_dom_mysql($d);
-local %myconfig = &foreign_config($mymod);
+my $mymod = &require_dom_mysql($d);
+my %myconfig = &foreign_config($mymod);
 return undef if ($myconfig{'host'} &&
 		 $myconfig{'host'} ne 'localhost' &&
 		 &to_ipaddress($myconfig{'host'}) ne
@@ -1878,7 +1878,7 @@ if ($mysqld) {
 	}
 $dir ||= $myconfig{'mysql_data'};
 return undef if (!-d $dir);
-local $escdb = $db;
+my $escdb = $db;
 $escdb =~ s/-/\@002d/g;
 if (-d "$myconfig{'mysql_data'}/$escdb") {
 	return "$myconfig{'mysql_data'}/$escdb";
@@ -1900,29 +1900,29 @@ else {
 # If always-from-template == 3, then only existing hosts will be used
 sub get_mysql_hosts
 {
-local ($d, $always) = @_;
+my ($d, $always) = @_;
 &require_mysql();
-local @hosts;
+my @hosts;
 if (!$always) {
 	@hosts = &get_mysql_allowed_hosts($d);
 	}
 if (!@hosts) {
 	# Fall back to those from template
-	local $tmpl = &get_template($d->{'template'});
+	my $tmpl = &get_template($d->{'template'});
 	@hosts = $tmpl->{'mysql_hosts'} eq "none" ? ( ) :
 	    split(/\s+/, &substitute_domain_template(
 				$tmpl->{'mysql_hosts'}, $d));
 	@hosts = ( 'localhost', '127.0.0.1' ) if (!@hosts);
-	local $mymod = &require_dom_mysql($d);
-	local %myconfig = &foreign_config($mymod);
+	my $mymod = &require_dom_mysql($d);
+	my %myconfig = &foreign_config($mymod);
 	if ($always == 2 ||
 	    $myconfig{'host'} && $myconfig{'host'} ne 'localhost') {
 		# Remove localhost from hosts as we are creating on the remote
 		@hosts = grep { $_ ne 'localhost' && !/^127\./ } @hosts;
 
 		# Add this host too, as we are talking to a remote server
-		local $myhost = &get_system_hostname();
-		local $myip = &to_ipaddress($myhost);
+		my $myhost = &get_system_hostname();
+		my $myip = &to_ipaddress($myhost);
 		if ($myip =~ /^127\./) {
 			# Try again to get an actual IP address
 			($myip) = grep { &check_ipaddress($_) &&
@@ -1946,7 +1946,7 @@ return &unique(@hosts);
 # password, a list of allowed hosts
 sub list_mysql_database_users
 {
-local ($d, $db) = @_;
+my ($d, $db) = @_;
 &require_mysql();
 if ($d->{'provision_mysql'}) {
 	# Fetch from provisioning server
@@ -1964,8 +1964,8 @@ if ($d->{'provision_mysql'}) {
 	}
 else {
 	# Query local MySQL server
-	local $qdb = &quote_mysql_database($db);
-	local $rv;
+	my $qdb = &quote_mysql_database($db);
+	my $rv;
 	eval {
 		# Try old password column first
 		local $main::error_must_die = 1;
@@ -1979,7 +1979,7 @@ else {
 			$rv = &execute_dom_sql($d, $mysql::master_db, "select user.user,user.authentication_string,db.host from user,db where db.user = user.user and (db.db = '$db' or db.db = '$qdb')");
 			};
 		}
-	local (@rv, %done);
+	my (@rv, %done);
 	foreach my $r (@{$rv->{'data'}}) {
 		my $u = $done{$r->[0]};
 		if (!$u) {
@@ -1999,7 +1999,7 @@ else {
 # Returns 1 if some user exists on the MySQL server
 sub check_mysql_user_clash
 {
-local ($d, $user) = @_;
+my ($d, $user) = @_;
 &require_mysql();
 return 1 if ($user eq 'root');	# Never available
 if ($d->{'provision_mysql'}) {
@@ -2011,7 +2011,7 @@ if ($d->{'provision_mysql'}) {
 	}
 else {
 	# Check locally
-	local $rv = &execute_dom_sql($d, $mysql::master_db,
+	my $rv = &execute_dom_sql($d, $mysql::master_db,
 		"select user from user where user = ?", $user);
 	return @{$rv->{'data'}} ? 1 : 0;
 	}
@@ -2022,7 +2022,7 @@ else {
 # Adds one mysql user, who can access multiple databases
 sub create_mysql_database_user
 {
-local ($d, $dbs, $user, $pass, $encpass, $auth_plugin) = @_;
+my ($d, $dbs, $user, $pass, $encpass, $auth_plugin) = @_;
 &require_mysql();
 &obtain_lock_mysql($d);
 if ($d->{'provision_mysql'}) {
@@ -2034,7 +2034,7 @@ if ($d->{'provision_mysql'}) {
 	else {
 		$info->{'pass'} = $pass;
 		}
-	local @hosts = map { &to_ipaddress($_) } &get_mysql_hosts($d, 2);
+	my @hosts = map { &to_ipaddress($_) } &get_mysql_hosts($d, 2);
 	$info->{'remote'} = \@hosts;
 	$info->{'database'} = $dbs;
 	my $conns = &get_mysql_user_connections($d, 1);
@@ -2047,14 +2047,14 @@ if ($d->{'provision_mysql'}) {
 	}
 else {
 	# Create locally
-	local $myuser = &mysql_username($user);
-	local @hosts = &get_mysql_hosts($d, 1);
+	my $myuser = &mysql_username($user);
+	my @hosts = &get_mysql_hosts($d, 1);
 	foreach my $h (@hosts) {
 		&execute_user_deletion_sql($d, $h, $user);
 		&execute_user_creation_sql($d, $h, $myuser, 
 		      $encpass ? "'".&mysql_escape($encpass)."'" :undef,
 		      $pass, $auth_plugin);
-		local $db;
+		my $db;
 		foreach $db (@$dbs) {
 			&create_mysql_db_grant($d, $h, $db, $myuser);
 			}
@@ -2068,10 +2068,10 @@ else {
 # Removes one database user and his access to all databases
 sub delete_mysql_database_user
 {
-local ($d, $user) = @_;
+my ($d, $user) = @_;
 &require_mysql();
 &obtain_lock_mysql($d);
-local $myuser = &mysql_username($user);
+my $myuser = &mysql_username($user);
 if ($d->{'provision_mysql'}) {
 	# Delete on provisioning server
 	my $mymod = &get_domain_mysql_module($d);
@@ -2094,11 +2094,11 @@ else {
 # mysql databases
 sub modify_mysql_database_user
 {
-local ($d, $olddbs, $dbs, $olduser, $user, $pass, $encpass) = @_;
+my ($d, $olddbs, $dbs, $olduser, $user, $pass, $encpass) = @_;
 &require_mysql();
 &obtain_lock_mysql($d);
-local $myuser = &mysql_username($user);
-local $myolduser = &mysql_username($olduser);
+my $myuser = &mysql_username($user);
+my $myolduser = &mysql_username($olduser);
 if ($d->{'provision_mysql'}) {
 	# Update on provisioning server
 	my $mymod = &get_domain_mysql_module($d);
@@ -2141,11 +2141,11 @@ else {
 		}
 	if (join(" ", @$dbs) ne join(" ", @$olddbs)) {
 		# Update accessible database list
-		local @hosts = &get_mysql_hosts($d);
+		my @hosts = &get_mysql_hosts($d);
 		&delete_mysql_db_grant($d, undef, $myuser);
-		local $h;
+		my $h;
 		foreach $h (@hosts) {
-			local $db;
+			my $db;
 			foreach $db (@$dbs) {
 				&create_mysql_db_grant($d, $h, $db, $myuser);
 				}
@@ -2206,14 +2206,14 @@ return ( [ $text{'sysinfo_mysql'}, $v ] );
 
 sub startstop_mysql
 {
-local ($typestatus) = @_;
+my ($typestatus) = @_;
 &require_mysql();
 return ( ) if ($config{'provision_mysql'} ||
 	       !&mysql::is_mysql_local());	# cannot stop/start remote
-local $r = defined($typestatus->{'mysql'}) ?
+my $r = defined($typestatus->{'mysql'}) ?
 		$typestatus->{'mysql'} == 1 :
 		&mysql::is_mysql_running();
-local @links = ( { 'link' => '/mysql/',
+my @links = ( { 'link' => '/mysql/',
 		   'desc' => $text{'index_mymanage'},
 		   'manage' => 1 } );
 if ($r == 1) {
@@ -2272,7 +2272,7 @@ else {
 # Returns a MySQL escaped database name like \% and \_ unescaped
 sub unquote_mysql_database
 {
-local ($db) = @_;
+my ($db) = @_;
 $db =~ s/\\_/_/g;
 $db =~ s/\\%/%/g;
 return $db;
@@ -2282,7 +2282,7 @@ return $db;
 # Returns a MySQL database name with % and _ characters escaped
 sub quote_mysql_database
 {
-local ($db) = @_;
+my ($db) = @_;
 $db =~ s/_/\\_/g;
 $db =~ s/%/\\%/g;
 return $db;
@@ -2292,7 +2292,7 @@ return $db;
 # Outputs HTML for editing MySQL related template options
 sub show_template_mysql
 {
-local ($tmpl) = @_;
+my ($tmpl) = @_;
 &require_mysql();
 
 # Default database name template
@@ -2412,7 +2412,7 @@ print &ui_table_row(&hlink($text{'tmpl_mysql_uconns'},
 # Updates MySQL related template options from %in
 sub parse_template_mysql
 {
-local ($tmpl) = @_;
+my ($tmpl) = @_;
 &require_mysql();
 
 # Save MySQL-related settings
@@ -2482,13 +2482,13 @@ sub creation_form_mysql
 {
 my ($d) = @_;
 &require_mysql();
-local $rv;
+my $rv;
 if (&get_dom_remote_mysql_version($d) >= 4.1) {
-	local $tmpl = &get_template($d->{'template'});
+	my $tmpl = &get_template($d->{'template'});
 
 	# Character set
-	local @charsets = &list_mysql_character_sets($d);
-	local $cs = $tmpl->{'mysql_charset'};
+	my @charsets = &list_mysql_character_sets($d);
+	my $cs = $tmpl->{'mysql_charset'};
 	$cs = "" if ($cs eq "none");
 	$rv .= &ui_table_row($text{'database_charset'},
 		     &ui_select("mysql_charset", $cs,
@@ -2497,11 +2497,11 @@ if (&get_dom_remote_mysql_version($d) >= 4.1) {
 				      @charsets ]));
 
 	# Collation order
-	local $cl = $tmpl->{'mysql_collate'};
+	my $cl = $tmpl->{'mysql_collate'};
 	$cl = "" if ($cs eq "none");
-	local @colls = &list_mysql_collation_orders($d);
+	my @colls = &list_mysql_collation_orders($d);
 	if (@colls) {
-		local %csmap = map { $_->[0], $_->[1] } @charsets;
+		my %csmap = map { $_->[0], $_->[1] } @charsets;
 		$rv .= &ui_table_row($text{'database_collate'},
 		     &ui_select("mysql_collate", $cl,
 			[ [ undef, "&lt;$text{'default'}&gt;" ],
@@ -2517,8 +2517,8 @@ return $rv;
 # for passing to create_mysql_database
 sub creation_parse_mysql
 {
-local ($d, $in) = @_;
-local $opts = { 'charset' => $in->{'mysql_charset'},
+my ($d, $in) = @_;
+my $opts = { 'charset' => $in->{'mysql_charset'},
 		'collate' => $in->{'mysql_collate'} };
 return $opts;
 }
@@ -2528,7 +2528,7 @@ return $opts;
 # allowed to connect to MySQL.
 sub get_mysql_allowed_hosts
 {
-local ($d) = @_;
+my ($d) = @_;
 return &get_mysql_user_allowed_hosts($d, &mysql_user($d));
 }
 
@@ -2551,7 +2551,7 @@ if ($d->{'provision_mysql'}) {
 	}
 else {
 	# Get from local DB
-	local $data = &execute_dom_sql($d, $mysql::master_db,
+	my $data = &execute_dom_sql($d, $mysql::master_db,
 	    "select distinct host from user where user = ?", $user);
 	return map { $_->[0] } @{$data->{'data'}};
 	}
@@ -2562,10 +2562,10 @@ else {
 # Returns undef on success, or an error message on failure.
 sub save_mysql_allowed_hosts
 {
-local ($d, $hosts) = @_;
+my ($d, $hosts) = @_;
 &require_mysql();
 &obtain_lock_mysql($d);
-local $user = &mysql_user($d);
+my $user = &mysql_user($d);
 
 if ($d->{'provision_mysql'}) {
 	# Call the remote API
@@ -2580,7 +2580,7 @@ else {
 	# Update MySQL permissions locally
 
 	# First get all the DBs owned by this domain, and sub-domains
-	local @dbs = &domain_databases($d, [ 'mysql' ]);
+	my @dbs = &domain_databases($d, [ 'mysql' ]);
 	foreach my $sd (&get_domain_by("parent", $d->{'id'})) {
 		push(@dbs, &domain_databases($sd, [ 'mysql' ]));
 		}
@@ -2655,13 +2655,13 @@ return &has_home_quotas() &&
 # like password('smeg')
 sub encrypted_mysql_pass
 {
-local ($d) = @_;
+my ($d) = @_;
 if ($d->{'mysql_enc_pass'}) {
 	return "'".&mysql_escape($d->{'mysql_enc_pass'})."'";
 	}
 else {
-	local $qpass = &mysql_escape(&mysql_pass($d));
-	local $pf = &get_mysql_password_func($d);
+	my $qpass = &mysql_escape(&mysql_pass($d));
+	my $pf = &get_mysql_password_func($d);
 	return "$pf('$qpass')";
 	}
 }
@@ -2692,13 +2692,13 @@ return $rv;
 # Tries to login to MySQL with the given credentials, returning undef on failure
 sub check_mysql_login
 {
-local ($d, $dbname, $dbuser, $dbpass) = @_;
+my ($d, $dbname, $dbuser, $dbpass) = @_;
 &require_mysql();
 local $main::error_must_die = 1;
 local $mysql::mysql_login = $dbuser;
 local $mysql::mysql_pass = $dbpass;
 eval { &execute_dom_sql($d, $dbname, "show tables") };
-local $err = $@;
+my $err = $@;
 if ($err) {
 	$err =~ s/\s+at\s+.*\sline//g;
 	return $err;
@@ -2713,7 +2713,7 @@ sub list_mysql_collation_orders
 {
 my ($d) = @_;
 &require_mysql();
-local @rv;
+my @rv;
 if ($config{'provision_mysql'}) {
 	my $mymod = &get_domain_mysql_module($d);
 	if ($mymod->{'config'}->{'host'}) {
@@ -2767,10 +2767,10 @@ else {
 # Checks if a MySQL database name is valid
 sub validate_database_name_mysql
 {
-local ($d, $dbname) = @_;
+my ($d, $dbname) = @_;
 $dbname =~ /^[a-z0-9\_\-]+$/i ||
 	return $text{'database_ename'};
-local $maxlen;
+my $maxlen;
 if ($d->{'provision_mysql'}) {
 	# Just assume that the DB name max is 64 chars
 	$maxlen = 64;
@@ -2778,10 +2778,10 @@ if ($d->{'provision_mysql'}) {
 else {
 	# Get the DB name max from the mysql.db table
 	&require_mysql();
-	local $mod = &require_dom_mysql($d);
-	local @str = &foreign_call($mod, "table_structure",
+	my $mod = &require_dom_mysql($d);
+	my @str = &foreign_call($mod, "table_structure",
 				   $mysql::master_db, "db");
-	local ($dbcol) = grep { lc($_->{'field'}) eq 'db' } @str;
+	my ($dbcol) = grep { lc($_->{'field'}) eq 'db' } @str;
 	$maxlen = $dbcol && $dbcol->{'type'} =~ /\((\d+)\)/ ? $1 : 64;
 	}
 length($dbname) <= $maxlen ||
@@ -2793,9 +2793,9 @@ return undef;
 # Returns default options for a new MySQL DB in some domain
 sub default_mysql_creation_opts
 {
-local ($d) = @_;
-local $tmpl = &get_template($d->{'template'});
-local %opts;
+my ($d) = @_;
+my $tmpl = &get_template($d->{'template'});
+my %opts;
 if ($tmpl->{'mysql_charset'} && $tmpl->{'mysql_charset'} ne 'none') {
 	$opts{'charset'} = $tmpl->{'mysql_charset'};
 	}
@@ -2809,12 +2809,12 @@ return \%opts;
 # Returns a hash ref of database creation options for an existing DB
 sub get_mysql_creation_opts
 {
-local ($d, $dbname) = @_;
+my ($d, $dbname) = @_;
 &require_mysql();
-local $data = &execute_dom_sql($d, $dbname, "show create database ".
+my $data = &execute_dom_sql($d, $dbname, "show create database ".
 					    &mysql::quotestr($dbname));
-local $sql = $data->{'data'}->[0]->[1];
-local $opts = { };
+my $sql = $data->{'data'}->[0]->[1];
+my $opts = { };
 if ($sql =~ /CHARACTER\s+SET\s+(\S+)/i) {
 	$opts->{'charset'} = $1;
 	}
@@ -2828,12 +2828,12 @@ return $opts;
 # Returns the names of all known MySQL databases
 sub list_all_mysql_databases
 {
-local ($d) = @_;
-local $prov = $d ? $d->{'provision_mysql'} : $config{'provision_mysql'};
+my ($d) = @_;
+my $prov = $d ? $d->{'provision_mysql'} : $config{'provision_mysql'};
 &require_mysql();
 if ($prov) {
 	# From provisioning server
-	local $info = { 'feature' => 'mysqldb' };
+	my $info = { 'feature' => 'mysqldb' };
 	my ($ok, $msg) = &provision_api_call(
 		"list-provision-history", $info, 1);
 	if (!$ok) {
@@ -2851,8 +2851,8 @@ else {
 # Sets the max connections for a user if defined in the template
 sub set_mysql_user_connections
 {
-local ($d, $host, $user, $mailbox) = @_;
-local $conns = &get_mysql_user_connections($d, $mailbox);
+my ($d, $host, $user, $mailbox) = @_;
+my $conns = &get_mysql_user_connections($d, $mailbox);
 if ($conns) {
 	if (&mysql_supports_grants($d)) {
 		# Need to use the alter user command
@@ -2873,9 +2873,9 @@ if ($conns) {
 # Returns the max connections to MySQL from a template
 sub get_mysql_user_connections
 {
-local ($d, $mailbox) = @_;
-local $tmpl = &get_template($d->{'template'});
-local $conns = $tmpl->{$mailbox ? 'mysql_uconns' : 'mysql_conns'};
+my ($d, $mailbox) = @_;
+my $tmpl = &get_template($d->{'template'});
+my $conns = $tmpl->{$mailbox ? 'mysql_uconns' : 'mysql_conns'};
 $conns = undef if ($conns eq "none");
 return $conns;
 }
@@ -2890,7 +2890,7 @@ return ("default", "small", "medium", "large", "huge");
 # diff my-large.cnf my-huge.cnf  | grep ">" | grep -v "#" | grep = | perl -ne 'print "[ \"$1\", \"$2\" ],\n" if (/(\S+)\s*=\s*(\S+)/)'
 sub list_mysql_size_settings
 {
-local ($size, $myver, $variant) = @_;
+my ($size, $myver, $variant) = @_;
 &require_mysql();
 ($myver, $variant) = &get_dom_remote_mysql_version() if (!$myver && !$variant);
 my $cachedir = &compare_versions($myver, "5.1.3") > 0 ? "table_open_cache"
@@ -3015,7 +3015,7 @@ sub execute_user_rename_sql
 my ($d, $olduser, $user) = @_;
 if (&mysql_supports_grants($d)) {
 	# Need to alter user
-	local $rv = &execute_dom_sql($d, $mysql::master_db,
+	my $rv = &execute_dom_sql($d, $mysql::master_db,
 		"select host from user where user = ?", $olduser);
 	foreach my $r (@{$rv->{'data'}}) {
 		&execute_dom_sql($d, $mysql::master_db,
@@ -3161,7 +3161,7 @@ if (&mysql_supports_grants($d)) {
 		}
 	else {
 		# Need to drop from all hosts explicitly
-		local $rv = &execute_dom_sql($d, $mysql::master_db,
+		my $rv = &execute_dom_sql($d, $mysql::master_db,
 			"select host from user where user = ?", $user);
 		foreach my $r (@{$rv->{'data'}}) {
 			push(@rv, "drop user if exists '$user'\@'$r->[0]'");
@@ -3310,7 +3310,7 @@ return 1;
 # Returns 1 if the domain's MySQL DB is on a remote system
 sub remote_mysql
 {
-local ($d) = @_;
+my ($d) = @_;
 my $mymod = &get_domain_mysql_module($d);
 return $mymod->{'config'}->{'host'};
 }

--- a/feature-postgres.pl
+++ b/feature-postgres.pl
@@ -16,7 +16,7 @@ return &foreign_available("postgresql");
 sub check_depends_postgres
 {
 return undef if (!$_[0]->{'parent'});
-local $parent = &get_domain($_[0]->{'parent'});
+my $parent = &get_domain($_[0]->{'parent'});
 return $text{'setup_edeppostgres'} if (!$parent->{'postgres'});
 return undef;
 }
@@ -26,7 +26,7 @@ return undef;
 sub check_anti_depends_postgres
 {
 if (!$_[0]->{'postgres'}) {
-	local @subs = &get_domain_by("parent", $_[0]->{'id'});
+	my @subs = &get_domain_by("parent", $_[0]->{'id'});
 	foreach my $s (@subs) {
 		return $text{'setup_edeppostgressub'} if ($s->{'postgres'});
 		}
@@ -47,7 +47,7 @@ return if (!$config{'postgres'});
 # Un-lock the PostgreSQL config file for some domain
 sub release_lock_postgres
 {
-local ($d) = @_;
+my ($d) = @_;
 return if (!$config{'postgres'});
 &release_lock_anything($d);
 }
@@ -57,12 +57,12 @@ return if (!$config{'postgres'});
 # This can be overridden to allow a takeover of the DB.
 sub check_warnings_postgres
 {
-local ($d, $oldd) = @_;
+my ($d, $oldd) = @_;
 $d->{'postgres'} && (!$oldd || !$oldd->{'postgres'}) || return undef;
 if (!$d->{'provision_postgres'}) {
 	# DB clash
 	&require_postgres();
-	local @dblist = &list_dom_postgres_databases($d);
+	my @dblist = &list_dom_postgres_databases($d);
 	return &text('setup_epostgresdb', $d->{'db'})
 		if (&indexof($d->{'db'}, @dblist) >= 0);
 
@@ -91,8 +91,8 @@ return $s->{'data'}->[0] ? 1 : 0;
 # Returns 1 if some PostgreSQL user or database is used by another domain
 sub check_postgres_clash
 {
-local ($d, $field) = @_;
-local @doms = grep { $_->{'postgres'} && $_->{'id'} ne $d->{'id'} }
+my ($d, $field) = @_;
+my @doms = grep { $_->{'postgres'} && $_->{'id'} ne $d->{'id'} }
 		   &list_domains();
 
 # Check for DB clash
@@ -125,14 +125,14 @@ return undef;
 # Create a new PostgreSQL database and user
 sub setup_postgres
 {
-local ($d, $nodb) = @_;
-local $tmpl = &get_template($d->{'template'});
+my ($d, $nodb) = @_;
+my $tmpl = &get_template($d->{'template'});
 if (!$d->{'postgres_module'}) {
         # Use the default module for this system
         $d->{'postgres_module'} = &get_default_postgres_module();
 	}
 &require_postgres();
-local $user = $d->{'postgres_user'} = &postgres_user($d);
+my $user = $d->{'postgres_user'} = &postgres_user($d);
 
 if (!$d->{'parent'}) {
 	if ($d->{'postgres_module'} ne 'postgresql') {
@@ -142,14 +142,14 @@ if (!$d->{'parent'}) {
 	else {
 		&$first_print($text{'setup_postgresuser'});
 		}
-	local $pass = &postgres_pass($d);
+	my $pass = &postgres_pass($d);
 	if (&postgres_user_exists($d, $user)) {
 		&execute_dom_psql($d, undef,
 			"alter user ".&postgres_uquote($user).
 			" with password $pass");
 		}
 	else {
-		local $popts = &get_postgresql_user_flags();
+		my $popts = &get_postgresql_user_flags();
 		&execute_dom_psql($d, undef,
 			"create user ".&postgres_uquote($user).
 			" with password $pass $popts");
@@ -158,7 +158,7 @@ if (!$d->{'parent'}) {
 	}
 if (!$nodb && $tmpl->{'mysql_mkdb'} && !$d->{'no_mysql_db'}) {
 	# Create the initial DB
-	local $opts = &default_postgres_creation_opts($d);
+	my $opts = &default_postgres_creation_opts($d);
 	&create_postgres_database($d, $d->{'db'}, $opts);
 	}
 else {
@@ -178,7 +178,7 @@ return 1;
 # actually change the database - that must be done by modify_postgres.
 sub set_postgres_pass
 {
-local ($d, $pass) = @_;
+my ($d, $pass) = @_;
 if (defined($pass)) {
 	$d->{'postgres_pass'} = $pass;
 	}
@@ -197,7 +197,7 @@ if ($d->{'parent'}) {
 	return &postgres_pass($parent);
 	}
 &require_postgres();
-local $pass = defined($d->{'postgres_pass'}) ? $d->{'postgres_pass'}
+my $pass = defined($d->{'postgres_pass'}) ? $d->{'postgres_pass'}
 					     : $d->{'pass'};
 return !$noquote && &get_dom_remote_postgres_version($d) >= 7 ?
 	&postgres_quote($pass) : $pass;
@@ -207,7 +207,7 @@ return !$noquote && &get_dom_remote_postgres_version($d) >= 7 ?
 # Returns a string in '' quotes, with escaping if needed
 sub postgres_quote
 {
-local ($str) = @_;
+my ($str) = @_;
 $str =~ s/'/''/g;
 return "'$str'";
 }
@@ -216,7 +216,7 @@ return "'$str'";
 # Returns a string in "" quotes, with escaping if needed
 sub postgres_uquote
 {
-local ($str) = @_;
+my ($str) = @_;
 if ($str =~ /^[A-Za-z0-9\.\_\-]+$/) {
 	return "\"".$str."\"";
 	}
@@ -352,7 +352,7 @@ elsif ($user ne $olduser && $d->{'parent'}) {
 # Delete the PostgreSQL database and user
 sub delete_postgres
 {
-local ($d, $preserve) = @_;
+my ($d, $preserve) = @_;
 &require_postgres();
 my @dblist = &unique(split(/\s+/, $d->{'db_postgres'}));
 my $pghost = &get_database_host_postgres($d);
@@ -367,7 +367,7 @@ if ($preserve && &remote_postgres($d)) {
 
 # Delete all databases
 &delete_postgres_database($d, @dblist) if (@dblist);
-local $user = &postgres_user($d);
+my $user = &postgres_user($d);
 
 if (!$d->{'parent'}) {
 	# Delete the user
@@ -411,15 +411,15 @@ return 1;
 # Copy all databases and their contents to a new domain
 sub clone_postgres
 {
-local ($d, $oldd) = @_;
+my ($d, $oldd) = @_;
 &$first_print($text{'clone_postgres'});
 
 # Re-create each DB with a new name
-local %dbmap;
+my %dbmap;
 foreach my $db (&domain_databases($oldd, [ 'postgres' ])) {
-	local $newname = $db->{'name'};
-	local $newprefix = &fix_database_name($d->{'prefix'}, 'postgres');
-	local $oldprefix = &fix_database_name($oldd->{'prefix'}, 'postgres');
+	my $newname = $db->{'name'};
+	my $newprefix = &fix_database_name($d->{'prefix'}, 'postgres');
+	my $oldprefix = &fix_database_name($oldd->{'prefix'}, 'postgres');
 	if ($newname eq $oldd->{'db'}) {
 		$newname = $d->{'db'};
 		}
@@ -434,8 +434,8 @@ foreach my $db (&domain_databases($oldd, [ 'postgres' ])) {
 		}
 	&push_all_print();
 	&set_all_null_print();
-	local $opts = &get_postgres_creation_opts($oldd, $db->{'name'});
-	local $ok = &create_postgres_database($d, $newname, $opts);
+	my $opts = &get_postgres_creation_opts($oldd, $db->{'name'});
+	my $ok = &create_postgres_database($d, $newname, $opts);
 	&pop_all_print();
 	if (!$ok) {
 		&$second_print(&text('clone_postgrescreate', $newname));
@@ -452,9 +452,9 @@ if (%dbmap) {
 	&$first_print($text{'clone_postgrescopy'});
 	my $mod = &require_dom_postgres($d);
 	foreach my $db (&domain_databases($d, [ 'postgres' ])) {
-		local $oldname = $dbmap{$db->{'name'}};
-		local $temp = &transname();
-		local ($sameunix, $login) = &get_dom_postgres_creds($d);
+		my $oldname = $dbmap{$db->{'name'}};
+		my $temp = &transname();
+		my ($sameunix, $login) = &get_dom_postgres_creds($d);
 		if ($sameunix && (my @uinfo = getpwnam($login))) {
 			# Create empty file postgres user can write to
 			&open_tempfile(EMPTY, ">$temp", 0, 1);
@@ -462,7 +462,7 @@ if (%dbmap) {
 			&set_ownership_permissions($uinfo[2], $uinfo[3],
 						   undef, $temp);
 			}
-		local $err = &foreign_call($mod, "backup_database",
+		my $err = &foreign_call($mod, "backup_database",
 					   $oldname, $temp, 'c', undef);
 		if ($err) {
 			&$second_print(&text('clone_postgresbackup',
@@ -486,9 +486,9 @@ if (%dbmap) {
 # Make sure all PostgreSQL databases exist
 sub validate_postgres
 {
-local ($d) = @_;
+my ($d) = @_;
 &require_postgres();
-local %got = map { $_, 1 } &list_dom_postgres_databases($d);
+my %got = map { $_, 1 } &list_dom_postgres_databases($d);
 foreach my $db (&domain_databases($d, [ "postgres" ])) {
 	$got{$db->{'name'}} || return &text('validate_epostgres',$db->{'name'});
 	}
@@ -654,7 +654,7 @@ if (!$d->{'wasmissing'}) {
 	}
 
 # Work out which databases are in backup
-local ($dbfile, @dbs);
+my ($dbfile, @dbs);
 foreach $dbfile (glob($file."_*")) {
 	if (-r $dbfile) {
 		$dbfile =~ /\Q$file\E_(.*)$/;
@@ -663,7 +663,7 @@ foreach $dbfile (glob($file."_*")) {
 	}
 
 # Finally, import the data
-local $db;
+my $db;
 foreach $db (@dbs) {
 	my $clash = &check_postgres_database_clash($d, $db->[0]);
 	if ($clash && $d->{'wasmissing'}) {
@@ -674,7 +674,7 @@ foreach $db (@dbs) {
 		my $ver = &get_dom_remote_postgres_version($d);
 		if (@tables && $ver >= 8.0) {
 			# But grant access to the DB to the domain owner
-			local $q = &postgres_uquote(&postgres_user($d));
+			my $q = &postgres_uquote(&postgres_user($d));
 			&execute_dom_psql(
 				$d, undef,
 				"alter database $db->[0] owner to $q");
@@ -703,7 +703,7 @@ foreach $db (@dbs) {
 		# file owned by him, and the parent directory world-accessible
 		&set_ownership_permissions($uinfo[2], $uinfo[3],
 					   undef, $db->[1]);
-		local $dir = $file;
+		my $dir = $file;
 		$dir =~ s/\/[^\/]+$//;
 		&set_ownership_permissions(undef, undef, 0711, $dir);
 		}
@@ -853,7 +853,7 @@ eval {
 		"revoke all on database ".&postgres_uquote($db).
 		" from public");
 	};
-local @dbs = split(/\s+/, $d->{'db_postgres'});
+my @dbs = split(/\s+/, $d->{'db_postgres'});
 push(@dbs, $db);
 $d->{'db_postgres'} = join(" ", @dbs);
 &release_lock_postgres($d);
@@ -930,7 +930,7 @@ else {
 # back to postgres
 sub revoke_postgres_database
 {
-local ($d, $dbname) = @_;
+my ($d, $dbname) = @_;
 &require_postgres();
 my $ver = &get_dom_remote_postgres_version($d);
 if ($ver && &postgres_user_exists($d, "postgres")) {
@@ -944,7 +944,7 @@ if ($ver && &postgres_user_exists($d, "postgres")) {
 # Returns a list of PostgreSQL users and passwords who can access some database
 sub list_all_postgres_users
 {
-local ($d, $db) = @_;
+my ($d, $db) = @_;
 return ( );	# XXX not possible
 }
 
@@ -952,7 +952,7 @@ return ( );	# XXX not possible
 # Returns a list of all PostgreSQL users
 sub list_postgres_database_users
 {
-local ($d, $db) = @_;
+my ($d, $db) = @_;
 return ( );	# XXX not possible
 }
 
@@ -995,11 +995,11 @@ return $pgconfig{'port'} || 5432;
 sub sysinfo_postgres
 {
 &require_postgres();
-local @rv;
+my @rv;
 eval {
 	# Protect against DBI errors
 	local $main::error_must_die = 1;
-	local $ver = &postgresql::get_postgresql_version();
+	my $ver = &postgresql::get_postgresql_version();
 	@rv = ( [ $text{'sysinfo_postgresql'}, $ver ] );
 	};
 return @rv;
@@ -1007,13 +1007,13 @@ return @rv;
 
 sub startstop_postgres
 {
-local ($typestatus) = @_;
+my ($typestatus) = @_;
 &require_postgres();
 return ( ) if (!&postgresql::is_postgresql_local());
-local $r = defined($typestatus->{'postgresql'}) ?
+my $r = defined($typestatus->{'postgresql'}) ?
                 $typestatus->{'postgresql'} == 1 :
 		&postgresql::is_postgresql_running();
-local @links = ( { 'link' => '/postgresql/',
+my @links = ( { 'link' => '/postgresql/',
 		   'desc' => $text{'index_pgmanage'},
 		   'manage' => 1 } );
 if ($r == 1) {
@@ -1039,7 +1039,7 @@ else {
 sub stop_service_postgres
 {
 &require_postgres();
-local $rv = &postgresql::stop_postgresql();
+my $rv = &postgresql::stop_postgresql();
 sleep(5);
 return $rv;
 }
@@ -1055,7 +1055,7 @@ return &postgresql::start_postgresql();
 # on failure
 sub check_postgres_login
 {
-local ($d, $dbname, $dbuser, $dbpass) = @_;
+my ($d, $dbname, $dbuser, $dbpass) = @_;
 &require_postgres();
 my $mod = &require_dom_postgres($d);
 my @defcreds = &get_dom_postgres_creds($d);
@@ -1064,7 +1064,7 @@ eval {
 	local $main::error_must_die = 1;
 	&execute_dom_psql($d, $dbname, "select version()");
 	};
-local $err = $@;
+my $err = $@;
 &foreign_call($mod, "set_login_pass", @defcreds);
 if ($err) {
 	$err =~ s/\s+at\s+.*\sline//g;
@@ -1096,8 +1096,8 @@ if ($ver >= 7.4) {
 # for passing to create_postgres_database
 sub creation_parse_postgres
 {
-local ($d, $in) = @_;
-local $opts = { 'encoding' => $in->{'postgres_encoding'} };
+my ($d, $in) = @_;
+my $opts = { 'encoding' => $in->{'postgres_encoding'} };
 return $opts;
 }
 
@@ -1111,7 +1111,7 @@ if (!scalar(@postgres_encodings_cache)) {
 	&open_readfile(ENCS, "$module_root_directory/postgres-encodings");
 	while(<ENCS>) {
 		s/\r|\n//g;
-		local @w = split(/\t/, $_);
+		my @w = split(/\t/, $_);
 		if ($w[2] !~ /\Q$w[0]\E/i) {
 			$w[2] .= " ($w[0])";
 			}
@@ -1128,7 +1128,7 @@ return @postgres_encodings_cache;
 # Outputs HTML for editing PostgreSQL related template options
 sub show_template_postgres
 {
-local ($tmpl) = @_;
+my ($tmpl) = @_;
 &require_postgres();
 
 # Default encoding
@@ -1145,7 +1145,7 @@ print &ui_table_row(&hlink($text{'tmpl_postgres_encoding'},
 # Updates PostgreSQL related template options from %in
 sub parse_template_postgres
 {
-local ($tmpl) = @_;
+my ($tmpl) = @_;
 &require_postgres();
 $tmpl->{'postgres_encoding'} = $in{'postgres_encoding'};
 }
@@ -1154,9 +1154,9 @@ $tmpl->{'postgres_encoding'} = $in{'postgres_encoding'};
 # Returns default options for a new PostgreSQL DB in some domain
 sub default_postgres_creation_opts
 {
-local ($d) = @_;
-local $tmpl = &get_template($d->{'template'});
-local %opts;
+my ($d) = @_;
+my $tmpl = &get_template($d->{'template'});
+my %opts;
 if ($tmpl->{'postgres_encoding'} &&
     $tmpl->{'postgres_encoding'} ne 'none') {
 	$opts{'encoding'} = $tmpl->{'postgres_encoding'};
@@ -1221,7 +1221,7 @@ return 1;
 # Returns true if the domain's PostgreSQL DB is on a remote system
 sub remote_postgres
 {
-local ($d) = @_;
+my ($d) = @_;
 my $host = &get_database_host_postgres($d);
 return $host eq "localhost" ? undef : $host;
 }

--- a/feature-spam.pl
+++ b/feature-spam.pl
@@ -45,7 +45,7 @@ if (!-d $spam_config_dir) {
 	&make_dir($spam_config_dir, 0755);
 	&set_ownership_permissions(undef, undef, 0755, $spam_config_dir);
 	}
-local $spamdir = "$spam_config_dir/$d->{'id'}";
+my $spamdir = "$spam_config_dir/$d->{'id'}";
 &make_dir($spamdir, 0750);
 &set_ownership_permissions($d->{'uid'}, $d->{'gid'}, 0750, $spamdir);
 
@@ -53,8 +53,8 @@ local $spamdir = "$spam_config_dir/$d->{'id'}";
 &obtain_lock_cron($d);
 
 # Add the procmail entry to get the VIRTUALMIN variable
-local @recipes = &procmail::get_procmailrc();
-local ($r, $gotvirt, $gotdef);
+my @recipes = &procmail::get_procmailrc();
+my ($r, $gotvirt, $gotdef);
 foreach $r (@recipes) {
 	if ($r->{'type'} eq '=' &&
 	    $r->{'action'} =~ /^VIRTUALMIN=/) {
@@ -66,12 +66,12 @@ foreach $r (@recipes) {
 	}
 if (!$gotvirt) {
 	# Need to add entries to lookup the domain, and run it's include file
-	local $var1 = { 'flags' => [ 'w', 'i' ],
+	my $var1 = { 'flags' => [ 'w', 'i' ],
 			'conds' => [ ],
 			'type' => '=',
 		        'action' => "VIRTUALMIN=|$domain_lookup_cmd \$LOGNAME" };
-	local $testcmd = &has_command("test") || "test";
-	local $var2 = { 'flags' => [ ],
+	my $testcmd = &has_command("test") || "test";
+	my $var2 = { 'flags' => [ ],
 			'conds' => [ [ "?", "$testcmd \"\$VIRTUALMIN\" != \"\"" ] ],
 			'block' => "INCLUDERC=$procmail_spam_dir/\$VIRTUALMIN",
 		      };
@@ -86,7 +86,7 @@ if (!$gotvirt) {
 	# Otherwise, add at the top
 	if (@recipes) {
 		# Has some recipes .. check if there is a TRAP
-		local ($trap, $aftertrap);
+		my ($trap, $aftertrap);
 		for(my $i=0; $i<@recipes; $i++) {
 			if ($recipes[$i]->{'name'} eq 'TRAP') {
 				$trap = $recipes[$i];
@@ -121,7 +121,7 @@ if (!$gotvirt) {
 # Create the lookup-domain.pl wrapper script, and hack it to turn off setuid
 &cron::create_wrapper($domain_lookup_cmd, $module_name,
 		      "lookup-domain.pl");
-local $lref = &read_file_lines($domain_lookup_cmd);
+my $lref = &read_file_lines($domain_lookup_cmd);
 splice(@$lref, 1, 0, "delete(\$ENV{'IFS'});",
 		     "delete(\$ENV{'CDPATH'});",
 		     "delete(\$ENV{'ENV'});",
@@ -132,18 +132,18 @@ splice(@$lref, 1, 0, "delete(\$ENV{'IFS'});",
 &flush_file_lines($domain_lookup_cmd);
 
 # Build spamassassin command to call
-local $cmd = &spamassassin_client_command($d);
+my $cmd = &spamassassin_client_command($d);
 
 # Create recipes to call spamassassin
-local $spamrc = "$procmail_spam_dir/$d->{'id'}";
-local $recipe0 = { 'name' => 'DROPPRIVS',	# Run all commands as user
+my $spamrc = "$procmail_spam_dir/$d->{'id'}";
+my $recipe0 = { 'name' => 'DROPPRIVS',	# Run all commands as user
 		   'value' => 'yes' };
-local @conds;
+my @conds;
 if ($cmd =~ /spamassassin/ && $config{'spam_size'}) {
 	# Add condition for max message size
 	push(@conds, [ '<', $config{'spam_size'} ]);
 	}
-local $recipe1 = { 'flags' => [ 'f', 'w' ],	# Call spamassassin
+my $recipe1 = { 'flags' => [ 'f', 'w' ],	# Call spamassassin
 		   'conds' => \@conds,
 		   'type' => '|',
 		   'action' => $cmd,
@@ -152,13 +152,13 @@ if ($config{'spam_lock'}) {
 	# Add locking to prevent concurrent runs
 	$recipe1->{'lockfile'} = $spamassassin_lock_file;
 	}
-local ($recipe2, $recipe3);
-local $varon = { 'name' => 'SPAMMODE', 'value' => 1 };
+my ($recipe2, $recipe3);
+my $varon = { 'name' => 'SPAMMODE', 'value' => 1 };
 if ($config{'spam_level'}) {
 	# Recipe to delete high-score spam
 	my $level = $config{'spam_level'};
 	$level = 50 if ($level > 50);
-	local $stars = join("", map { "\\*" } (1..$level));
+	my $stars = join("", map { "\\*" } (1..$level));
 	$recipe3 = { 'flags' => [ ],
 		     'conds' => [ [ '', '^X-Spam-Level: '.$stars ] ],
 		     'action' => '/dev/null' };
@@ -169,7 +169,7 @@ if ($config{'spam_delivery'}) {
 		     'conds' => [ [ '', '^X-Spam-Status: Yes' ] ],
 		     'action' => $config{'spam_delivery'} };
 	}
-local $varoff = { 'name' => 'SPAMMODE', 'value' => 0 };
+my $varoff = { 'name' => 'SPAMMODE', 'value' => 0 };
 &procmail::create_recipe($recipe0, $spamrc);
 &procmail::create_recipe($recipe1, $spamrc);
 if ($recipe2 || $recipe3) {
@@ -234,7 +234,7 @@ my $spamid = $d->{'parent'} || $d->{'id'};
 $client ||= $config{'spam_client'};
 my $cmd = &has_command($client);
 if ($client eq 'spamc') {
-	local ($host, $port) = split(/:/, $config{'spam_host'});
+	my ($host, $port) = split(/:/, $config{'spam_host'});
 	if ($host) {
 		$cmd .= " -d $host";
 		if ($port) {
@@ -278,7 +278,7 @@ sub setup_default_delivery
 {
 &require_spam();
 &obtain_lock_spam();
-local @recipes = &procmail::get_procmailrc();
+my @recipes = &procmail::get_procmailrc();
 my ($gotdef, $gotorgmail, $gotdel, $gotdrop);
 foreach my $r (@recipes) {
 	if ($r->{'action'} eq '$DEFAULT' && !@{$r->{'conds'}}) {
@@ -310,8 +310,8 @@ foreach my $r (@recipes) {
 
 # The DEFAULT destination needs to be set to match the mail server, as procmail
 # will deliver to /var/mail/USER by default
-local ($dir, $style, $mailbox, $maildir) = &get_mail_style();
-local $maildef = $dir && $dir =~ /^(.*)\/$/ ? "$1/\$LOGNAME/" :
+my ($dir, $style, $mailbox, $maildir) = &get_mail_style();
+my $maildef = $dir && $dir =~ /^(.*)\/$/ ? "$1/\$LOGNAME/" :
 	         $dir ? "$dir/\$LOGNAME" :
 		 $maildir ? "\$HOME/$maildir/" :
 		 $mailbox ? "\$HOME/$mailbox" :
@@ -399,8 +399,8 @@ sub enable_procmail_logging
 {
 &require_spam();
 &obtain_lock_spam();
-local @recipes = &procmail::get_procmailrc();
-local ($gotlog, $gottrap);
+my @recipes = &procmail::get_procmailrc();
+my ($gotlog, $gottrap);
 foreach my $r (@recipes) {
 	if ($r->{'name'} eq 'LOGFILE') {
 		$gotlog = 1;
@@ -428,10 +428,10 @@ if (!$gottrap) {
 foreach my $d (&list_domains()) {
 	next if (!$d->{'spam'});
 	&obtain_lock_spam($d);
-	local $spamrc = "$procmail_spam_dir/$d->{'id'}";
-	local @recipes = &procmail::parse_procmail_file($spamrc);
-	local ($spamrec, $spamrecafter, $gotspammode);
-	local $i = 0;
+	my $spamrc = "$procmail_spam_dir/$d->{'id'}";
+	my @recipes = &procmail::parse_procmail_file($spamrc);
+	my ($spamrec, $spamrecafter, $gotspammode);
+	my $i = 0;
 	foreach my $r (@recipes) {
 		if ($r->{'name'} eq 'SPAMMODE') {
 			$gotspammode = 1;
@@ -445,8 +445,8 @@ foreach my $d (&list_domains()) {
 		$i++;
 		}
 	if ($spamrec && !$gotspammode) {
-		local $varon = { 'name' => 'SPAMMODE', 'value' => 1 };
-		local $varoff = { 'name' => 'SPAMMODE', 'value' => 0 };
+		my $varon = { 'name' => 'SPAMMODE', 'value' => 1 };
+		my $varoff = { 'name' => 'SPAMMODE', 'value' => 0 };
 		if ($spamrecafter) {
 			&procmail::create_recipe_before($varoff, $spamrecafter,
 							$spamrc);
@@ -459,9 +459,9 @@ foreach my $d (&list_domains()) {
 
 	# Do the same for viruses
 	if ($d->{'virus'}) {
-		local @recipes = &procmail::parse_procmail_file($spamrc);
-		local ($clamrec, $clamafter, $gotclammode);
-		local $i = 0;
+		my @recipes = &procmail::parse_procmail_file($spamrc);
+		my ($clamrec, $clamafter, $gotclammode);
+		my $i = 0;
 		foreach my $r (@recipes) {
 			if ($r->{'name'} eq 'VIRUSMODE') {
 				$gotclammode = 1;
@@ -474,8 +474,8 @@ foreach my $d (&list_domains()) {
 			$i++;
 			}
 		if ($clamrec && !$gotclammode) {
-			local $varon = { 'name' => 'VIRUSMODE', 'value' => 1 };
-			local $varoff = { 'name' => 'VIRUSMODE', 'value' => 0 };
+			my $varon = { 'name' => 'VIRUSMODE', 'value' => 1 };
+			my $varoff = { 'name' => 'VIRUSMODE', 'value' => 0 };
 			if ($clamrecafter) {
 				&procmail::create_recipe_before(
 					$varoff, $clamrecafter, $spamrc);
@@ -498,10 +498,10 @@ foreach my $d (&list_domains()) {
 if ($config{'logrotate'} && &foreign_installed("logrotate")) {
 	# Add logrotate section, if needed
 	&require_logrotate();
-	local $log = &get_logrotate_section($procmail_log_file);
+	my $log = &get_logrotate_section($procmail_log_file);
 	if (!$log) {
-		local $parent = &logrotate::get_config_parent();
-		local $lconf = { 'file' => &logrotate::get_add_file(),
+		my $parent = &logrotate::get_config_parent();
+		my $lconf = { 'file' => &logrotate::get_add_file(),
 				 'name' => [ $procmail_log_file ] };
 		$lconf->{'members'} = [
 				{ 'name' => 'rotate',
@@ -528,7 +528,7 @@ if ($config{'logrotate'} && &foreign_installed("logrotate")) {
 sub procmail_logging_enabled
 {
 &require_spam();
-local @recipes = &procmail::get_procmailrc();
+my @recipes = &procmail::get_procmailrc();
 foreach my $r (@recipes) {
 	if ($r->{'name'} eq 'LOGFILE') {
 		return 1;
@@ -553,9 +553,9 @@ my ($d) = @_;
 &$first_print($d->{'virus'} ? $text{'delete_spamvirus'}
 			    : $text{'delete_spam'});
 &obtain_lock_spam($d);
-local $spamrc = "$procmail_spam_dir/$d->{'id'}";
+my $spamrc = "$procmail_spam_dir/$d->{'id'}";
 &unlink_logged($spamrc);
-local $spamdir = "$spam_config_dir/$d->{'id'}";
+my $spamdir = "$spam_config_dir/$d->{'id'}";
 &system_logged("rm -rf ".quotemeta($spamdir));
 &clear_lookup_domain_cache($d);
 &save_domain_spam_autoclear($d, undef);
@@ -569,27 +569,27 @@ return 1;
 # correcting the domain ID
 sub clone_spam
 {
-local ($d, $oldd) = @_;
+my ($d, $oldd) = @_;
 &$first_print($text{'clone_spam'});
 &obtain_lock_spam($d);
-local $pm = "$procmail_spam_dir/$d->{'id'}";
-local $opm = "$procmail_spam_dir/$oldd->{'id'}";
+my $pm = "$procmail_spam_dir/$d->{'id'}";
+my $opm = "$procmail_spam_dir/$oldd->{'id'}";
 &copy_source_dest($opm, $pm);
-local $lref = &read_file_lines($pm);
+my $lref = &read_file_lines($pm);
 foreach my $l (@$lref) {
 	$l =~ s/\Q$oldd->{'id'}\E/$d->{'id'}/;
 	}
 &flush_file_lines($pm);
-local $spamdir = "$spam_config_dir/$d->{'id'}";
-local $ospamdir = "$spam_config_dir/$oldd->{'id'}";
+my $spamdir = "$spam_config_dir/$d->{'id'}";
+my $ospamdir = "$spam_config_dir/$oldd->{'id'}";
 &system_logged("rm -rf ".quotemeta($spamdir)."/*");
 &system_logged("cd ".quotemeta($ospamdir)." && tar cf - . | ".
 	       "(cd $spamdir && tar xpf -)");
 
 # Fix email addresses in per-domain spamassassin config file
-local $spamfile = "$spamdir/virtualmin.cf";
+my $spamfile = "$spamdir/virtualmin.cf";
 &set_ownership_permissions($d->{'uid'}, $d->{'gid'}, undef, $spamfile);
-local $lref = &read_file_lines($spamfile);
+my $lref = &read_file_lines($spamfile);
 foreach my $l (@$lref) {
 	if ($l =~ /^whitelist_from\s+\Q$oldd->{'emailto_addr'}\E/) {
 		$l = "whitelist_from $d->{'emailto_addr'}";
@@ -622,21 +622,21 @@ return 0;
 # Also saves the auto-spam clearing settings.
 sub backup_spam
 {
-local ($d, $file, $opts, $homefmt, $increment, $asd, $allopts, $key) = @_;
-local $compression = $allopts->{'dir'}->{'compression'};
+my ($d, $file, $opts, $homefmt, $increment, $asd, $allopts, $key) = @_;
+my $compression = $allopts->{'dir'}->{'compression'};
 &$first_print($text{'backup_spamcp'});
-local $spamrc = "$procmail_spam_dir/$d->{'id'}";
-local $spamdir = "$spam_config_dir/$d->{'id'}";
+my $spamrc = "$procmail_spam_dir/$d->{'id'}";
+my $spamdir = "$spam_config_dir/$d->{'id'}";
 if (-r $spamrc) {
 	&copy_write_as_domain_user($d, $spamrc, $file);
-	local $temp = &transname();
+	my $temp = &transname();
 	&execute_command(&make_archive_command(
 		$compression, $spamdir, $temp, ".")." 2>&1");
 	&copy_write_as_domain_user($d, $temp, $file."_cf");
 	&unlink_file($temp);
 
 	# Save spam clearing
-	local $auto = &get_domain_spam_autoclear($_[0]);
+	my $auto = &get_domain_spam_autoclear($_[0]);
 	&write_as_domain_user($d,
 		sub { &write_file($file."_auto", $auto || { }) });
 	&$second_print($text{'setup_done'});
@@ -653,11 +653,11 @@ else {
 # Also restores auto-clearing setting, if in backup.
 sub restore_spam
 {
-local ($d, $file) = @_;
+my ($d, $file) = @_;
 &$first_print($text{'restore_spamcp'});
 &obtain_lock_spam($d);
-local $spamrc = "$procmail_spam_dir/$d->{'id'}";
-local $spamdir = "$spam_config_dir/$d->{'id'}";
+my $spamrc = "$procmail_spam_dir/$d->{'id'}";
+my $spamdir = "$spam_config_dir/$d->{'id'}";
 &copy_source_dest($file, $spamrc);
 &execute_command(&make_unarchive_command($spamdir, $file."_cf")." 2>&1");
 
@@ -676,7 +676,7 @@ foreach my $l (@$lref) {
 if (-r $file."_auto") {
 	# Replace auto-clearing setting
 	&save_domain_spam_autoclear($d, undef);
-	local %auto;
+	my %auto;
 	&read_file($file."_auto", \%auto);
 	if (%auto) {
 		&save_domain_spam_autoclear($d, \%auto);
@@ -684,7 +684,7 @@ if (-r $file."_auto") {
 	}
 
 # If spamtrap aliases exist, make sure the files and cron job do
-local $st = &get_spamtrap_aliases($d);
+my $st = &get_spamtrap_aliases($d);
 if ($st > 0) {
 	&setup_spamtrap_directories($d);
 	&setup_spamtrap_cron();
@@ -702,11 +702,11 @@ return 1;
 # Adds or removes a lockfile to all domains' spamassassin calls
 sub save_global_spam_lockfile
 {
-local ($enabled) = @_;
+my ($enabled) = @_;
 foreach my $d (&get_domain_by("spam", 1)) {
-	local $spamrc = "$procmail_spam_dir/$d->{'id'}";
-	local @recipes = &procmail::parse_procmail_file($spamrc);
-	local @spamrec = &find_spam_recipe(\@recipes);
+	my $spamrc = "$procmail_spam_dir/$d->{'id'}";
+	my @recipes = &procmail::parse_procmail_file($spamrc);
+	my @spamrec = &find_spam_recipe(\@recipes);
 	if ($spamrec[0]) {
 		# Found it .. modify
 		if ($enabled) {
@@ -725,14 +725,14 @@ foreach my $d (&get_domain_by("spam", 1)) {
 sub sysinfo_spam
 {
 &require_spam();
-local $vers = &spam::get_spamassassin_version();
+my $vers = &spam::get_spamassassin_version();
 return ( [ $text{'sysinfo_spam'}, $vers ] );
 }
 
 sub links_spam
 {
-local ($d) = @_;
-local $client = &get_domain_spam_client($d);
+my ($d) = @_;
+my $client = &get_domain_spam_client($d);
 if ($client ne "spamc") {
 	return ( { 'mod' => 'spam',
 		   'desc' => $text{'links_spam'},
@@ -755,8 +755,8 @@ return ( );
 # 4 - Setting of SPAMMODE=0
 sub find_spam_recipe
 {
-local ($recs) = @_;
-local @rv;
+my ($recs) = @_;
+my @rv;
 for(my $i=0; $i<@$recs; $i++) {
 	if ($recs->[$i]->{'action'} =~ /(spamassassin|spamc)($|\s)/) {
 		# Found spamassassin
@@ -798,12 +798,12 @@ return @rv;
 # /dev/null)
 sub get_domain_spam_delivery
 {
-local ($d) = @_;
+my ($d) = @_;
 &require_spam();
-local $spamrc = "$procmail_spam_dir/$d->{'id'}";
-local @recipes = &procmail::parse_procmail_file($spamrc);
-local @spamrec = &find_spam_recipe(\@recipes);
-local @rv;
+my $spamrc = "$procmail_spam_dir/$d->{'id'}";
+my @recipes = &procmail::parse_procmail_file($spamrc);
+my @spamrec = &find_spam_recipe(\@recipes);
+my @rv;
 if (!@spamrec) {
 	@rv = (-1, undef);
 	}
@@ -846,15 +846,15 @@ return @rv;
 # Updates the delivery method for spam for some domain
 sub save_domain_spam_delivery
 {
-local ($d, $mode, $dest, $level, $ddest) = @_;
+my ($d, $mode, $dest, $level, $ddest) = @_;
 &require_spam();
-local $spamrc = "$procmail_spam_dir/$d->{'id'}";
-local @recipes = &procmail::parse_procmail_file($spamrc);
-local @spamrec = &find_spam_recipe(\@recipes);
+my $spamrc = "$procmail_spam_dir/$d->{'id'}";
+my @recipes = &procmail::parse_procmail_file($spamrc);
+my @spamrec = &find_spam_recipe(\@recipes);
 return 0 if (!@spamrec);
 
 # Preserve existing settings if not set
-local ($oldmode, $olddest, $oldlevel, $oldddest) =
+my ($oldmode, $olddest, $oldlevel, $oldddest) =
 	&get_domain_spam_delivery($d);
 if (!defined($mode)) {
 	($mode, $dest) = ($oldmode, $olddest);
@@ -871,7 +871,7 @@ if (!defined($ddest)) {
 $ddest ||= "/dev/null";
 
 # Remove the existing recipes (except the spamassassin call)
-local @todel = sort { $b->{'line'} <=> $a->{'line'} }
+my @todel = sort { $b->{'line'} <=> $a->{'line'} }
 		    grep { $_ } @spamrec[1..$#spamrec];
 foreach my $r (@todel) {
 	&procmail::delete_recipe($r);
@@ -881,20 +881,20 @@ foreach my $r (@todel) {
 $level = 50 if (defined($level) && $level > 50);
 
 # Make those we now want
-local @want;
+my @want;
 if ($mode != 5 || $level) {
 	# Start of delivery section
 	push(@want, { 'name' => 'SPAMMODE', 'value' => 1 });
 	}
 if ($level) {
 	# High-level deletion
-	local $stars = join("", map { "\\*" } (1..$level));
+	my $stars = join("", map { "\\*" } (1..$level));
 	push(@want, { 'conds' => [ [ '', '^X-Spam-Level: '.$stars ] ],
 		      'action' => $ddest });
 	}
 if ($mode != 5) {
 	# Regular delivery
-	local $folder;
+	my $folder;
 	if ($mode == 4 || $mode == 6) {
 		if ($dest =~ /^[a-z0-9\.\_\-]+$/i) {
 			$folder = $dest;
@@ -903,12 +903,12 @@ if ($mode != 5) {
 			$folder = &default_spam_folder_suffix($d);
 			}
 		}
-	local $action = $mode == 0 ? "/dev/null" :
+	my $action = $mode == 0 ? "/dev/null" :
 			$mode == 4 ? "\$HOME/mail/$folder" :
 			$mode == 6 ? "\$HOME/Maildir/.$folder/" :
 			$mode == 1 ? "\$HOME/$dest" :
 				      $dest;
-	local $type = $mode == 2 ? "!" : "";
+	my $type = $mode == 2 ? "!" : "";
 	push(@want, { 'conds' => [ [ '', '^X-Spam-Status: Yes' ] ],
 		      'action' => $action,
 		      'type' => $type });
@@ -922,7 +922,7 @@ if ($mode != 5 || $level) {
 if (@want) {
 	@recipes = &procmail::parse_procmail_file($spamrc);
 	@spamrec = &find_spam_recipe(\@recipes);
-	local $idx = &indexof($spamrec[0], @recipes);
+	my $idx = &indexof($spamrec[0], @recipes);
 	if ($idx == $#recipes) {
 		# Add at end
 		foreach my $r (@want) {
@@ -959,10 +959,10 @@ return "Junk";
 # Returns the client program (spamassassin or spamc) used by some domain
 sub get_domain_spam_client
 {
-local ($d) = @_;
+my ($d) = @_;
 &require_spam();
-local $spamrc = "$procmail_spam_dir/$d->{'id'}";
-local @recipes = &procmail::parse_procmail_file($spamrc);
+my $spamrc = "$procmail_spam_dir/$d->{'id'}";
+my @recipes = &procmail::parse_procmail_file($spamrc);
 foreach my $r (@recipes) {
 	if ($r->{'action'} =~ /\/\S+\/(spamassassin|spamc)/) {
 		return $1;
@@ -975,14 +975,14 @@ return undef;	# Cannot happen!
 # Updates the procmail rule which calls spamassassin or spamc
 sub save_domain_spam_client
 {
-local ($d, $client) = @_;
+my ($d, $client) = @_;
 &require_spam();
-local $spamrc = "$procmail_spam_dir/$d->{'id'}";
-local @recipes = &procmail::parse_procmail_file($spamrc);
+my $spamrc = "$procmail_spam_dir/$d->{'id'}";
+my @recipes = &procmail::parse_procmail_file($spamrc);
 foreach my $r (@recipes) {
 	if ($r->{'action'} =~ /\/\S+\/(spamassassin|spamc)/) {
 		$r->{'action'} = &spamassassin_client_command($d, $client);
-		local ($c) = grep { $_->[0] eq '<' } @{$r->{'conds'}};
+		my ($c) = grep { $_->[0] eq '<' } @{$r->{'conds'}};
 		if ($c && !$config{'spam_size'}) {
 			# Remove size condition
 			@{$r->{'conds'}} = grep { $_ ne $c } @{$r->{'conds'}};
@@ -1005,16 +1005,16 @@ foreach my $r (@recipes) {
 # is spamc, also returns the spamd hostname and max message size
 sub get_global_spam_client
 {
-local ($client, $host, $size);
+my ($client, $host, $size);
 if ($config{'spam_client_global'}) {
 	# We know the global setting for sure
 	$client = $config{'spam_client'};
 	}
 else {
 	# Find the most used one for all domains
-	local (%cmdcount, $maxcmd);
+	my (%cmdcount, $maxcmd);
 	foreach my $d (grep { $_->{'spam'} } &list_domains()) {
-		local $cmd = &get_domain_spam_client($d);
+		my $cmd = &get_domain_spam_client($d);
 		if ($cmd) {
 			$cmdcount{$cmd}++;
 			if (!$maxcmd || $cmdcount{$cmd} > $cmdcount{$maxcmd}) {
@@ -1033,7 +1033,7 @@ return wantarray ? ( $client, $host, $size ) : $client;
 # Updates all domains with a new SpamAssassin client program
 sub save_global_spam_client
 {
-local ($client, $host, $size) = @_;
+my ($client, $host, $size) = @_;
 $config{'spam_client'} = $client;
 $config{'spam_client_global'} = 1;
 $config{'spam_host'} = $host;
@@ -1049,7 +1049,7 @@ foreach my $d (grep { $_->{'spam'} } &list_domains()) {
 sub get_global_quota_exitcode
 {
 &require_spam();
-local @recipes = &procmail::get_procmailrc();
+my @recipes = &procmail::get_procmailrc();
 foreach my $r (@recipes) {
 	if ($r->{'action'} =~ /\Q$domain_lookup_cmd\E.*\s+\-\-exitcode\s+(\d+)/) {
 		return $1;
@@ -1062,11 +1062,11 @@ return 73;
 # Updates the exit code from lookup-domain when a user is close to or over quota
 sub save_global_quota_exitcode
 {
-local ($code) = @_;
+my ($code) = @_;
 &require_spam();
 &lock_file($procmail::procmailrc);
-local @recipes = &procmail::get_procmailrc();
-local $changed = 0;
+my @recipes = &procmail::get_procmailrc();
+my $changed = 0;
 foreach my $r (@recipes) {
 	if ($r->{'action'} =~ /\Q$domain_lookup_cmd\E(.*?)\s+\$LOGNAME/) {
 		# Fix call to lookup-domain to return correct exit code
@@ -1127,13 +1127,13 @@ $config{'lookup_domain_port'} = $port;
 # configuration, and removes any whitelists that don't correspond to users.
 sub update_spam_whitelist
 {
-local ($d) = @_;
+my ($d) = @_;
 return if (!$d->{'spam'} || !$d->{'spam_white'});
 &require_spam();
-local $spamfile = "$spam_config_dir/$d->{'id'}/virtualmin.cf";
-local $conf = &spam::get_config($spamfile);
-local @whites = &spam::find_value("whitelist_from", $conf);
-local @oldwhites = @whites;
+my $spamfile = "$spam_config_dir/$d->{'id'}/virtualmin.cf";
+my $conf = &spam::get_config($spamfile);
+my @whites = &spam::find_value("whitelist_from", $conf);
+my @oldwhites = @whites;
 @whites = grep { !/\@$d->{'dom'}$/ } @whites;
 foreach my $user (&list_domain_users($d, 0, 1, 1, 1)) {
 	push(@whites, &remove_userdom($user->{'user'}, $d)."\@".$d->{'dom'});
@@ -1151,12 +1151,12 @@ if (join(" ", @whites) ne join(" ", @oldwhites)) {
 # Outputs HTML for editing spamassassin related template options
 sub show_template_spam
 {
-local ($tmpl) = @_;
+my ($tmpl) = @_;
 
 # Default spam clearing mode
-local ($cmode, $cnum) = split(/\s+/, $tmpl->{'spamclear'});
-local $cdays = $cmode eq 'days' ? $cnum : undef;
-local $csize = $cmode eq 'size' ? $cnum : undef;
+my ($cmode, $cnum) = split(/\s+/, $tmpl->{'spamclear'});
+my $cdays = $cmode eq 'days' ? $cnum : undef;
+my $csize = $cmode eq 'size' ? $cnum : undef;
 print &ui_table_row(&hlink($text{'tmpl_spamclear'}, 'template_spamclear'),
 	    &ui_radio("spamclear", $cmode,
 	        [ $tmpl->{'default'} ? ( )
@@ -1169,9 +1169,9 @@ print &ui_table_row(&hlink($text{'tmpl_spamclear'}, 'template_spamclear'),
 		]));
 
 # Default trash clearing mode
-local ($cmode, $cnum) = split(/\s+/, $tmpl->{'trashclear'});
-local $cdays = $cmode eq 'days' ? $cnum : undef;
-local $csize = $cmode eq 'size' ? $cnum : undef;
+my ($cmode, $cnum) = split(/\s+/, $tmpl->{'trashclear'});
+my $cdays = $cmode eq 'days' ? $cnum : undef;
+my $csize = $cmode eq 'size' ? $cnum : undef;
 print &ui_table_row(&hlink($text{'tmpl_trashclear'}, 'template_trashclear'),
 	    &ui_radio("trashclear", $cmode,
 	        [ $tmpl->{'default'} ? ( )
@@ -1196,7 +1196,7 @@ print &ui_table_row(&hlink($text{'tmpl_spamtrap'}, 'template_spamtrap'),
 # Updates spamassassin related template options from %in
 sub parse_template_spam
 {
-local ($tmpl) = @_;
+my ($tmpl) = @_;
 
 # Parse spam clearing option
 if ($in{'spamclear'} eq '') {
@@ -1244,11 +1244,11 @@ $tmpl->{'spamtrap'} = $in{'spamtrap'};
 # Removes entries from the lookup-domain cache for a user all users in a domain
 sub clear_lookup_domain_cache
 {
-local ($d, $user) = @_;
+my ($d, $user) = @_;
 
 # Open the cache DBM
-local $cachefile = "$ENV{'WEBMIN_VAR'}/lookup-domain-cache";
-local %cache;
+my $cachefile = "$ENV{'WEBMIN_VAR'}/lookup-domain-cache";
+my %cache;
 eval "use SDBM_File";
 dbmopen(%cache, $cachefile, 0700);
 eval "\$cache{'1111111111'} = 1";
@@ -1274,12 +1274,12 @@ else {
 # Returns an object containing spam clearing info for this domain, if defined
 sub get_domain_spam_autoclear
 {
-local ($d) = @_;
-local %spamclear;
+my ($d) = @_;
+my %spamclear;
 &read_file_cached($spamclear_file, \%spamclear);
-local $ds = $spamclear{$d->{'id'}};
+my $ds = $spamclear{$d->{'id'}};
 return undef if (!$ds);
-local %auto = map { split(/=/, $_, 2) } split(/\s+/, $ds);
+my %auto = map { split(/=/, $_, 2) } split(/\s+/, $ds);
 return \%auto;
 }
 
@@ -1288,10 +1288,10 @@ return \%auto;
 # cron job if needed
 sub save_domain_spam_autoclear
 {
-local ($d, $auto) = @_;
+my ($d, $auto) = @_;
 
 # Update config file
-local %spamclear;
+my %spamclear;
 &read_file_cached($spamclear_file, \%spamclear);
 if ($auto) {
 	$spamclear{$d->{'id'}} = join(" ", map { $_."=".$auto->{$_} }
@@ -1309,10 +1309,10 @@ else {
 # spam clearing is enabled for any domain
 sub setup_spamclear_cron_job
 {
-local $job = &find_cron_script($spamclear_cmd);
-local %spamclear;
+my $job = &find_cron_script($spamclear_cmd);
+my %spamclear;
 &read_file_cached($spamclear_file, \%spamclear);
-local $want = %spamclear || $config{'retention_policy'};
+my $want = %spamclear || $config{'retention_policy'};
 if ($job && !$want) {
 	# Disable job, as we don't need it
 	&delete_cron_script($job);
@@ -1336,8 +1336,8 @@ elsif (!$job && $want) {
 # spam directory.
 sub create_spam_config_links
 {
-local ($d) = @_;
-local $defdir;
+my ($d) = @_;
+my $defdir;
 &require_spam();
 if (-d $spam::config{'local_cf'}) {
 	$defdir = $spam::config{'local_cf'};
@@ -1345,14 +1345,14 @@ if (-d $spam::config{'local_cf'}) {
 elsif ($spam::config{'local_cf'} =~ /^(.*)\//) {
 	$defdir = $1;
 	}
-local $spamdir = "$spam_config_dir/$d->{'id'}";
+my $spamdir = "$spam_config_dir/$d->{'id'}";
 if ($defdir) {
 	# Remove any old links
 	opendir(DIR, $spamdir);
 	foreach my $f (readdir(DIR)) {
-		local $p = "$spamdir/$f";
+		my $p = "$spamdir/$f";
 		if ($f ne "." && $f ne "..") {
-			local $lnk = readlink($p);
+			my $lnk = readlink($p);
 			if ($lnk && !-e $lnk) {
 				unlink($p);
 				}
@@ -1376,7 +1376,7 @@ if ($defdir) {
 # files in /tmp
 sub setup_spam_config_job
 {
-local $job = &find_cron_script($spamconfig_cron_cmd);
+my $job = &find_cron_script($spamconfig_cron_cmd);
 if (!$job) {
 	# Create, and run for the first time
 	$job = { 'mins' => int(rand()*60),
@@ -1402,10 +1402,10 @@ foreach my $d (grep { $_->{'spam'} } &list_domains()) {
 sub setup_lookup_domain_daemon
 {
 &foreign_require("init");
-local $pidfile = "$ENV{'WEBMIN_VAR'}/lookup-domain-daemon.pid";
-local $helper = &get_api_helper_command();
-local $killcmd = &has_command('kill');
-local $testcmd = &has_command('test');
+my $pidfile = "$ENV{'WEBMIN_VAR'}/lookup-domain-daemon.pid";
+my $helper = &get_api_helper_command();
+my $killcmd = &has_command('kill');
+my $testcmd = &has_command('test');
 if (!&init::action_status("lookup-domain")) {
 	# Need to create and start the action
 	&init::enable_at_boot(
@@ -1433,9 +1433,9 @@ sub delete_lookup_domain_daemon
 {
 &foreign_require("init");
 &init::disable_at_boot("lookup-domain");
-local $pidfile = "$ENV{'WEBMIN_VAR'}/lookup-domain-daemon.pid";
+my $pidfile = "$ENV{'WEBMIN_VAR'}/lookup-domain-daemon.pid";
 &init::stop_action("lookup-domain");
-local $pid = &check_pid_file($pidfile);
+my $pid = &check_pid_file($pidfile);
 if ($pid) {
 	kill('TERM', $pid);
 	}
@@ -1453,7 +1453,7 @@ return &init::action_status("lookup-domain") == 2 ? 1 : 0;
 # Returns the full email address for the spam alias, like spamtrap@foo.com
 sub spam_alias_name
 {
-local ($d) = @_;
+my ($d) = @_;
 return 'spamtrap'.'@'.$d->{'dom'};
 }
 
@@ -1461,7 +1461,7 @@ return 'spamtrap'.'@'.$d->{'dom'};
 # Returns the full email address for the ham alias, like hamtrap@foo.com
 sub ham_alias_name
 {
-local ($d) = @_;
+my ($d) = @_;
 return 'hamtrap'.'@'.$d->{'dom'};
 }
 
@@ -1469,7 +1469,7 @@ return 'hamtrap'.'@'.$d->{'dom'};
 # Returns the file in which spam is stored for some domain
 sub spam_alias_file
 {
-local ($d) = @_;
+my ($d) = @_;
 return $spam_alias_dir."/".$d->{'id'};
 }
 
@@ -1477,7 +1477,7 @@ return $spam_alias_dir."/".$d->{'id'};
 # Returns the file in which ham is stored for some domain
 sub ham_alias_file
 {
-local ($d) = @_;
+my ($d) = @_;
 return $ham_alias_dir."/".$d->{'id'};
 }
 
@@ -1487,8 +1487,8 @@ return $ham_alias_dir."/".$d->{'id'};
 # ham aliases too.
 sub get_spamtrap_aliases
 {
-local ($d) = @_;
-local (%got, $clash);
+my ($d) = @_;
+my (%got, $clash);
 foreach my $a (&list_domain_aliases($d)) {
 	if ($a->{'from'} eq &spam_alias_name($d)) {
 		# Spam alias .. make sure it goes to the right file
@@ -1511,7 +1511,7 @@ foreach my $a (&list_domain_aliases($d)) {
 			}
 		}
 	}
-local $rv = $clash ? -1 : $got{'spam'} && $got{'ham'} ? 1 : 0;
+my $rv = $clash ? -1 : $got{'spam'} && $got{'ham'} ? 1 : 0;
 return wantarray ? ($rv, $got{'spam'}, $got{'ham'}) : $rv;
 }
 
@@ -1521,10 +1521,10 @@ return wantarray ? ($rv, $got{'spam'}, $got{'ham'}) : $rv;
 # on failure.
 sub setup_spamtrap_aliases
 {
-local ($d) = @_;
+my ($d) = @_;
 
 # Check for aliases already
-local ($ok, $spama, $hama) = &get_spamtrap_aliases($d);
+my ($ok, $spama, $hama) = &get_spamtrap_aliases($d);
 if ($ok == 1) {
 	return $text{'spamtrap_already'};
 	}
@@ -1538,8 +1538,8 @@ elsif ($ok < 0) {
 &setup_spamtrap_directories($d);
 
 # Create aliases
-local $spamfile = &spam_alias_file($d);
-local $hamfile = &ham_alias_file($d);
+my $spamfile = &spam_alias_file($d);
+my $hamfile = &ham_alias_file($d);
 $spama = { 'from' => &spam_alias_name($d), 'to' => [ $spamfile ] };
 $hama = { 'from' => &ham_alias_name($d), 'to' => [ $hamfile ] };
 &create_virtuser($spama);
@@ -1554,12 +1554,12 @@ return undef;
 # Create the spamtrap directories and mail files for a domain
 sub setup_spamtrap_directories
 {
-local ($d) = @_;
+my ($d) = @_;
 &make_dir($trap_base_dir, 0755) if (!-d $trap_base_dir);
 &make_dir($spam_alias_dir, 01777) if (!-d $spam_alias_dir);
 &make_dir($ham_alias_dir, 01777) if (!-d $ham_alias_dir);
-local $spamfile = &spam_alias_file($d);
-local $hamfile = &ham_alias_file($d);
+my $spamfile = &spam_alias_file($d);
+my $hamfile = &ham_alias_file($d);
 foreach my $f ($spamfile, $hamfile) {
 	if (!-r $f) {
 		&open_tempfile(SPAMFILE, ">$f", 0, 1);
@@ -1574,7 +1574,7 @@ foreach my $f ($spamfile, $hamfile) {
 sub setup_spamtrap_cron
 {
 &foreign_require("cron");
-local $job = &find_cron_script($spamtrap_cron_cmd);
+my $job = &find_cron_script($spamtrap_cron_cmd);
 if (!$job) {
 	$job = { 'user' => 'root',
 		 'command' => $spamtrap_cron_cmd,
@@ -1592,10 +1592,10 @@ if (!$job) {
 # Remove the spamtrap and hamtrap aliases for a domain, and any mail files
 sub delete_spamtrap_aliases
 {
-local ($d) = @_;
+my ($d) = @_;
 
 # Get the aliases, and remove them
-local ($ok, $spama, $hama) = &get_spamtrap_aliases($d);
+my ($ok, $spama, $hama) = &get_spamtrap_aliases($d);
 if ($ok == 1) {
 	&delete_virtuser($spama);
 	&delete_virtuser($hama);
@@ -1605,8 +1605,8 @@ else {
 	}
 
 # Delete the mail files
-local $spamfile = &spam_alias_file($d);
-local $hamfile = &ham_alias_file($d);
+my $spamfile = &spam_alias_file($d);
+my $hamfile = &ham_alias_file($d);
 &unlink_file($spamfile);
 &unlink_file($hamfile);
 
@@ -1618,12 +1618,12 @@ return undef;
 # 1 if yes, or -1 if we can't tell (due to a non-supported OS).
 sub check_spamd_status
 {
-local @pids = grep { $_ != $$ } &find_byname("spamd");
+my @pids = grep { $_ != $$ } &find_byname("spamd");
 if (@pids) {
 	# Running already, so we assume everything is cool
 	return 1;
 	}
-local $spamd = &has_command("spamd") ||
+my $spamd = &has_command("spamd") ||
 	       &has_command("/opt/csw/bin/spamd");
 if (!$spamd) {
 	# Not installed
@@ -1637,12 +1637,12 @@ return 0;	# Can be started
 # standard functions.
 sub enable_spamd
 {
-local $st = &check_spamd_status();
+my $st = &check_spamd_status();
 return 1 if ($st == 1 || $st == -1);
 
 # Find init script
 &foreign_require("init");
-local $init;
+my $init;
 foreach my $i ("spamassassin", "spamd", "sa-spamd") {
 	if (&init::action_status($i)) {
 		$init = $i;
@@ -1653,17 +1653,17 @@ $init ||= "virtualmin-spamassassin";	# Fall back to ours
 
 # Create or enable init script
 &$first_print(&text('spamd_boot'));
-local $spamd = &has_command("spamd") ||
+my $spamd = &has_command("spamd") ||
 	       &has_command("/opt/csw/bin/spamd");
 &init::enable_at_boot($init, "Start SpamAssassin filter server",
 	"spamd --pidfile=/var/run/spamd.pid -d",
 	"kill `cat /var/run/spamd.pid`");
 
 # Update OS-specific config files
-local $dfile = "/etc/default/spamassassin";
+my $dfile = "/etc/default/spamassassin";
 if (-r $dfile) {
 	# Init script won't start on Debian without this flag
-	local %defs;
+	my %defs;
 	&lock_file($dfile);
 	&read_env_file($dfile, \%defs);
 	if (!$defs{'ENABLED'} || !$defs{'CRON'}) {
@@ -1684,7 +1684,7 @@ if (&init::action_status("spamassassin-maintenance.timer")) {
 
 # Start now
 &$first_print($text{'spamd_start'});
-local ($ok, $out) = &init::start_action($init);
+my ($ok, $out) = &init::start_action($init);
 if ($ok) {
 	&$second_print($text{'setup_done'});
 	}
@@ -1701,13 +1701,13 @@ return 1;
 # Turn off spamd now and at boot time
 sub disable_spamd
 {
-local $st = &check_spamd_status();
+my $st = &check_spamd_status();
 return 1 if ($st == 0 || $st == -1);
 
 # Find init script
 &$first_print(&text('spamd_unboot'));
 &foreign_require("init");
-local $init;
+my $init;
 foreach my $i ("spamassassin", "spamd", "sa-spamd", "virtualmin-spamassassin") {
 	if (&init::action_status($i)) {
 		$init = $i;
@@ -1730,7 +1730,7 @@ if (&init::action_status("spamassassin-maintenance.timer")) {
 
 # Stop spamd process
 &$first_print($text{'spamd_stop'});
-local ($ok, $out) = &init::stop_action($init);
+my ($ok, $out) = &init::stop_action($init);
 if (!$ok) {
 	&kill_byname_logged('spamd', 'TERM');
 	}
@@ -1744,7 +1744,7 @@ return 1;
 # if quota if full.
 sub setup_quota_full_bounce
 {
-local @recipes = &procmail::get_procmailrc();
+my @recipes = &procmail::get_procmailrc();
 
 # Find existing VIRTUALMIN= and EXITCODE= recipes
 my ($virt, $exitcode, $virtafter);
@@ -1762,20 +1762,20 @@ foreach my $r (@recipes) {
 return 0 if (!$virt || $exitcode);
 
 # Create new recipe objects
-local $var1 = { 'name' => 'EXITCODE',
+my $var1 = { 'name' => 'EXITCODE',
 		'value' => '$?' };
-local $testcmd = &has_command("test") || "test";
-local $cmd;
+my $testcmd = &has_command("test") || "test";
+my $cmd;
 if ($gconfig{'os_type'} eq 'solaris') {
 	$cmd = "sh -c \"$testcmd '\$EXITCODE' = '73'\"";
 	}
 else {
 	$cmd = "$testcmd \"\$EXITCODE\" = \"73\"";
 	}
-local $var2 = { 'flags' => [ ],
+my $var2 = { 'flags' => [ ],
 		'conds' => [ [ "?", $cmd ] ],
 	        'action' => '/dev/null' };
-local $var3 = { 'name' => 'EXITCODE',
+my $var3 = { 'name' => 'EXITCODE',
                 'value' => '0' };
 
 # Add after the VIRTUALMIN= line
@@ -1789,12 +1789,12 @@ local $var3 = { 'name' => 'EXITCODE',
 # and long descriptions for the action to switch statuses
 sub startstop_spam
 {
-local ($scanner, $host) = &get_global_spam_client();
+my ($scanner, $host) = &get_global_spam_client();
 if ($scanner ne "spamc" || $host) {
 	# Spamd isn't being used
 	return ( );
 	}
-local @pids = grep { $_ != $$ } &find_byname("spamd");
+my @pids = grep { $_ != $$ } &find_byname("spamd");
 if (@pids) {
 	return ( { 'status' => 1,
 		   'name' => $text{'index_spamname'},
@@ -1817,7 +1817,7 @@ sub start_service_spam
 {
 &push_all_print();
 &set_all_null_print();
-local $rv = &enable_spamd();
+my $rv = &enable_spamd();
 &pop_all_print();
 return $rv ? undef : $text{'spamd_estartmsg'};
 }
@@ -1831,11 +1831,11 @@ sub stop_service_spam
 foreach my $init ("spamassassin", "spamd", "sa-spamd",
 	          "virtualmin-spamassassin") {
 	if (&init::action_status($init)) {
-		local ($ok, $out) = &init::stop_action($init);
+		my ($ok, $out) = &init::stop_action($init);
 		return $ok ? undef : "<tt>".&html_escape($out)."</tt>";
 		}
 	}
-local @pids = grep { $_ != $$ } &find_byname("spamd");
+my @pids = grep { $_ != $$ } &find_byname("spamd");
 if (@pids) {
 	if (&kill_logged('TERM', @pids)) {
 		return undef;
@@ -1851,7 +1851,7 @@ else {
 # Lock a domain's spamassassin config file and procmail file
 sub obtain_lock_spam
 {
-local ($d) = @_;
+my ($d) = @_;
 return if (!$config{'spam'});
 &obtain_lock_anything($d);
 
@@ -1879,7 +1879,7 @@ $main::get_lock_spam++;
 # Un-lock a domain's spamassassin config file and procmail file
 sub release_lock_spam
 {
-local ($d) = @_;
+my ($d) = @_;
 return if (!$config{'spam'});
 
 if ($d) {

--- a/feature-ssl.pl
+++ b/feature-ssl.pl
@@ -21,14 +21,14 @@ return undef;
 # the clashing domain's cert can be used for this domain.
 sub check_warnings_ssl
 {
-local ($d, $oldd) = @_;
+my ($d, $oldd) = @_;
 &require_apache();
-local $tmpl = &get_template($d->{'template'});
-local $defport = $tmpl->{'web_sslport'} || 443;
-local $port = $d->{'web_sslport'} || $defport;
+my $tmpl = &get_template($d->{'template'});
+my $defport = $tmpl->{'web_sslport'} || 443;
+my $port = $d->{'web_sslport'} || $defport;
 
 # Check if Apache supports SNI, which makes clashing certs not so bad
-local $sni = &has_sni_support($d);
+my $sni = &has_sni_support($d);
 
 if ($port != $defport) {
 	# Has a private port
@@ -42,13 +42,13 @@ elsif ($sni) {
 else {
 	# Neither .. but we can still do SSL, if there are no other domains
 	# with SSL on the same IPv4 address
-	local ($sslclash) = grep { $_->{'ip'} eq $d->{'ip'} &&
+	my ($sslclash) = grep { $_->{'ip'} eq $d->{'ip'} &&
 				   $_->{'ssl'} &&
 				   $_->{'id'} ne $d->{'id'}} &list_domains();
 	if (!$d->{'virt'} && $sslclash && (!$oldd || !$oldd->{'ssl'})) {
 		# Clash .. but is the cert OK?
 		if (!&check_domain_certificate($d->{'dom'}, $sslclash)) {
-			local @certdoms = &list_domain_certificate($sslclash);
+			my @certdoms = &list_domain_certificate($sslclash);
 			return &text('setup_edepssl5', $d->{'ip'},
 				join(", ", map { "<tt>$_</tt>" } @certdoms),
 				$sslclash->{'dom'});
@@ -60,11 +60,11 @@ else {
 	# Check for <virtualhost> on the IP, if we are turning on SSL
 	if (!$oldd || !$oldd->{'ssl'}) {
 		&require_apache();
-		local $conf = &apache::get_config();
+		my $conf = &apache::get_config();
 		foreach my $v (&apache::find_directive_struct("VirtualHost",
 							      $conf)) {
 			foreach my $w (@{$v->{'words'}}) {
-				local ($vip, $vport) = split(/:/, $w);
+				my ($vip, $vport) = split(/:/, $w);
 				if ($vip eq $d->{'ip'} && $vport == $port) {
 					return &text('setup_edepssl4',
 						     $d->{'ip'}, $port);
@@ -74,14 +74,14 @@ else {
 		}
 
 	# Perform the same check on IPv6
-	local ($sslclash6) = grep { $_->{'ip6'} &&
+	my ($sslclash6) = grep { $_->{'ip6'} &&
 				    $_->{'ip6'} eq $d->{'ip6'} &&
 				    $_->{'ssl'} &&
 				    $_->{'id'} ne $d->{'id'}} &list_domains();
 	if (!$d->{'virt6'} && $sslclash6 && (!$oldd || !$oldd->{'ssl'})) {
 		# Clash .. but is the cert OK?
 		if (!&check_domain_certificate($d->{'dom'}, $sslclash)) {
-			local @certdoms = &list_domain_certificate($sslclash);
+			my @certdoms = &list_domain_certificate($sslclash);
 			return &text('setup_edepssl5', $d->{'ip6'},
 				join(", ", map { "<tt>$_</tt>" } @certdoms),
 				$sslclash->{'dom'});
@@ -93,12 +93,12 @@ else {
 	# Check for <virtualhost> on the IPv6 address, if we are turning on SSL
 	if (!$oldd || !$oldd->{'ssl'}) {
 		&require_apache();
-		local $conf = &apache::get_config();
+		my $conf = &apache::get_config();
 		foreach my $v (&apache::find_directive_struct("VirtualHost",
 							      $conf)) {
 			foreach my $w (@{$v->{'words'}}) {
 				$w =~ /^\[([^\/]+)\]/ || next;
-				local $vip = $1;
+				my $vip = $1;
 				if ($vip eq $d->{'ip6'} && $vport == $port) {
 					return &text('setup_edepssl4',
 						     $d->{'ip6'}, $port);
@@ -115,12 +115,12 @@ else {
 # Creates a website with SSL enabled, and a private key and cert it to use.
 sub setup_ssl
 {
-local ($d) = @_;
-local $tmpl = &get_template($d->{'template'});
-local $web_sslport = $d->{'web_sslport'} || $tmpl->{'web_sslport'} || 443;
+my ($d) = @_;
+my $tmpl = &get_template($d->{'template'});
+my $web_sslport = $d->{'web_sslport'} || $tmpl->{'web_sslport'} || 443;
 &require_apache();
 &obtain_lock_web($d);
-local $conf = &apache::get_config();
+my $conf = &apache::get_config();
 $d->{'letsencrypt_renew'} = 1;		# Default let's encrypt renewal
 
 # Find out if this domain will share a cert with another
@@ -133,13 +133,13 @@ if (!$generated && !-r $d->{'ssl_cert'}) {
 	return 0;
 	}
 &refresh_ssl_cert_expiry($d);
-local $chained = $d->{'ssl_chain'};
+my $chained = $d->{'ssl_chain'};
 &sync_combined_ssl_cert($d);
 
 # Add NameVirtualHost if needed, and if there is more than one SSL site on
 # this IP address
-local $nvstar = &add_name_virtual($d, $conf, $web_sslport, 1, $d->{'ip'});
-local $nvstar6; 
+my $nvstar = &add_name_virtual($d, $conf, $web_sslport, 1, $d->{'ip'});
+my $nvstar6;
 if ($d->{'ip6'}) {                                
         $nvstar6 = &add_name_virtual($d, $conf, $web_sslport, 1, $d->{'ip6'});
         }       
@@ -162,34 +162,34 @@ if (!$virt) {
 	}
 
 # Double-check cert and key
-local $certdata = &read_file_contents($d->{'ssl_cert'});
-local $keydata = &read_file_contents($d->{'ssl_key'});
-local $err = &validate_cert_format($certdata, 'cert');
+my $certdata = &read_file_contents($d->{'ssl_cert'});
+my $keydata = &read_file_contents($d->{'ssl_key'});
+my $err = &validate_cert_format($certdata, 'cert');
 if ($err) {
 	&$second_print(&text('setup_esslcert', $err));
 	return 0;
 	}
-local $err = &validate_cert_format($keydata, 'key');
+my $err = &validate_cert_format($keydata, 'key');
 if ($err) {
 	&$second_print(&text('setup_esslkey', $err));
 	return 0;
 	}
 if ($d->{'ssl_chain'}) {
-	local $cadata = &read_file_contents($d->{'ssl_chain'});
-	local $err = &validate_cert_format($cadata, 'ca');
+	my $cadata = &read_file_contents($d->{'ssl_chain'});
+	my $err = &validate_cert_format($cadata, 'ca');
 	if ($err) {
 		&$second_print(&text('setup_esslca', $err));
 		return 0;
 		}
 	}
-local $err = &check_cert_key_match($certdata, $keydata);
+my $err = &check_cert_key_match($certdata, $keydata);
 if ($err) {
 	&$second_print(&text('setup_esslmatch', $err));
 	return 0;
 	}
 
 # Add the actual <VirtualHost>
-local $f = $virt->{'file'};
+my $f = $virt->{'file'};
 my @mems = &clone_apache_config($virt->{'members'});
 my @ssldirs = &apache_ssl_directives($d, $tmpl);
 push(@mems, &apache_lines_to_config(\@ssldirs));
@@ -260,17 +260,17 @@ my @certs = &get_all_domain_service_ssl_certs($aliasd);
 # modify_ssl(&domain, &olddomain)
 sub modify_ssl
 {
-local ($d, $oldd) = @_;
-local $rv = 0;
+my ($d, $oldd) = @_;
+my $rv = 0;
 &require_apache();
 &obtain_lock_web($d);
 
 # Get objects for SSL and non-SSL virtual hosts
-local ($virt, $vconf, $conf) = &get_apache_virtual($oldd->{'dom'},
+my ($virt, $vconf, $conf) = &get_apache_virtual($oldd->{'dom'},
                                                    $oldd->{'web_sslport'});
-local ($nonvirt, $nonvconf) = &get_apache_virtual($d->{'dom'},
+my ($nonvirt, $nonvconf) = &get_apache_virtual($d->{'dom'},
 						  $d->{'web_port'});
-local $tmpl = &get_template($d->{'template'});
+my $tmpl = &get_template($d->{'template'});
 
 if ($d->{'ip'} ne $oldd->{'ip'} ||
     $d->{'ip6'} ne $oldd->{'ip6'} ||
@@ -283,10 +283,10 @@ if ($d->{'ip'} ne $oldd->{'ip'} ||
 		&$second_print($text{'delete_noapache'});
 		goto VIRTFAILED;
 		}
-	local $nvstar = &add_name_virtual($d, $conf,
+	my $nvstar = &add_name_virtual($d, $conf,
 					  $d->{'web_sslport'}, 0,
 					  $d->{'ip'});
-	local $nvstar6;
+	my $nvstar6;
 	if ($d->{'ip6'}) {
 		$nvstar6 = &add_name_virtual(
 			$d, $conf, $d->{'web_sslport'}, 0,
@@ -323,7 +323,7 @@ if ($d->{'user'} ne $oldd->{'user'}) {
 		&$second_print($text{'delete_noapache'});
 		goto VIRTFAILED;
 		}
-	local @vals = &apache::find_directive("SuexecUserGroup", $nonvconf);
+	my @vals = &apache::find_directive("SuexecUserGroup", $nonvconf);
 	if (@vals) {
 		&apache::save_directive(
 			"SuexecUserGroup", \@vals, $vconf, $conf);
@@ -349,11 +349,11 @@ if ($d->{'dom'} ne $oldd->{'dom'}) {
 VIRTFAILED:
 if ($d->{'ip'} ne $oldd->{'ip'} && $oldd->{'ssl_same'}) {
 	# IP has changed - maybe clear ssl_same field
-	local ($sslclash) = grep { $_->{'ip'} eq $d->{'ip'} &&
+	my ($sslclash) = grep { $_->{'ip'} eq $d->{'ip'} &&
 				   $_->{'ssl'} &&
 				   $_->{'id'} ne $d->{'id'} &&
 				   !$_->{'ssl_same'} } &list_domains();
-	local $oldsslclash = &get_domain($oldd->{'ssl_same'});
+	my $oldsslclash = &get_domain($oldd->{'ssl_same'});
 	if ($sslclash && $oldd->{'ssl_same'} eq $sslclash->{'id'}) {
 		# No need to change
 		}
@@ -385,10 +385,10 @@ if ($d->{'dom'} ne $oldd->{'dom'} && &self_signed_cert($d) &&
     !&check_domain_certificate($d->{'dom'}, $d)) {
 	# Domain name has changed .. re-generate self-signed cert
 	&$first_print($text{'save_ssl11'});
-	local $info = &cert_info($d);
+	my $info = &cert_info($d);
 	&lock_file($d->{'ssl_cert'});
 	&lock_file($d->{'ssl_key'});
-	local @newalt = $info->{'alt'} ? @{$info->{'alt'}} : ( );
+	my @newalt = $info->{'alt'} ? @{$info->{'alt'}} : ( );
 	foreach my $a (@newalt) {
 		if ($a eq $oldd->{'dom'}) {
 			$a = $d->{'dom'};
@@ -397,9 +397,9 @@ if ($d->{'dom'} ne $oldd->{'dom'} && &self_signed_cert($d) &&
 			$a = $1.".".$d->{'dom'};
 			}
 		}
-	local $email = $info->{'emailAddress'};
+	my $email = $info->{'emailAddress'};
 	$email =~ s/\@\Q$oldd->{'dom'}\E$/\@$d->{'dom'}/;
-	local $err = &generate_self_signed_cert(
+	my $err = &generate_self_signed_cert(
 		$d->{'ssl_cert'}, $d->{'ssl_key'},
 		undef,
 		1825,
@@ -482,20 +482,20 @@ return $rv;
 # Deletes the SSL virtual server from the Apache config
 sub delete_ssl
 {
-local ($d) = @_;
+my ($d) = @_;
 
 &require_apache();
 &$first_print($text{'delete_ssl'});
 &obtain_lock_web($d);
-local $conf = &apache::get_config();
+my $conf = &apache::get_config();
 
 # Remove the custom Listen directive added for the domain, if any
 &remove_listen($d, $conf, $d->{'web_sslport'} || $default_web_sslport);
 
 # Remove the <virtualhost>
-local ($virt, $vconf) = &get_apache_virtual($d->{'dom'},
+my ($virt, $vconf) = &get_apache_virtual($d->{'dom'},
 			    $d->{'web_sslport'} || $default_web_sslport);
-local $tmpl = &get_template($d->{'template'});
+my $tmpl = &get_template($d->{'template'});
 if ($virt) {
 	&delete_web_virtual_server($virt, $conf);
 	&$second_print($text{'setup_done'});
@@ -534,7 +534,7 @@ return 1;
 sub clone_ssl
 {
 my ($d, $oldd) = @_;
-local $tmpl = &get_template($d->{'template'});
+my $tmpl = &get_template($d->{'template'});
 &$first_print($text{'clone_ssl'});
 my ($virt, $vconf, $conf) = &get_apache_virtual($d->{'dom'},
 						$d->{'web_sslport'});
@@ -555,7 +555,7 @@ if (!$virt) {
 # Is the linked SSL cert still valid for the new domain? If not, break the
 # linkage by copying over the cert.
 if ($d->{'ssl_same'} && !&check_domain_certificate($d->{'dom'}, $d)) {
-	local $oldsame = &get_domain($d->{'ssl_same'});
+	my $oldsame = &get_domain($d->{'ssl_same'});
 	&break_ssl_linkage($d, $oldsame);
 	}
 
@@ -581,25 +581,25 @@ return 1;
 # cert files are missing.
 sub validate_ssl
 {
-local ($d) = @_;
-local ($virt, $vconf, $conf) = &get_apache_virtual(
+my ($d) = @_;
+my ($virt, $vconf, $conf) = &get_apache_virtual(
 				$d->{'dom'}, $d->{'web_sslport'});
 return &text('validate_essl', "<tt>$d->{'dom'}</tt>") if (!$virt);
 
 # Check IP addresses
 if ($d->{'virt'}) {
-	local $ipp = $d->{'ip'}.":".$d->{'web_sslport'};
+	my $ipp = $d->{'ip'}.":".$d->{'web_sslport'};
 	&indexof($ipp, @{$virt->{'words'}}) >= 0 ||
 		return &text('validate_ewebip', $ipp);
 	}
 if ($d->{'virt6'}) {
-	local $ipp = "[".$d->{'ip6'}."]:".$d->{'web_sslport'};
+	my $ipp = "[".$d->{'ip6'}."]:".$d->{'web_sslport'};
 	&indexof($ipp, @{$virt->{'words'}}) >= 0 ||
 		return &text('validate_ewebip6', $ipp);
 	}
 
 # Make sure cert file exists
-local $cert = &apache::find_directive("SSLCertificateFile", $vconf, 1);
+my $cert = &apache::find_directive("SSLCertificateFile", $vconf, 1);
 if (!$cert) {
 	return &text('validate_esslcert');
 	}
@@ -615,7 +615,7 @@ elsif (&is_under_directory($d->{'home'}, $cert) &&
 	}
 
 # Make sure key exists
-local $key = &apache::find_directive("SSLCertificateKeyFile", $vconf, 1);
+my $key = &apache::find_directive("SSLCertificateKeyFile", $vconf, 1);
 if ($key) {
 	if (!-e $key) {
 		return &text('validate_esslkeyfile', "<tt>$key</tt>");
@@ -630,17 +630,17 @@ if ($key) {
 	}
 
 # Make sure the cert is readable
-local $info = &cert_info($d);
+my $info = &cert_info($d);
 if (!$info || !$info->{'cn'}) {
 	return &text('validate_esslcertinfo', "<tt>$cert</tt>");
 	}
-local $err = &validate_cert_format($cert, 'cert');
+my $err = &validate_cert_format($cert, 'cert');
 if ($err) {
 	return $err;
 	}
 
 # Check the key type
-local $type = &get_ssl_key_type($key, $d->{'ssl_pass'});
+my $type = &get_ssl_key_type($key, $d->{'ssl_pass'});
 $type || return &text('validate_esslkeytype', "<tt>$key</tt>");
 
 # Make sure the cert and key match
@@ -667,7 +667,7 @@ if (!$match) {
 
 # Make sure the cert isn't expired
 if ($info && $info->{'notafter'} && !$d->{'disabled'}) {
-	local $notafter = &parse_notafter_date($info->{'notafter'});
+	my $notafter = &parse_notafter_date($info->{'notafter'});
 	if ($notafter < time()) {
 		return &text('validate_esslexpired', &make_date($notafter));
 		}
@@ -723,17 +723,17 @@ return undef;
 # port 443 on the domain's IP is in use by Webmin or Usermin
 sub check_ssl_clash
 {
-local $tmpl = &get_template($_[0]->{'template'});
-local $web_sslport = $tmpl->{'web_sslport'} || 443;
+my $tmpl = &get_template($_[0]->{'template'});
+my $web_sslport = $tmpl->{'web_sslport'} || 443;
 if (!$_[1] || $_[1] eq 'dom') {
 	# Check for <virtualhost> clash by domain name
-	local ($cvirt, $cconf) = &get_apache_virtual($_[0]->{'dom'},
+	my ($cvirt, $cconf) = &get_apache_virtual($_[0]->{'dom'},
 						     $web_sslport);
 	return 1 if ($cvirt);
 	}
 if (!$_[1] || $_[1] eq 'ip') {
 	# Check for clash by IP and port with Webmin or Usermin
-	local $err = &check_webmin_port_clash($_[0], $web_sslport);
+	my $err = &check_webmin_port_clash($_[0], $web_sslport);
 	return $err if ($err);
 	}
 return 0;
@@ -774,7 +774,7 @@ sub disable_ssl
 {
 &$first_print($text{'disable_ssl'});
 &require_apache();
-local ($virt, $vconf) = &get_apache_virtual($_[0]->{'dom'},
+my ($virt, $vconf) = &get_apache_virtual($_[0]->{'dom'},
 					    $_[0]->{'web_sslport'});
 if ($virt) {
         &create_disable_directives($virt, $vconf, $_[0]);
@@ -793,7 +793,7 @@ sub enable_ssl
 {
 &$first_print($text{'enable_ssl'});
 &require_apache();
-local ($virt, $vconf) = &get_apache_virtual($_[0]->{'dom'},
+my ($virt, $vconf) = &get_apache_virtual($_[0]->{'dom'},
 					    $_[0]->{'web_sslport'});
 if ($virt) {
         &remove_disable_directives($virt, $vconf, $_[0]);
@@ -980,7 +980,7 @@ return $rv;
 # Returns a hash of details of a domain's cert
 sub cert_info
 {
-local ($d) = @_;
+my ($d) = @_;
 return &cert_file_info($d->{'ssl_cert'});
 }
 
@@ -1015,12 +1015,12 @@ return @rv;
 # Returns details of a cert in PEM text format
 sub cert_data_info
 {
-local ($data) = @_;
-local $temp = &transname();
+my ($data) = @_;
+my $temp = &transname();
 &open_tempfile(TEMP, ">$temp", 0, 1);
 &print_tempfile(TEMP, $data);
 &close_tempfile(TEMP);
-local $info = &cert_file_info($temp);
+my $info = &cert_file_info($temp);
 &unlink_file($temp);
 return $info;
 }
@@ -1415,12 +1415,12 @@ return &mailboxes::parse_mail_date($str);
 # same file, or the same modulus and expiry date.
 sub same_cert_file
 {
-local ($file1, $file2) = @_;
+my ($file1, $file2) = @_;
 return 1 if (!$file1 && !$file2);
 return 0 if ($file1 && !$file2 || !$file1 && $file2);
 return 1 if (&same_file($file1, $file2));
-local $info1 = &cert_file_info($file1);
-local $info2 = &cert_file_info($file2);
+my $info1 = &cert_file_info($file1);
+my $info2 = &cert_file_info($file2);
 return 1 if (!$info1 && !$info2);
 return 0 if ($info1 && !$info2 || !$info1 && $info2);
 return $info1->{'modulus'} && $info2->{'modulus'} &&
@@ -1433,13 +1433,13 @@ return $info1->{'modulus'} && $info2->{'modulus'} &&
 # for any of the certs in file2.
 sub same_cert_file_any
 {
-local ($file1, $file2) = @_;
+my ($file1, $file2) = @_;
 return 1 if (!$file1 && !$file2);
 return 0 if ($file1 && !$file2 || !$file1 && $file2);
 return 1 if (&same_file($file1, $file2));
-local $info1 = &cert_file_info($file1);
+my $info1 = &cert_file_info($file1);
 foreach my $sp (&cert_file_split($file2)) {
-	local $info2 = &cert_data_info($sp);
+	my $info2 = &cert_data_info($sp);
 	return 1 if ($info1->{'modulus'} && $info2->{'modulus'} &&
 		     $info1->{'modulus'} eq $info2->{'modulus'} &&
 		     $info1->{'notafter'} eq $info2->{'notafter'});
@@ -1476,20 +1476,20 @@ return undef;
 # Returns 0 if a passphrase is needed by not given, 1 if not needed, 2 if OK
 sub check_passphrase
 {
-local ($newkey, $pass) = @_;
-local $temp = &transname();
+my ($newkey, $pass) = @_;
+my $temp = &transname();
 &open_tempfile(KEY, ">$temp", 0, 1);
 &set_ownership_permissions(undef, undef, 0700, $temp);
 &print_tempfile(KEY, $newkey);
 &close_tempfile(KEY);
 my $type = &get_ssl_key_type($temp, $pass);
-local $rv = &execute_command("openssl $type -in ".quotemeta($temp).
+my $rv = &execute_command("openssl $type -in ".quotemeta($temp).
 			     " -text -passin pass:NONE");
 if (!$rv) {
 	return 1;
 	}
 if ($pass) {
-	local $rv = &execute_command("openssl $type -in ".quotemeta($temp).
+	my $rv = &execute_command("openssl $type -in ".quotemeta($temp).
 				     " -text -passin pass:".quotemeta($pass));
 	if (!$rv) {
 		return 2;
@@ -1502,9 +1502,9 @@ return 0;
 # Given an SSL key file, returns the size in bits
 sub get_key_size
 {
-local ($file) = @_;
+my ($file) = @_;
 my $type = &get_ssl_key_type($file);
-local $out = &backquote_command(
+my $out = &backquote_command(
 	"openssl $type -in ".quotemeta($file)." -text 2>&1 </dev/null");
 if ($out =~ /Private-Key:\s+\((\d+)/i) {
 	return $1;
@@ -1517,20 +1517,20 @@ return undef;
 # Otherwise, remove the passphrase config.
 sub save_domain_passphrase
 {
-local ($d) = @_;
-local $p = &domain_has_website($d);
+my ($d) = @_;
+my $p = &domain_has_website($d);
 if ($p ne "web") {
 	return &plugin_call($p, "feature_save_web_passphrase", $d);
 	}
-local $pass_script = "$ssl_passphrase_dir/$d->{'id'}";
+my $pass_script = "$ssl_passphrase_dir/$d->{'id'}";
 &lock_file($pass_script);
-local ($virt, $vconf, $conf) = &get_apache_virtual($d->{'dom'},
+my ($virt, $vconf, $conf) = &get_apache_virtual($d->{'dom'},
                                                    $d->{'web_sslport'});
 return "SSL virtual host not found" if (!$vconf);
-local @pps = &apache::find_directive("SSLPassPhraseDialog", $conf);
-local @pps_str = &apache::find_directive_struct("SSLPassPhraseDialog", $conf);
+my @pps = &apache::find_directive("SSLPassPhraseDialog", $conf);
+my @pps_str = &apache::find_directive_struct("SSLPassPhraseDialog", $conf);
 &lock_file(@pps_str ? $pps_str[0]->{'file'} : $conf->[0]->{'file'});
-local ($pps) = grep { $_ eq "exec:$pass_script" } @pps;
+my ($pps) = grep { $_ eq "exec:$pass_script" } @pps;
 if ($d->{'ssl_pass'}) {
 	# Create script, add to Apache config
 	if (!-d $ssl_passphrase_dir) {
@@ -1632,21 +1632,21 @@ return $pub;
 # an error message if not. The type can be one of 'key', 'cert', 'ca' or 'csr'
 sub validate_cert_format
 {
-local ($data, $type) = @_;
+my ($data, $type) = @_;
 if ($data =~ /^\//) {
 	$data = &read_file_contents($data);
 	}
-local %headers = ( 'key' => '(RSA |EC )?PRIVATE KEY',
+my %headers = ( 'key' => '(RSA |EC )?PRIVATE KEY',
 		   'cert' => '(CERTIFICATE|PUBLIC KEY)',
 		   'ca' => '(CERTIFICATE|PUBLIC KEY)',
 		   'csr' => 'CERTIFICATE REQUEST',
 		   'newkey' => '(RSA |EC )?PRIVATE KEY' );
-local $h = $headers{$type};
+my $h = $headers{$type};
 $h || return "Unknown SSL file type $type";
 ($data) = &extract_cert_parameters($data);
-local @lines = grep { /\S/ } split(/\r?\n/, $data);
-local $begin = quotemeta("-----BEGIN ").$h.quotemeta("-----");
-local $end = quotemeta("-----END ").$h.quotemeta("-----");
+my @lines = grep { /\S/ } split(/\r?\n/, $data);
+my $begin = quotemeta("-----BEGIN ").$h.quotemeta("-----");
+my $end = quotemeta("-----END ").$h.quotemeta("-----");
 @lines || return "Data is <em>empty</em>, but expected -----BEGIN $h-----";
 $lines[0] =~ /^$begin$/ ||
 	return "Data starts with $lines[0] , but expected -----BEGIN $h-----";
@@ -1731,8 +1731,8 @@ return undef;
 # Returns a domain's cert in PKCS12 format
 sub cert_pkcs12_data
 {
-local ($d) = @_;
-local $cmd = "openssl pkcs12 -in ".quotemeta($d->{'ssl_cert'}).
+my ($d) = @_;
+my $cmd = "openssl pkcs12 -in ".quotemeta($d->{'ssl_cert'}).
              " -inkey ".quotemeta($_[0]->{'ssl_key'}).
 	     " -export -passout pass: -nokeys";
 open(OUT, &command_as_user($d->{'user'}, 0, $cmd)." |");
@@ -1747,8 +1747,8 @@ return $data;
 # Returns a domain's key in PKCS12 format
 sub key_pkcs12_data
 {
-local ($d) = @_;
-local $cmd = "openssl pkcs12 -in ".quotemeta($d->{'ssl_cert'}).
+my ($d) = @_;
+my $cmd = "openssl pkcs12 -in ".quotemeta($d->{'ssl_cert'}).
              " -inkey ".quotemeta($_[0]->{'ssl_key'}).
 	     " -export -passout pass: -nocerts";
 open(OUT, &command_as_user($d->{'user'}, 0, $cmd)." |");
@@ -1767,10 +1767,10 @@ my ($d, $getfunc, $putfunc, $postfunc) = @_;
 my @doms = ( $d, &get_domain_by("alias", $d->{'id'}) );
 my @dnames = map { ($_->{'dom'}, "*.".$_->{'dom'}) } @doms;
 &foreign_require("webmin");
-local %miniserv;
+my %miniserv;
 &$getfunc(\%miniserv);
-local @ipkeys = &webmin::get_ipkeys(\%miniserv);
-local @ips;
+my @ipkeys = &webmin::get_ipkeys(\%miniserv);
+my @ips;
 if ($d->{'virt'}) {
 	push(@ips, $d->{'ip'});
 	}
@@ -1795,10 +1795,10 @@ sub delete_ipkeys
 {
 my ($d, $getfunc, $putfunc, $postfunc) = @_;
 &foreign_require("webmin");
-local %miniserv;
+my %miniserv;
 &$getfunc(\%miniserv);
-local @ipkeys = &webmin::get_ipkeys(\%miniserv);
-local @newipkeys;
+my @ipkeys = &webmin::get_ipkeys(\%miniserv);
+my @newipkeys;
 foreach my $ipk (@ipkeys) {
 	my $del = &indexof($d->{'dom'}, @{$ipk->{'ips'}}) >= 0;
 	if ($d->{'virt'} && !$del) {
@@ -1843,9 +1843,9 @@ else {
 # Returns extra Apache directives needed for SSL
 sub apache_ssl_directives
 {
-local ($d, $tmpl) = @_;
+my ($d, $tmpl) = @_;
 &require_apache();
-local @dirs;
+my @dirs;
 push(@dirs, "SSLEngine on");
 if (&apache_combined_cert($d)) {
 	push(@dirs, "SSLCertificateFile $d->{'ssl_combined'}");
@@ -1861,7 +1861,7 @@ if ($tmpl->{'web_sslprotos'}) {
 	push(@dirs, "SSLProtocol ".$tmpl->{'web_sslprotos'});
 	}
 else {
-	local @tls = ( "SSLv2", "SSLv3" );
+	my @tls = ( "SSLv2", "SSLv3" );
 	if ($apache::httpd_modules{'core'} >= 2.4) {
 		push(@tls, "TLSv1");
 		if (&compare_version_numbers(&get_openssl_version(), '>=', '1.0.0')) {
@@ -1871,7 +1871,7 @@ else {
 	push(@dirs, "SSLProtocol ".join(" ", "all", map { "-".$_ } @tls));
 	}
 if ($tmpl->{'web_ssl'} ne 'none') {
-	local $ssl_dirs = $tmpl->{'web_ssl'};
+	my $ssl_dirs = $tmpl->{'web_ssl'};
 	$ssl_dirs =~ s/\t/\n/g;
 	$ssl_dirs = &substitute_domain_template($ssl_dirs, $d);
 	push(@dirs, split(/\n/, $ssl_dirs));
@@ -1884,7 +1884,7 @@ return @dirs;
 # message if not
 sub check_certificate_data
 {
-local ($data) = @_;
+my ($data) = @_;
 my @lines = split(/\r?\n/, $data);
 my @certs;
 my $inside = 0;
@@ -1904,13 +1904,13 @@ foreach my $l (@lines) {
 	}
 $inside && return $text{'cert_einside'};
 @certs || return $text{'cert_ecerts'};
-local $temp = &transname();
+my $temp = &transname();
 foreach my $cdata (@certs) {
 	&open_tempfile(CERTDATA, ">$temp", 0, 1);
 	&print_tempfile(CERTDATA, $cdata);
 	&close_tempfile(CERTDATA);
-	local $out = &backquote_command("openssl x509 -in ".quotemeta($temp)." -issuer -subject -enddate 2>&1");
-	local $ex = $?;
+	my $out = &backquote_command("openssl x509 -in ".quotemeta($temp)." -issuer -subject -enddate 2>&1");
+	my $ex = $?;
 	&unlink_file($temp);
 	if ($ex) {
 		return "<tt>".&html_escape($out)."</tt>";
@@ -1959,7 +1959,7 @@ return $file."/ssl.".$mode;
 # Set permissions on a cert file so that Apache can read them.
 sub set_certificate_permissions
 {
-local ($d, $file) = @_;
+my ($d, $file) = @_;
 if (&is_under_directory($d->{'home'}, $file)) {
 	&set_permissions_as_domain_user($d, 0700, $file);
 	}
@@ -1973,8 +1973,8 @@ else {
 # domain, 0 if not. Based on the common names, including wildcards and UCC
 sub check_domain_certificate
 {
-local ($dname, $d_or_info) = @_;
-local $info = $d_or_info->{'dom'} ? &cert_info($d_or_info) : $d_or_info;
+my ($dname, $d_or_info) = @_;
+my $info = $d_or_info->{'dom'} ? &cert_info($d_or_info) : $d_or_info;
 foreach my $check ($dname, "www.".$dname) {
 	if (lc($info->{'cn'}) eq lc($check)) {
 		# Exact match
@@ -2008,9 +2008,9 @@ return 0;
 # Returns a list of domain names that are in the cert for a domain
 sub list_domain_certificate
 {
-local ($d_or_info) = @_;
-local $info = $d_or_info->{'dom'} ? &cert_info($d_or_info) : $d_or_info;
-local @rv;
+my ($d_or_info) = @_;
+my $info = $d_or_info->{'dom'} ? &cert_info($d_or_info) : $d_or_info;
+my @rv;
 push(@rv, $info->{'cn'});
 push(@rv, @{$info->{'alt'}});
 return &unique(@rv);
@@ -2177,12 +2177,12 @@ return undef;
 # Lock the Apache config file for some domain, and the Webmin config
 sub obtain_lock_ssl
 {
-local ($d) = @_;
+my ($d) = @_;
 return if (!$config{'ssl'});
 &obtain_lock_anything($d);
 &obtain_lock_web($d) if ($d->{'web'});
 if ($main::got_lock_ssl == 0) {
-	local @sfiles = ($ENV{'MINISERV_CONFIG'} ||
+	my @sfiles = ($ENV{'MINISERV_CONFIG'} ||
 		         "$config_directory/miniserv.conf",
 		        $config_directory =~ /^(.*)\/webmin$/ ?
 		         "$1/usermin/miniserv.conf" :
@@ -2203,7 +2203,7 @@ $main::got_lock_ssl++;
 # Un-lock the Apache config file for some domain, and the Webmin config
 sub release_lock_ssl
 {
-local ($d) = @_;
+my ($d) = @_;
 return if (!$config{'ssl'});
 &release_lock_web($d) if ($d->{'web'});
 if ($main::got_lock_ssl == 1) {
@@ -2220,12 +2220,12 @@ $main::got_lock_ssl-- if ($main::got_lock_ssl);
 # return it (or a list of matches)
 sub find_matching_certificate_domain
 {
-local ($d) = @_;
-local @sslclashes = grep { $_->{'ip'} eq $d->{'ip'} &&
+my ($d) = @_;
+my @sslclashes = grep { $_->{'ip'} eq $d->{'ip'} &&
 			   &domain_has_ssl($_) &&
 			   $_->{'id'} ne $d->{'id'} &&
 			   !$_->{'ssl_same'} } &list_domains();
-local @rv;
+my @rv;
 foreach my $sslclash (@sslclashes) {
 	if (&check_domain_certificate($d->{'dom'}, $sslclash)) {
 		push(@rv, $sslclash);
@@ -2364,7 +2364,7 @@ return 1;
 # domain and Apache config to match
 sub break_ssl_linkage
 {
-local ($d, $samed) = @_;
+my ($d, $samed) = @_;
 my @beforecerts = &get_all_domain_service_ssl_certs($d);
 
 # Copy the cert and key to the new owning domain's directory. The guard
@@ -2416,7 +2416,7 @@ $d->{'ssl_cert_expiry'} = $samed->{'ssl_cert_expiry'} if ($samed->{'ssl_cert_exp
 # names are no longer legit for the cert, break the link.
 sub break_invalid_ssl_linkages
 {
-local ($d, $newcert) = @_;
+my ($d, $newcert) = @_;
 foreach $od (&get_domain_by("ssl_same", $d->{'id'})) {
 	if (!&check_domain_certificate($od->{'dom'}, $newcert || $d)) {
 		&obtain_lock_ssl($d);
@@ -2432,7 +2432,7 @@ foreach $od (&get_domain_by("ssl_same", $d->{'id'})) {
 # the assumption that a new cert type has been installed
 sub disable_letsencrypt_renewal
 {
-local ($d) = @_;
+my ($d) = @_;
 if ($d->{'letsencrypt_renew'} || $d->{'letsencrypt_last_id'}) {
 	delete($d->{'letsencrypt_renew'});
 	delete($d->{'letsencrypt_last_id'});
@@ -3614,15 +3614,15 @@ return 0;
 # path to ensure direct access
 sub before_letsencrypt_website
 {
-local ($d) = @_;
-local $rv = { };
+my ($d) = @_;
+my $rv = { };
 &push_all_print();
 &set_all_null_print();
 &setup_noproxy_path($d, { 'uses' => [ 'proxy' ] }, undef,
 		    { 'path' => '/.well-known' });
 if (&has_web_redirects($d)) {
 	# Remove redirects that may block let's encrypt
-	local @redirs;
+	my @redirs;
 	foreach my $r (&list_redirects($d)) {
 		if ($r->{'path'} eq '/' && $r->{'http'}) {
 			# Possible problem redirect
@@ -3643,7 +3643,7 @@ return $rv;
 # Undoes changes made by before_letsencrypt_website
 sub after_letsencrypt_website
 {
-local ($d, $before) = @_;
+my ($d, $before) = @_;
 &push_all_print();
 &set_all_null_print();
 if ($before->{'redirs'}) {
@@ -3937,7 +3937,7 @@ return 0;
 # Outputs HTML for editing SSL related template options
 sub show_template_ssl
 {
-local ($tmpl) = @_;
+my ($tmpl) = @_;
 
 # SSL cert size
 print &ui_table_row(
@@ -4096,7 +4096,7 @@ print &ui_table_row(&hlink($text{'newweb_mysql'},
 # Updates SSL related template options from %in
 sub parse_template_ssl
 {
-local ($tmpl) = @_;
+my ($tmpl) = @_;
 
 # Save key size
 if ($in{'ssl_key_size_def'}) {
@@ -4167,7 +4167,7 @@ $tmpl->{'web_mysql_ssl'} = $in{'web_mysql_ssl'};
 # and if the website is just being turned on now.
 sub chained_ssl
 {
-local ($d, $oldd) = @_;
+my ($d, $oldd) = @_;
 if ($config{'ssl'} != 3) {
 	# Not in auto mode, so don't touch
 	return undef;

--- a/feature-status.pl
+++ b/feature-status.pl
@@ -8,7 +8,7 @@ return if ($require_status++);
 
 sub check_depends_status
 {
-local ($d) = @_;
+my ($d) = @_;
 if (!&domain_has_website($d)) {
 	return $text{'setup_edepstatus'};
 	}
@@ -30,17 +30,17 @@ my ($d) = @_;
 
 &$first_print($text{'setup_status'});
 &require_status();
-local $tmpl = &get_template($d->{'template'});
+my $tmpl = &get_template($d->{'template'});
 
 # Create website monitor
-local $serv = &make_monitor($d, 0);
+my $serv = &make_monitor($d, 0);
 &status::save_service($serv);
 &$second_print($text{'setup_done'});
 
 if (&domain_has_ssl($d)) {
 	# Add SSL website monitor too
 	&$first_print($text{'setup_statusssl'});
-	local $serv = &make_monitor($d, 1);
+	my $serv = &make_monitor($d, 1);
 	&status::save_service($serv);
 	&$second_print($text{'setup_done'});
 	}
@@ -48,7 +48,7 @@ if (&domain_has_ssl($d)) {
 if (&domain_has_ssl($d) && $tmpl->{'statussslcert'}) {
 	# Add SSL cert monitor
 	&$first_print($text{'setup_statussslcert'});
-	local $certserv = &make_sslcert_monitor($d);
+	my $certserv = &make_sslcert_monitor($d);
 	&status::save_service($certserv);
 	&$second_print($text{'setup_done'});
 	}
@@ -59,10 +59,10 @@ return 1;
 # Returns a hash ref for a status object for monitoring a webserver
 sub make_monitor
 {
-local ($d, $ssl) = @_;
-local $tmpl = &get_template($d->{'template'});
-local $host = &get_domain_http_hostname($d);
-local $serv = { 'id' => $d->{'id'}.($ssl ? "_ssl" : "_web"),
+my ($d, $ssl) = @_;
+my $tmpl = &get_template($d->{'template'});
+my $host = &get_domain_http_hostname($d);
+my $serv = { 'id' => $d->{'id'}.($ssl ? "_ssl" : "_web"),
 		'type' => 'http',
 		'desc' => $ssl ? "Website $host (SSL)" 
 			       : "Website $host",
@@ -84,10 +84,10 @@ return $serv;
 # Returns a hash ref for a status object for monitoring an SSL domain's cert
 sub make_sslcert_monitor
 {
-local ($d) = @_;
-local $tmpl = &get_template($d->{'template'});
-local $host = &get_domain_http_hostname($d);
-local $serv = { 'id' => $d->{'id'}."_sslcert",
+my ($d) = @_;
+my $tmpl = &get_template($d->{'template'});
+my $host = &get_domain_http_hostname($d);
+my $serv = { 'id' => $d->{'id'}."_sslcert",
 		'type' => 'sslcert',
 		'desc' => "SSL cert $host",
 		'fails' => 2,
@@ -107,9 +107,9 @@ return $serv;
 # Returns the addresses to send email to for a monitor
 sub monitor_email
 {
-local ($d) = @_;
-local $tmpl = &get_template($d->{'template'});
-local @rv;
+my ($d) = @_;
+my $tmpl = &get_template($d->{'template'});
+my @rv;
 if ($tmpl->{'status'} ne 'none') {
 	push(@rv, $tmpl->{'status'});
 	}
@@ -130,8 +130,8 @@ if ($d->{'dom'} ne $oldd->{'dom'} ||
     $d->{'emailto'} ne $oldd->{'emailto'}) {
 	# Update HTTP monitor
 	&$first_print($text{'save_status'});
-	local $serv = &status::get_service($d->{'id'}."_web");
-	local $host = &get_domain_http_hostname($d);
+	my $serv = &status::get_service($d->{'id'}."_web");
+	my $host = &get_domain_http_hostname($d);
 	if ($serv) {
 		$serv->{'host'} = $host;
 		$serv->{'desc'} = "Website $host";
@@ -145,7 +145,7 @@ if ($d->{'dom'} ne $oldd->{'dom'} ||
 
 	if (&domain_has_ssl_cert($d)) {
 		# Update cert monitor
-		local $certserv = &status::get_service($d->{'id'}."_sslcert");
+		my $certserv = &status::get_service($d->{'id'}."_sslcert");
 		if ($certserv) {
 			&$first_print($text{'save_statussslcert'});
 			$certserv->{'url'} =
@@ -160,7 +160,7 @@ if ($d->{'dom'} ne $oldd->{'dom'} ||
 	if (&domain_has_ssl($d)) {
 		# Update HTTPS monitor
 		&$first_print($text{'save_statusssl'});
-		local $serv = &status::get_service($d->{'id'}."_ssl");
+		my $serv = &status::get_service($d->{'id'}."_ssl");
 		if ($serv) {
 			$serv->{'host'} = $host;
 			$serv->{'desc'} = "Website $host (SSL)";
@@ -177,14 +177,14 @@ if ($d->{'dom'} ne $oldd->{'dom'} ||
 if (&domain_has_ssl($d) && !&domain_has_ssl($oldd)) {
 	# Turned on SSL .. add monitor
 	&$first_print($text{'setup_status'});
-	local $serv = &make_monitor($d, 1);
+	my $serv = &make_monitor($d, 1);
 	&status::save_service($serv);
 	&$second_print($text{'setup_done'});
 	}
 elsif (!&domain_has_ssl($d) && &domain_has_ssl($oldd)) {
 	# Turned off SSL .. remove monitor (but not the cert monitor)
 	&$first_print($text{'delete_statusssl'});
-	local $serv = &status::get_service($d->{'id'}."_ssl");
+	my $serv = &status::get_service($d->{'id'}."_ssl");
 	if ($serv) {
 		&status::delete_service($serv);
 		&$second_print($text{'setup_done'});
@@ -197,7 +197,7 @@ elsif (!&domain_has_ssl($d) && &domain_has_ssl($oldd)) {
 if (&domain_has_ssl_cert($d) && !&domain_has_ssl_cert($oldd)) {
 	# Added a cert ... add monitor
 	&$first_print($text{'setup_status'});
-	local $certserv = &make_sslcert_monitor($d);
+	my $certserv = &make_sslcert_monitor($d);
 	&status::save_service($certserv);
 	&$second_print($text{'setup_done'});
 	}
@@ -212,7 +212,7 @@ my ($d) = @_;
 # Remove HTTP status monitor
 &$first_print($text{'delete_status'});
 &require_status();
-local $serv = &status::get_service($d->{'id'}."_web");
+my $serv = &status::get_service($d->{'id'}."_web");
 if ($serv) {
 	&status::delete_service($serv);
 	&$second_print($text{'setup_done'});
@@ -224,7 +224,7 @@ else {
 if (&domain_has_ssl($d)) {
 	# Remove HTTPS status monitor
 	&$first_print($text{'delete_statusssl'});
-	local $serv = &status::get_service($d->{'id'}."_ssl");
+	my $serv = &status::get_service($d->{'id'}."_ssl");
 	if ($serv) {
 		&status::delete_service($serv);
 		&$second_print($text{'setup_done'});
@@ -237,7 +237,7 @@ if (&domain_has_ssl($d)) {
 if (&domain_has_ssl_cert($d)) {
 	# Remove SSL cert monitor
 	&$first_print($text{'delete_statussslcert'});
-	local $certserv = &status::get_service($d->{'id'}."_sslcert");
+	my $certserv = &status::get_service($d->{'id'}."_sslcert");
 	if ($certserv) {
 		&status::delete_service($certserv);
 		}
@@ -250,12 +250,12 @@ return 1;
 # Check for the required monitors
 sub validate_status
 {
-local ($d) = @_;
+my ($d) = @_;
 &require_status();
-local $serv = &status::get_service($_[0]->{'id'}."_web");
+my $serv = &status::get_service($_[0]->{'id'}."_web");
 return &text('validate_estatusweb') if (!$serv);
 if (&domain_has_ssl($d)) {
-	local $serv = &status::get_service($_[0]->{'id'}."_ssl");
+	my $serv = &status::get_service($_[0]->{'id'}."_ssl");
 	return &text('validate_estatusssl') if (!$serv);
 	}
 return undef;
@@ -268,7 +268,7 @@ sub disable_status
 # Disable HTTP status monitor
 &$first_print($text{'disable_status'});
 &require_status();
-local $serv = &status::get_service($_[0]->{'id'}."_web");
+my $serv = &status::get_service($_[0]->{'id'}."_web");
 if ($serv) {
 	$serv->{'nosched'} = 1;
 	&status::save_service($serv);
@@ -281,12 +281,12 @@ else {
 # Disable HTTPS status monitor
 if (domain_has_ssl($_[0])) {
 	&$first_print($text{'disable_statusssl'});
-	local $certserv = &status::get_service($_[0]->{'id'}."_sslcert");
+	my $certserv = &status::get_service($_[0]->{'id'}."_sslcert");
 	if ($certserv) {
 		$certserv->{'nosched'} = 1;
 		&status::save_service($certserv);
 		}
-	local $serv = &status::get_service($_[0]->{'id'}."_ssl");
+	my $serv = &status::get_service($_[0]->{'id'}."_ssl");
 	if ($serv) {
 		$serv->{'nosched'} = 1;
 		&status::save_service($serv);
@@ -306,7 +306,7 @@ sub enable_status
 # Enable HTTP status monitor
 &$first_print($text{'enable_status'});
 &require_status();
-local $serv = &status::get_service($_[0]->{'id'}."_web");
+my $serv = &status::get_service($_[0]->{'id'}."_web");
 if ($serv) {
 	$serv->{'nosched'} = 0;
 	&status::save_service($serv);
@@ -319,12 +319,12 @@ else {
 # Disable HTTPS status monitor
 if (&domain_has_ssl($_[0])) {
 	&$first_print($text{'enable_statusssl'});
-	local $certserv = &status::get_service($_[0]->{'id'}."_sslcert");
+	my $certserv = &status::get_service($_[0]->{'id'}."_sslcert");
 	if ($certserv) {
 		$certserv->{'nosched'} = 0;
 		&status::save_service($certserv);
 		}
-	local $serv = &status::get_service($_[0]->{'id'}."_ssl");
+	my $serv = &status::get_service($_[0]->{'id'}."_ssl");
 	if ($serv) {
 		$serv->{'nosched'} = 0;
 		&status::save_service($serv);
@@ -341,10 +341,10 @@ return 1;
 # Outputs HTML for editing status monitoring related template options
 sub show_template_status
 {
-local ($tmpl) = @_;
+my ($tmpl) = @_;
 &require_status();
 
-local @status_fields = ( "status", "statusonly", "statustimeout",
+my @status_fields = ( "status", "statusonly", "statustimeout",
 			 "statustimeout_def", "statussslcert", "statustmpl" );
 print &ui_table_row(
 	&hlink($text{'tmpl_status'}, "template_status"),
@@ -375,7 +375,7 @@ print &ui_table_row(
 		    [ 2, $text{'tmpl_statussslcert2'} ] ]));
 
 # Default email template
-local @stmpls = &status::list_templates();
+my @stmpls = &status::list_templates();
 print &ui_table_row(
 	&hlink($text{'tmpl_statustmpl'}, "template_statustmpl"),
 	&ui_select("statustmpl", $tmpl->{'statustmpl'},
@@ -387,7 +387,7 @@ print &ui_table_row(
 # Updates status monitoring related template options from %in
 sub parse_template_status
 {
-local ($tmpl) = @_;
+my ($tmpl) = @_;
 
 # Save status monitoring settings
 $tmpl->{'status'} = &parse_none_def("status");

--- a/feature-virt.pl
+++ b/feature-virt.pl
@@ -4,35 +4,35 @@
 # Bring up an interface for a domain, if the IP isn't already enabled
 sub setup_virt
 {
-local ($d) = @_;
+my ($d) = @_;
 &obtain_lock_virt($d);
 &foreign_require("net");
-local @active = &net::active_interfaces();
+my @active = &net::active_interfaces();
 if (!$d->{'virtalready'}) {
 	# Actually bring up
 	&$first_print(&text('setup_virt', $d->{'ip'}));
-	local ($iface) = grep { $_->{'fullname'} eq $config{'iface'} } @active;
+	my ($iface) = grep { $_->{'fullname'} eq $config{'iface'} } @active;
 	if (!$iface) {
 		# Interface doesn't really exist!
 		&$second_print(&text('setup_virtmissing', $config{'iface'}));
 		return 0;
 		}
-	local $b;
-	local $vmin = $config{'iface_base'} || int($net::min_virtual_number);
-	local $vmax = -1;
+	my $b;
+	my $vmin = $config{'iface_base'} || int($net::min_virtual_number);
+	my $vmax = -1;
 	foreach $b (@active) {
 		$vmax = $b->{'virtual'}
 			if ($b->{'virtual'} ne '' &&
 			    $b->{'name'} eq $iface->{'name'} &&
 			    $b->{'virtual'} > $vmax);
 		}
-	local $vwant = $vmax + 1;
+	my $vwant = $vmax + 1;
 	if ($vwant < $vmin) {
 		$vwant = $vmin;
 		}
-	local $netmask = $d->{'netmask'} || $net::virtual_netmask ||
+	my $netmask = $d->{'netmask'} || $net::virtual_netmask ||
 			 $iface->{'netmask'};
-	local $virt = { 'address' => $d->{'ip'},
+	my $virt = { 'address' => $d->{'ip'},
 			'netmask' => $netmask,
 			'broadcast' => &net::compute_broadcast($d->{'ip'},
 							       $netmask),
@@ -55,7 +55,7 @@ if (!$d->{'virtalready'}) {
 else {
 	# Just guess the interface
 	&$first_print(&text('setup_virt2', $d->{'ip'}));
-	local ($virt) = grep { $_->{'address'} eq $d->{'ip'} } @active;
+	my ($virt) = grep { $_->{'address'} eq $d->{'ip'} } @active;
 	$d->{'iface'} = $virt ? $virt->{'fullname'} : undef;
 	if ($d->{'iface'}) {
 		&$second_print(&text('setup_virtdone2', $d->{'iface'}));
@@ -74,14 +74,14 @@ return 1;
 # Take down the network interface for a domain
 sub delete_virt
 {
-local ($d) = @_;
+my ($d) = @_;
 if (!$d->{'virtalready'}) {
 	&$first_print($text{'delete_virt'});
 	&obtain_lock_virt($d);
 	&foreign_require("net");
-	local ($biface) = grep { $_->{'address'} eq $d->{'ip'} }
+	my ($biface) = grep { $_->{'address'} eq $d->{'ip'} }
 			       &net::boot_interfaces();
-	local ($aiface) = grep { $_->{'address'} eq $d->{'ip'} }
+	my ($aiface) = grep { $_->{'address'} eq $d->{'ip'} }
 			       &net::active_interfaces();
 	if (!$biface) {
 		&$second_print(&text('delete_noiface', $d->{'iface'}));
@@ -110,16 +110,16 @@ return 1;
 # Change the virtual IP address for a domain
 sub modify_virt
 {
-local ($d, $oldd) = @_;
+my ($d, $oldd) = @_;
 if ($d->{'ip'} ne $oldd->{'ip'} && $d->{'virt'} &&
     !$d->{'virtalready'}) {
 	# Change IP on virtual interface
 	&$first_print($text{'save_virt'});
 	&obtain_lock_virt($d);
 	&foreign_require("net");
-	local ($biface) = grep { $_->{'address'} eq $oldd->{'ip'} }
+	my ($biface) = grep { $_->{'address'} eq $oldd->{'ip'} }
 			       &net::boot_interfaces();
-	local ($aiface) = grep { $_->{'address'} eq $oldd->{'ip'} }
+	my ($aiface) = grep { $_->{'address'} eq $oldd->{'ip'} }
 			       &net::active_interfaces();
 	if ($biface) {
 		if ($biface->{'virtual'} ne '') {
@@ -156,15 +156,15 @@ return 1;
 # Check for boot-time and active network interfaces
 sub validate_virt
 {
-local ($d) = @_;
+my ($d) = @_;
 if (!$_[0]->{'virtalready'}) {
 	# Only check boot-time interface if added by Virtualmin
-	local @boots = &bootup_ip_addresses();
+	my @boots = &bootup_ip_addresses();
 	if (&indexof($d->{'ip'}, @boots) < 0) {
 		return &text('validate_evirtb', $d->{'ip'});
 		}
 	}
-local @acts = &active_ip_addresses();
+my @acts = &active_ip_addresses();
 if (&indexof($d->{'ip'}, @acts) < 0) {
 	return &text('validate_evirta', $d->{'ip'});
 	}
@@ -176,13 +176,13 @@ return undef;
 sub check_virt_clash
 {
 # Check active and boot-time interfaces
-local %allips = &interface_ip_addresses();
+my %allips = &interface_ip_addresses();
 return 1 if ($allips{$_[0]});
 
 # Do a quick ping test
-local $pingcmd = $gconfig{'os_type'} =~ /-linux$/ ?
+my $pingcmd = $gconfig{'os_type'} =~ /-linux$/ ?
 			"ping -c 1 -t 1" : "ping";
-local ($out, $timed_out) = &backquote_with_timeout(
+my ($out, $timed_out) = &backquote_with_timeout(
 				$pingcmd." ".$_[0]." 2>&1", 2, 1);
 return 1 if (!$timed_out && !$?);
 
@@ -194,10 +194,10 @@ return 0;
 # Returns HTML for selecting a virtual IP mode for a new server, or not
 sub virtual_ip_input
 {
-local ($tmpls, $resel, $orig, $mode, $ip) = @_;
+my ($tmpls, $resel, $orig, $mode, $ip) = @_;
 $mode ||= 0;
-local $defip = &get_default_ip($resel);
-local ($t, $anyalloc, $anychoose, $anyzone);
+my $defip = &get_default_ip($resel);
+my ($t, $anyalloc, $anychoose, $anyzone);
 if (&running_in_zone() || &running_in_vserver()) {
 	# When running in a Solaris zone or VServer, you MUST select an
 	# existing active IP, as they are controlled from the host.
@@ -207,18 +207,18 @@ elsif (&can_use_feature("virt")) {
 	# Check if private IPs are allocated or manual, if we are
 	# allowed to choose them.
 	foreach $t (@$tmpls) {
-		local $tmpl = &get_template($t->{'id'});
+		my $tmpl = &get_template($t->{'id'});
 		if ($tmpl->{'ranges'} ne "none") { $anyalloc++; }
 		else { $anychoose++; }
 		}
 	}
-local @opts;
+my @opts;
 if ($orig) {
 	# For restores - option to use original IP
 	push(@opts, [ -1, $text{'form_origip'} ]);
 	}
 push(@opts, [ 0, &text('form_shared', $defip) ]);
-local @shared = sort { $a cmp $b } &list_shared_ips();
+my @shared = sort { $a cmp $b } &list_shared_ips();
 if (@shared && &can_edit_sharedips()) {
 	# Can select from extra shared list
 	push(@opts, [ 3, $text{'form_shared2'},
@@ -239,7 +239,7 @@ if ($anychoose) {
 if ($anyzone) {
 	# Can select an existing active IP
 	&foreign_require("net");
-	local @act = grep { $_->{'virtual'} ne '' }
+	my @act = grep { $_->{'virtual'} ne '' }
 			  &net::active_interfaces();
 	if (@act) {
 		push(@opts, [ 4, $text{'form_activeip'},
@@ -268,23 +268,23 @@ return &ui_radio_table("virt", $mode, \@opts, 1);
 # already flag and netmask. May call &error if the input is invalid.
 sub parse_virtual_ip
 {
-local ($tmpl, $resel) = @_;
+my ($tmpl, $resel) = @_;
 if ($in{'virt'} == 2) {
 	# Automatic IP allocation chosen .. select one from either the
 	# reseller's range, or the template
 	if ($resel) {
 		# Creating by or under a reseller .. use his range, if any
 		foreach my $r (split(/\s+/, $resel)) {
-			local %acl = &get_reseller_acl($r);
+			my %acl = &get_reseller_acl($r);
 			if ($acl{'ranges'}) {
-				local ($ip, $netmask) = &free_ip_address(\%acl);
+				my ($ip, $netmask) = &free_ip_address(\%acl);
 				$ip || &error(&text('setup_evirtalloc'));
 				return ($ip, 1, 0, $netmask);
 				}
 			}
 		}
 	$tmpl->{'ranges'} ne "none" || &error(&text('setup_evirttmpl'));
-	local ($ip, $netmask) = &free_ip_address($tmpl);
+	my ($ip, $netmask) = &free_ip_address($tmpl);
 	$ip || &error(&text('setup_evirtalloc'));
 	return ($ip, 1, 0, $netmask);
 	}
@@ -292,12 +292,12 @@ elsif ($in{'virt'} == 1) {
 	# Manual IP allocation chosen
 	$tmpl->{'ranges'} eq "none" || &error(&text('setup_evirttmpl2'));
 	&check_ipaddress($in{'ip'}) || &error($text{'setup_eip'});
-	local $clash = &check_virt_clash($in{'ip'});
+	my $clash = &check_virt_clash($in{'ip'});
 	if ($in{'virtalready'}) {
 		# Fail if the IP isn't yet active, or if claimed by another
 		# virtual server
 		$clash || &error(&text('setup_evirtclash2', $in{'ip'}));
-		local $already = &get_domain_by("ip", $in{'ip'});
+		my $already = &get_domain_by("ip", $in{'ip'});
 		$already && &error(&text('setup_evirtclash4',
 					 $already->{'dom'}));
 		}
@@ -317,21 +317,21 @@ elsif ($in{'virt'} == 4 && (&running_in_zone() || &running_in_vserver())) {
 	# On an active IP on a virtual machine that cannot bring up its
 	# own IP.
 	&check_ipaddress($in{'zoneip'}) || &error($text{'setup_eip'});
-	local $clash = &check_virt_clash($in{'zoneip'});
+	my $clash = &check_virt_clash($in{'zoneip'});
 	$clash || &error(&text('setup_evirtclash2', $in{'zoneip'}));
-	local $already = &get_domain_by("ip", $in{'ip'});
+	my $already = &get_domain_by("ip", $in{'ip'});
 	$already && &error(&text('setup_evirtclash4',
 				 $already->{'dom'}));
 	return ($in{'zoneip'}, 1, 1);
 	}
 elsif ($in{'virt'} == 5) {
 	# Allocate if needed, shared otherwise
-	local ($ip, $netmask) = &free_ip_address($tmpl);
+	my ($ip, $netmask) = &free_ip_address($tmpl);
 	return ($ip, 1, 0, $netmask);
 	}
 else {
 	# Global shared IP
-	local $defip = &get_default_ip($resel);
+	my $defip = &get_default_ip($resel);
 	return ($defip, 0, 0);
 	}
 }
@@ -340,20 +340,20 @@ else {
 # Outputs HTML for editing virtual IP related template options
 sub show_template_virt
 {
-local ($tmpl) = @_;
+my ($tmpl) = @_;
 
 # IP allocation ranges (v4 and possibly v6)
 foreach my $ranges ("ranges", &supports_ip6() ? ( "ranges6" ) : ( )) {
-	local @ranges;
+	my @ranges;
 	@ranges = &parse_ip_ranges($tmpl->{$ranges})
 		if ($tmpl->{$ranges} ne "none");
-	local @rfields = map { ($ranges."_start_".$_, $ranges."_end_".$_) }
+	my @rfields = map { ($ranges."_start_".$_, $ranges."_end_".$_) }
 			     (0..scalar(@ranges)+1);
-	local $rtable = &none_def_input($ranges, $tmpl->{$ranges},
+	my $rtable = &none_def_input($ranges, $tmpl->{$ranges},
 			 $text{'tmpl_rangesbelow'}, 0, 0, undef, \@rfields);
-	local @table;
-	local $i = 0;
-	local $s = $ranges eq "ranges" ? 20 : 6;
+	my @table;
+	my $i = 0;
+	my $s = $ranges eq "ranges" ? 20 : 6;
 	foreach my $r (@ranges, [ ], [ ]) {
 		push(@table, [ &ui_textbox($ranges."_start_$i", $r->[0], 20),
 			       &ui_textbox($ranges."_end_$i", $r->[1], 20),
@@ -377,7 +377,7 @@ foreach my $ranges ("ranges", &supports_ip6() ? ( "ranges6" ) : ( )) {
 # Updates virtual IP related template options from %in
 sub parse_template_virt
 {
-local ($tmpl) = @_;
+my ($tmpl) = @_;
 
 # Save IPv4 and possibly v6 allocation ranges
 foreach my $ranges ("ranges", &supports_ip6() ? ( "ranges6" ) : ( )) {
@@ -388,7 +388,7 @@ foreach my $ranges ("ranges", &supports_ip6() ? ( "ranges6" ) : ( )) {
 		$tmpl->{$ranges} = undef;
 		}
 	else {
-		local (@ranges, $start, $end);
+		my (@ranges, $start, $end);
 		for(my $i=0; defined($start = $in{$ranges."_start_$i"}); $i++) {
 			next if (!$start);
 			$end = $in{$ranges."_end_$i"};
@@ -400,8 +400,8 @@ foreach my $ranges ("ranges", &supports_ip6() ? ( "ranges6" ) : ( )) {
 				    &error(&text('tmpl_eranges_start', $start));
 				&check_ipaddress($end) ||
 				    &error(&text('tmpl_eranges_end', $start));
-				local @start = split(/\./, $start);
-				local @end = split(/\./, $end);
+				my @start = split(/\./, $start);
+				my @end = split(/\./, $end);
 				$start[0] == $end[0] && $start[1] == $end[1] &&
 				    $start[2] == $end[2] ||
 					&error(&text('tmpl_eranges_net',

--- a/feature-virt6.pl
+++ b/feature-virt6.pl
@@ -29,12 +29,12 @@ return $supports_ip6_cache;
 # Adds an IPv6 address to the system for a domain
 sub setup_virt6
 {
-local ($d) = @_;
+my ($d) = @_;
 &obtain_lock_virt($d);
 if (!$d->{'virt6already'}) {
 	# Save and bring up the IPv6 interface
 	&$first_print(&text('setup_virt6', $d->{'ip6'}));
-	local $virt = { 'name' => $config{'iface6'} || $config{'iface'},
+	my $virt = { 'name' => $config{'iface6'} || $config{'iface'},
 		        'netmask' => $d->{'netmask6'} ||
 				     $config{'netmask6'} || 64,
 			'address' => $d->{'ip6'} };
@@ -48,14 +48,14 @@ if (!$d->{'virt6already'}) {
 # Add IPv6 reverse entry, if possible
 if ($config{'dns'} && !$d->{'provision_dns'} && !$d->{'dns_cloud'}) {
 	&require_bind();
-	local $ip6 = $d->{'ip6'};
-	local ($revconf, $revfile, $revrec) = &bind8::find_reverse($ip6);
+	my $ip6 = $d->{'ip6'};
+	my ($revconf, $revfile, $revrec) = &bind8::find_reverse($ip6);
 	if ($revconf && $revfile && !$revrec) {
 		&lock_file(&bind8::make_chroot($revfile));
 		&bind8::create_record($revfile,
 			&bind8::net_to_ip6int($d->{'ip6'}),
 			undef, "IN", "PTR", $d->{'dom'}.".");
-		local @rrecs = &bind8::read_zone_file(
+		my @rrecs = &bind8::read_zone_file(
 			$revfile, $revconf->{'name'});
 		&bind8::bump_soa_record($revfile, \@rrecs);
 		&unlock_file(&bind8::make_chroot($revfile));
@@ -70,7 +70,7 @@ return 1;
 # Changes the IPv6 address for a domain, if needed
 sub modify_virt6
 {
-local ($d, $oldd) = @_;
+my ($d, $oldd) = @_;
 if ($d->{'ip6'} ne $oldd->{'ip6'} && !$d->{'virt6already'}) {
 	# Remove and re-add the IPv6 interface
 	&delete_virt6($oldd);
@@ -82,20 +82,20 @@ if ($d->{'ip6'} ne $oldd->{'ip6'} && !$d->{'virt6already'}) {
 # Removes the IPv6 interface for a domain
 sub delete_virt6
 {
-local ($d) = @_;
+my ($d) = @_;
 &obtain_lock_virt($d);
 if (!$d->{'virt6already'}) {
 	# Bring down and delete the IPv6 interface
 	&$first_print(&text('delete_virt6', $d->{'ip6'}));
-	local ($active) = grep { &canonicalize_ip6($_->{'address'}) eq
+	my ($active) = grep { &canonicalize_ip6($_->{'address'}) eq
 				 &canonicalize_ip6($d->{'ip6'}) }
 			       &active_ip6_interfaces();
-	local ($boot) = grep { &canonicalize_ip6($_->{'address'}) eq
+	my ($boot) = grep { &canonicalize_ip6($_->{'address'}) eq
 			       &canonicalize_ip6($d->{'ip6'}) }
 			     &boot_ip6_interfaces();
 	&delete_ip6_interface($boot) if ($boot);
 	&deactivate_ip6_interface($active) if ($active);
-	local $any = $active || $boot;
+	my $any = $active || $boot;
 	if ($any) {
 		&$second_print(&text('delete_virt6done', $any->{'name'}));
 		}
@@ -108,8 +108,8 @@ if (!$d->{'virt6already'}) {
 # Remove IPv6 reverse address, if defined
 if ($config{'dns'} && !$d->{'provision_dns'} && !$d->{'dns_cloud'}) {
 	&require_bind();
-	local $ip6 = $d->{'ip6'};
-	local ($revconf, $revfile, $revrec) = &bind8::find_reverse($ip6);
+	my $ip6 = $d->{'ip6'};
+	my ($revconf, $revfile, $revrec) = &bind8::find_reverse($ip6);
 	if ($revconf && $revfile && $revrec &&
 	    $revrec->{'values'}->[0] eq $d->{'dom'}.".") {
 		&lock_file(&bind8::make_chroot($revrec->{'file'}));
@@ -133,15 +133,15 @@ return 1;
 # Check for boot-time and active IP6 network interfaces
 sub validate_virt6
 {
-local ($d) = @_;
+my ($d) = @_;
 if (!$_[0]->{'virt6already'}) {
 	# Only check boot-time interface if added by Virtualmin
-	local @boots = map { &canonicalize_ip6($_) } &bootup_ip_addresses();
+	my @boots = map { &canonicalize_ip6($_) } &bootup_ip_addresses();
 	if (&indexoflc(&canonicalize_ip6($d->{'ip6'}), @boots) < 0) {
 		return &text('validate_evirt6b', $d->{'ip6'});
 		}
 	}
-local @acts = map { &canonicalize_ip6($_) } &active_ip_addresses();
+my @acts = map { &canonicalize_ip6($_) } &active_ip_addresses();
 if (&indexoflc(&canonicalize_ip6($d->{'ip6'}), @acts) < 0) {
 	return &text('validate_evirt6a', $d->{'ip6'});
 	}
@@ -152,7 +152,7 @@ return undef;
 # Returns 1 if some IPv6 is already in use, 0 if not
 sub check_virt6_clash
 {
-local ($ip6) = @_;
+my ($ip6) = @_;
 
 # Check interfaces
 foreach my $i (&active_ip6_interfaces(), &boot_ip6_interfaces()) {
@@ -162,8 +162,8 @@ foreach my $i (&active_ip6_interfaces(), &boot_ip6_interfaces()) {
 
 # Do a quick ping test
 if (&has_command("ping6")) {
-	local $pingcmd = "ping6 -c 1 -t 1";
-	local ($out, $timed_out) = &backquote_with_timeout(
+	my $pingcmd = "ping6 -c 1 -t 1";
+	my ($out, $timed_out) = &backquote_with_timeout(
 					$pingcmd." ".$ip6." 2>&1", 2, 1);
 	return 1 if (!$timed_out && !$?);
 	}
@@ -176,10 +176,10 @@ return 0;
 # Returns HTML for selecting a virtual IPv6 mode for a new server, or not
 sub virtual_ip6_input
 {
-local ($tmpls, $resel, $orig, $mode) = @_;
+my ($tmpls, $resel, $orig, $mode) = @_;
 $mode ||= 0;
-local $defip6 = &get_default_ip6($resel);
-local ($t, $anyalloc, $anychoose, $anyzone);
+my $defip6 = &get_default_ip6($resel);
+my ($t, $anyalloc, $anychoose, $anyzone);
 if (&running_in_zone() || &running_in_vserver()) {
 	# When running in a Solaris zone or VServer, you MUST select an
 	# existing active IP, as they are controlled from the host.
@@ -189,12 +189,12 @@ elsif (&can_use_feature("virt6")) {
 	# Check if private IPs are allocated or manual, if we are
 	# allowed to choose them.
 	foreach $t (@$tmpls) {
-		local $tmpl = &get_template($t->{'id'});
+		my $tmpl = &get_template($t->{'id'});
 		if ($tmpl->{'ranges6'} ne "none") { $anyalloc++; }
 		else { $anychoose++; }
 		}
 	}
-local @opts;
+my @opts;
 push(@opts, [ -2, $text{'edit_virt6off'} ]);
 if ($orig) {
 	# For restores - option to use original IP
@@ -203,7 +203,7 @@ if ($orig) {
 if ($defip6) {
 	push(@opts, [ 0, &text('form_shared', $defip6) ]);
 	}
-local @shared = sort { $a cmp $b } &list_shared_ip6s();
+my @shared = sort { $a cmp $b } &list_shared_ip6s();
 if (@shared && &can_edit_sharedips()) {
 	# Can select from extra shared list
 	push(@opts, [ 3, $text{'form_shared2'},
@@ -224,7 +224,7 @@ if ($anychoose) {
 if ($anyzone) {
 	# Can select an existing active IP, for inside a Solaris zone
 	&foreign_require("net");
-	local @act = grep { $_->{'virtual'} ne '' }
+	my @act = grep { $_->{'virtual'} ne '' }
 			  &net::active_interfaces();
 	if (@act) {
 		push(@opts, [ 4, $text{'form_activeip'},
@@ -253,7 +253,7 @@ return &ui_radio_table("virt6", $mode, \@opts, 1);
 # already flag and netmask. May call &error if the input is invalid.
 sub parse_virtual_ip6
 {
-local ($tmpl, $resel) = @_;
+my ($tmpl, $resel) = @_;
 if ($in{'virt6'} == -2) {
 	# Completely disabled
 	return ( );
@@ -264,16 +264,16 @@ elsif ($in{'virt6'} == 2) {
 	if ($resel) {
 		# Creating by or under a reseller .. use his range, if any
 		foreach my $r (split(/\s+/, $resel)) {
-			local %acl = &get_reseller_acl($r);
+			my %acl = &get_reseller_acl($r);
 			if ($acl{'ranges6'}) {
-				local ($ip,$netmask) = &free_ip6_address(\%acl);
+				my ($ip,$netmask) = &free_ip6_address(\%acl);
 				$ip || &error(&text('setup_evirtalloc'));
 				return ($ip, 1, 0, $netmask);
 				}
 			}
 		}
 	$tmpl->{'ranges6'} ne "none" || &error(&text('setup_evirttmpl'));
-	local ($ip, $netmask) = &free_ip6_address($tmpl);
+	my ($ip, $netmask) = &free_ip6_address($tmpl);
 	$ip || &error(&text('setup_evirtalloc'));
 	return ($ip, 1, 0, $netmask);
 	}
@@ -281,12 +281,12 @@ elsif ($in{'virt6'} == 1) {
 	# Manual IP allocation chosen
 	$tmpl->{'ranges6'} eq "none" || &error(&text('setup_evirttmpl2'));
 	&check_ip6address($in{'ip6'}) || &error($text{'setup_eip'});
-	local $clash = &check_virt6_clash($in{'ip6'});
+	my $clash = &check_virt6_clash($in{'ip6'});
 	if ($in{'virt6already'}) {
 		# Fail if the IP isn't yet active, or if claimed by another
 		# virtual server
 		$clash || &error(&text('setup_evirtclash2', $in{'ip6'}));
-		local $already = &get_domain_by("ip6", $in{'ip6'});
+		my $already = &get_domain_by("ip6", $in{'ip6'});
 		$already && &error(&text('setup_evirtclash4',
 					 $already->{'dom'}));
 		}
@@ -306,21 +306,21 @@ elsif ($in{'virt6'} == 4 && (&running_in_zone() || &running_in_vserver())) {
 	# On an active IP on a virtual machine that cannot bring up its
 	# own IP.
 	&check_ip6address($in{'zoneip6'}) || &error($text{'setup_eip'});
-	local $clash = &check_virt6_clash($in{'zoneip6'});
+	my $clash = &check_virt6_clash($in{'zoneip6'});
 	$clash || &error(&text('setup_evirtclash2', $in{'zoneip6'}));
-	local $already = &get_domain_by("ip6", $in{'ip6'});
+	my $already = &get_domain_by("ip6", $in{'ip6'});
 	$already && &error(&text('setup_evirtclash4',
 				 $already->{'dom'}));
 	return ($in{'zoneip6'}, 1, 1);
 	}
 elsif ($in{'virt6'} == 5) {
 	# Allocate if needed, shared otherwise
-	local ($ip, $netmask) = &free_ip6_address($tmpl);
+	my ($ip, $netmask) = &free_ip6_address($tmpl);
 	return ($ip, 1, 0, $netmask);
 	}
 else {
 	# Global shared IP
-	local $defip = &get_default_ip6($resel);
+	my $defip = &get_default_ip6($resel);
 	return ($defip, 0, 0);
 	}
 }
@@ -330,7 +330,7 @@ else {
 sub active_ip6_interfaces
 {
 &foreign_require("net");
-local @rv;
+my @rv;
 foreach my $i (&net::active_interfaces()) {
 	next if (!$i->{'address6'});
 	for(my $j=0; $j<@{$i->{'address6'}}; $j++) {
@@ -347,7 +347,7 @@ return @rv;
 sub boot_ip6_interfaces
 {
 &foreign_require("net");
-local @rv;
+my @rv;
 foreach my $i (&net::boot_interfaces()) {
 	next if (!$i->{'address6'});
 	for(my $j=0; $j<@{$i->{'address6'}}; $j++) {
@@ -363,7 +363,7 @@ return @rv;
 # Activate an IPv6 address right now. Calls error on failure.
 sub activate_ip6_interface
 {
-local ($iface) = @_;
+my ($iface) = @_;
 &foreign_require("net");
 if (&auto_apply_interface()) {
 	&net::apply_network();
@@ -382,7 +382,7 @@ else {
 # Record an IPv6 address for activation at boot time
 sub save_ip6_interface
 {
-local ($iface) = @_;
+my ($iface) = @_;
 &foreign_require("net");
 my @boot = &net::boot_interfaces();
 my ($boot) = grep { $_->{'fullname'} eq $iface->{'name'} } @boot;
@@ -396,7 +396,7 @@ push(@{$boot->{'netmask6'}}, $iface->{'netmask'});
 # Removes an IPv6 address that is currently active. Calls error on failure.
 sub deactivate_ip6_interface
 {
-local ($iface) = @_;
+my ($iface) = @_;
 if (&auto_apply_interface()) {
 	&net::apply_network();
 	}
@@ -423,7 +423,7 @@ else {
 # Removes an IPv6 address that is activated at boot time
 sub delete_ip6_interface
 {
-local ($iface) = @_;
+my ($iface) = @_;
 my @boot = &net::boot_interfaces();
 my ($boot) = grep { $_->{'fullname'} eq $iface->{'name'} } @boot;
 $boot || &error("No boot interface found for $iface->{'name'}");
@@ -448,8 +448,8 @@ sub ip6_interfaces_file
 {
 if ($gconfig{'os_type'} eq 'redhat-linux') {
 	# On redhat, this is typically the ifcfg-eth0 file
-	local $ifacename = $config{'iface6'} || $config{'iface'};
-	local ($boot) = grep { $_->{'fullname'} eq $ifacename }
+	my $ifacename = $config{'iface6'} || $config{'iface'};
+	my ($boot) = grep { $_->{'fullname'} eq $ifacename }
 			     &net::boot_interfaces();
 	return $boot->{'file'} if ($boot);
 	}

--- a/feature-virus.pl
+++ b/feature-virus.pl
@@ -19,11 +19,11 @@ sub setup_virus
 &obtain_lock_virus($_[0]);
 &require_spam();
 
-local $spamrc = "$procmail_spam_dir/$_[0]->{'id'}";
+my $spamrc = "$procmail_spam_dir/$_[0]->{'id'}";
 
 # Find the clamscan recipe
-local @recipes = &procmail::parse_procmail_file($spamrc);
-local @clamrec = &find_clam_recipe(\@recipes);
+my @recipes = &procmail::parse_procmail_file($spamrc);
+my @clamrec = &find_clam_recipe(\@recipes);
 if (@clamrec) {
 	# Already there?
 	&$second_print($text{'setup_virusalready'});
@@ -34,14 +34,14 @@ else {
 	&create_clamdscan_remote_wrapper_cmd();
 
 	# Add the recipe
-	local $recipe0 = { 'flags' => [ 'c', 'w' ],
+	my $recipe0 = { 'flags' => [ 'c', 'w' ],
 			   'type' => '|',
 			   'action' => $clam_wrapper_cmd." ".
 				       &full_clamscan_path() };
-	local $varon = { 'name' => 'VIRUSMODE', 'value' => 1 };
-	local $recipe1 = { 'flags' => [ 'e' ],
+	my $varon = { 'name' => 'VIRUSMODE', 'value' => 1 };
+	my $recipe1 = { 'flags' => [ 'e' ],
 			   'action' => $config{'clam_delivery'} };
-	local $varoff = { 'name' => 'VIRUSMODE', 'value' => 0 };
+	my $varoff = { 'name' => 'VIRUSMODE', 'value' => 0 };
 	if (@recipes > 1) {
 		&procmail::create_recipe_before($recipe0, $recipes[1], $spamrc);
 		&procmail::create_recipe_before($varon, $recipes[1], $spamrc);
@@ -70,7 +70,7 @@ sub modify_virus
 # Just remove the procmail entry that calls clamscan
 sub delete_virus
 {
-local $spamrc = "$procmail_spam_dir/$_[0]->{'id'}";
+my $spamrc = "$procmail_spam_dir/$_[0]->{'id'}";
 if (!-r $spamrc && !$_[0]->{'spam'}) {
 	# Spam already deleted, so the whole procmail file will have been
 	# already removed. So do nothing!
@@ -79,8 +79,8 @@ if (!-r $spamrc && !$_[0]->{'spam'}) {
 &$first_print($text{'delete_virus'});
 &obtain_lock_virus($_[0]);
 &require_spam();
-local @recipes = &procmail::parse_procmail_file($spamrc);
-local @clamrec = &find_clam_recipe(\@recipes);
+my @recipes = &procmail::parse_procmail_file($spamrc);
+my @clamrec = &find_clam_recipe(\@recipes);
 if (@clamrec) {
 	&procmail::delete_recipe($clamrec[1]);
 	&procmail::delete_recipe($clamrec[0]);
@@ -120,12 +120,12 @@ sub copy_clam_wrapper
 # Make sure the domain's procmail config file calls ClamAV
 sub validate_virus
 {
-local ($d) = @_;
+my ($d) = @_;
 &require_spam();
-local $spamrc = "$procmail_spam_dir/$d->{'id'}";
+my $spamrc = "$procmail_spam_dir/$d->{'id'}";
 return &text('validate_espamprocmail', "<tt>$spamrc</tt>") if (!-r $spamrc);
-local @recipes = &procmail::parse_procmail_file($spamrc);
-local @clamrec = &find_clam_recipe(\@recipes);
+my @recipes = &procmail::parse_procmail_file($spamrc);
+my @clamrec = &find_clam_recipe(\@recipes);
 return &text('validate_evirus', "<tt>$spamrc</tt>") if (!@clamrec);
 return undef;
 }
@@ -141,7 +141,7 @@ return 0;
 # Returns the two recipes used for virus filtering
 sub find_clam_recipe
 {
-local $i;
+my $i;
 for($i=0; $i<@{$_[0]}; $i++) {
 	if ($_[0]->[$i]->{'action'} =~ /clam(d?)scan/ ||
 	    $_[0]->[$i]->{'action'} =~ /\Q$clam_wrapper_cmd\E/) {
@@ -161,8 +161,8 @@ return ( );
 # Returns the ClamAV version
 sub sysinfo_virus
 {
-local $out = &backquote_command("$config{'clamscan_cmd'} -V 2>/dev/null", 1);
-local $vers = $out =~ /ClamAV\s+([0-9\.]+)/i ? $1 : "Unknown";
+my $out = &backquote_command("$config{'clamscan_cmd'} -V 2>/dev/null", 1);
+my $vers = $out =~ /ClamAV\s+([0-9\.]+)/i ? $1 : "Unknown";
 return ( [ $text{'sysinfo_virus'}, $vers ] );
 }
 
@@ -172,9 +172,9 @@ sub fix_clam_wrapper
 {
 &require_spam();
 foreach my $d (grep { $_->{'virus'} } &list_domains()) {
-	local $spamrc = "$procmail_spam_dir/$d->{'id'}";
-	local @recipes = &procmail::parse_procmail_file($spamrc);
-	local @clamrec = &find_clam_recipe(\@recipes);
+	my $spamrc = "$procmail_spam_dir/$d->{'id'}";
+	my @recipes = &procmail::parse_procmail_file($spamrc);
+	my @clamrec = &find_clam_recipe(\@recipes);
 	if ($clamrec[0]->{'action'} !~ /\Q$clam_wrapper_cmd\E/ &&
 	    $clamrec[0]->{'action'} =~ /^(\S*clam(d?)scan)\s+\-$/) {
 		$clamrec[0]->{'action'} = "$clam_wrapper_cmd $1";
@@ -190,11 +190,11 @@ foreach my $d (grep { $_->{'virus'} } &list_domains()) {
 # -1 - Broken!
 sub get_domain_virus_delivery
 {
-local ($d) = @_;
+my ($d) = @_;
 &require_spam();
-local $spamrc = "$procmail_spam_dir/$d->{'id'}";
-local @recipes = &procmail::parse_procmail_file($spamrc);
-local @clamrec = &find_clam_recipe(\@recipes);
+my $spamrc = "$procmail_spam_dir/$d->{'id'}";
+my @recipes = &procmail::parse_procmail_file($spamrc);
+my @clamrec = &find_clam_recipe(\@recipes);
 if (!@clamrec) {
 	return (-1);
 	}
@@ -225,16 +225,16 @@ else {
 # Updates the delivery method for viruses for some domain
 sub save_domain_virus_delivery
 {
-local ($d, $mode, $dest) = @_;
+my ($d, $mode, $dest) = @_;
 &require_spam();
-local $spamrc = "$procmail_spam_dir/$d->{'id'}";
-local @recipes = &procmail::parse_procmail_file($spamrc);
-local @clamrec = &find_clam_recipe(\@recipes);
+my $spamrc = "$procmail_spam_dir/$d->{'id'}";
+my @recipes = &procmail::parse_procmail_file($spamrc);
+my @clamrec = &find_clam_recipe(\@recipes);
 return 0 if (!@clamrec);
-local $r = $clamrec[1];
+my $r = $clamrec[1];
 
 # Preserve existing settings if not set
-local ($oldmode, $olddest) = &get_domain_virus_delivery($d);
+my ($oldmode, $olddest) = &get_domain_virus_delivery($d);
 if (!defined($mode)) {
 	($mode, $dest) = ($oldmode, $olddest);
 	}
@@ -243,7 +243,7 @@ elsif (!defined($dest)) {
 	}
 
 # Work out folder name, defaulting to upper case
-local $folder;
+my $folder;
 if ($mode == 4 || $mode == 6) {
 	if ($dest =~ /^[a-z0-9\.\_\-]+$/i) {
 		$folder = $dest;
@@ -266,7 +266,7 @@ return 1;
 # Returns the clamav scan command, using the full path plus any args
 sub full_clamscan_path
 {
-local $prog = $config{'clamscan_cmd'};
+my $prog = $config{'clamscan_cmd'};
 if ($prog eq "clamd-stream-client") {
 	$prog .= &make_stream_client_args($config{'clamscan_host'});
 	}
@@ -277,10 +277,10 @@ elsif ($prog eq "clamdscan-remote") {
 	$prog = $clamdscan_remote_wrapper_cmd.
 		&make_stream_client_args($config{'clamscan_host'});
 	}
-local ($cmd, @args) = &split_quoted_string($prog);
-local $fullcmd = &has_command($cmd);
+my ($cmd, @args) = &split_quoted_string($prog);
+my $fullcmd = &has_command($cmd);
 return undef if (!$fullcmd);
-local @rv = ( $fullcmd, @args );
+my @rv = ( $fullcmd, @args );
 return join(" ", map { /\s/ ? "\"$_\"" : $_ } @rv);
 }
 
@@ -304,7 +304,7 @@ return $rv;
 # Returns any extra args needed for clamdscan, like for the config file
 sub get_clamdscan_args
 {
-local $scanfile = "/etc/clamd.d/scan.conf";
+my $scanfile = "/etc/clamd.d/scan.conf";
 &foreign_require("init");
 if (-r $scanfile && (&init::action_status("clamd\@scan") ||
 		     &init::action_status("clamd.scan"))) {
@@ -318,15 +318,15 @@ return undef;
 # clamdscan or some other path.
 sub get_domain_virus_scanner
 {
-local ($d) = @_;
+my ($d) = @_;
 &require_spam();
-local $spamrc = "$procmail_spam_dir/$d->{'id'}";
-local @recipes = &procmail::parse_procmail_file($spamrc);
-local @clamrec = &find_clam_recipe(\@recipes);
+my $spamrc = "$procmail_spam_dir/$d->{'id'}";
+my @recipes = &procmail::parse_procmail_file($spamrc);
+my @clamrec = &find_clam_recipe(\@recipes);
 if (@clamrec) {
-	local $rv = $clamrec[0]->{'action'};
+	my $rv = $clamrec[0]->{'action'};
 	$rv =~ s/^\Q$clam_wrapper_cmd\E\s+//;
-	local @rvs = &split_quoted_string($rv);
+	my @rvs = &split_quoted_string($rv);
 	if ($rvs[0] eq &has_command("clamscan")) {
 		$rv = "clamscan";
 		}
@@ -350,11 +350,11 @@ else {
 # Updates the virus scanning program in the procmail config
 sub save_domain_virus_scanner
 {
-local ($d, $prog) = @_;
+my ($d, $prog) = @_;
 &require_spam();
-local $spamrc = "$procmail_spam_dir/$d->{'id'}";
-local @recipes = &procmail::parse_procmail_file($spamrc);
-local @clamrec = &find_clam_recipe(\@recipes);
+my $spamrc = "$procmail_spam_dir/$d->{'id'}";
+my @recipes = &procmail::parse_procmail_file($spamrc);
+my @clamrec = &find_clam_recipe(\@recipes);
 if (@clamrec) {
 	if ($prog eq "clamscan") {
 		$prog = &has_command("clamscan");
@@ -416,7 +416,7 @@ else {
 # Update all domains to use a new scanning command
 sub save_global_virus_scanner
 {
-local ($cmd, $host) = @_;
+my ($cmd, $host) = @_;
 $config{'clamscan_cmd'} = $cmd;
 $config{'clamscan_cmd_global'} = 1;
 $config{'clamscan_host'} = $host;
@@ -433,8 +433,8 @@ foreach my $d (grep { $_->{'virus'} } &list_domains()) {
 # that it is working but slow.
 sub test_virus_scanner
 {
-local ($cmd, $host) = @_;
-local $fullcmd = $cmd;
+my ($cmd, $host) = @_;
+my $fullcmd = $cmd;
 if ($cmd eq "clamd-stream-client") {
 	# Set remote host
 	$fullcmd .= &make_stream_client_args($host);
@@ -451,7 +451,7 @@ else {
 		}
 	$fullcmd .= " -";
 	}
-local ($out, $timed_out) =
+my ($out, $timed_out) =
 	&backquote_with_timeout("$fullcmd </dev/null 2>&1", 10, 1);
 if ($timed_out) {
 	return undef;
@@ -472,14 +472,14 @@ else {
 # 1 if yes, or -1 if we can't tell (due to a non-supported OS).
 sub check_clamd_status
 {
-local %avahi_pids = map { $_, 1 }
+my %avahi_pids = map { $_, 1 }
 			grep { $_ != $$ } &find_byname("avahi-daemon");
-local @pids = grep { $_ != $$ && !$avahi_pids{$_} } &find_byname("clamd");
+my @pids = grep { $_ != $$ && !$avahi_pids{$_} } &find_byname("clamd");
 if (@pids) {
 	# Running already, so we assume everything is cool
 	return 1;
 	}
-local $clamd = &has_command("clamd") ||
+my $clamd = &has_command("clamd") ||
 	       &has_command("/opt/csw/sbin/clamd");
 if (!$clamd) {
 	# No installed
@@ -516,11 +516,11 @@ return -1;
 # standard functions.
 sub enable_clamd
 {
-local $st = &check_clamd_status();
+my $st = &check_clamd_status();
 return 1 if ($st == 1 || $st == -1);
 
 # Check for simple init scripts
-local $init;
+my $init;
 &foreign_require("init");
 foreach my $i ("clamav-daemon", "clamdscan-clamd", "clamav-clamd", "clamd", "clamd\@scan") {
 	if (&init::action_status($i)) {
@@ -533,10 +533,10 @@ foreach my $i ("clamav-daemon", "clamdscan-clamd", "clamav-clamd", "clamd", "cla
 foreach my $c ("/etc/clamd.conf", "/etc/clamd.d/scan.conf",
 	       "/etc/clamd.d/virtualmin.conf") {
 	next if (!-r $c);
-	local $lref = &read_file_lines($c);
-	local $sfile;
-	local $clamuser;
-	local $added_socketmode = 0;
+	my $lref = &read_file_lines($c);
+	my $sfile;
+	my $clamuser;
+	my $added_socketmode = 0;
 	foreach my $l (@$lref) {
 		if ($l =~ /^\s*LocalSocket\s+(\S+)/) {
 			$sfile = $1;
@@ -554,7 +554,7 @@ foreach my $c ("/etc/clamd.conf", "/etc/clamd.d/scan.conf",
 		}
 	&flush_file_lines($c);
 	if ($sfile =~ /^(\S+)\/([^\/]+)$/) {
-		local $sdir = $1;
+		my $sdir = $1;
 		if (!-d $sdir) {
 			if ($clamuser) {
 				&make_dir($sdir, 0755);
@@ -576,7 +576,7 @@ foreach my $c ("/etc/clamd.conf", "/etc/clamd.d/scan.conf",
 if (&init::action_status('clamav-freshclam')) {
 	&$first_print(&text('clamd_start_updater'));
 	&init::enable_at_boot('clamav-freshclam');
-	local ($ok, $out) = &init::restart_action('clamav-freshclam');
+	my ($ok, $out) = &init::restart_action('clamav-freshclam');
 	if (!$ok || $out =~ /failed|error/i) {
 		&$second_print(&text('clamd_estart',
 				"<tt>".&html_escape($out)."</tt>"));
@@ -592,7 +592,7 @@ if ($init) {
 	&$first_print(&text('clamd_start'));
 	if (&init::action_status($init)) {
 		&init::enable_at_boot($init);
-		local ($ok, $out) = &init::restart_action($init);
+		my ($ok, $out) = &init::restart_action($init);
 		if (!$ok || $out =~ /failed|error/i) {
 			&$second_print(&text('clamd_estart',
 					"<tt>".&html_escape($out)."</tt>"));
@@ -608,24 +608,24 @@ if ($init) {
 
 elsif (&init::action_status("clamd-wrapper")) {
         # Looks like a Redhat system .. start by creating the .conf file
-	local $service = "virtualmin";
-	local $cfile = "/etc/clamd.d/$service.conf";
-	local $srcpat = "/usr/share/doc/clamav-server-*/clamd.conf";
-	local ($srcfile) = glob($srcpat);
+	my $service = "virtualmin";
+	my $cfile = "/etc/clamd.d/$service.conf";
+	my $srcpat = "/usr/share/doc/clamav-server-*/clamd.conf";
+	my ($srcfile) = glob($srcpat);
 	&$first_print(&text('clamd_copyconf', "<tt>$cfile</tt>"));
 	if (!$srcfile && !-r $cfile) {
 		&$second_print(&text('clamd_esrcfile', "<tt>$srcpat</tt>"));
 		return 0;
 		}
-	local $user = "nobody";
-	local @uinfo = getgrnam($user);
-	local $group = getgrgid($uinfo[3]);
+	my $user = "nobody";
+	my @uinfo = getgrnam($user);
+	my $group = getgrgid($uinfo[3]);
 	&lock_file($cfile);
 	if (!-r $cfile) {
 		&copy_source_dest($srcfile, $cfile);
 		}
-	local $lref = &read_file_lines($cfile);
-	local ($logfile, $socketfile);
+	my $lref = &read_file_lines($cfile);
+	my ($logfile, $socketfile);
 	foreach my $l (@$lref) {
 		if ($l =~ /^\s*Example/) {
 			$l = "# Example";
@@ -646,7 +646,7 @@ elsif (&init::action_status("clamd-wrapper")) {
 		}
 	&flush_file_lines($cfile);
 	&unlock_file($cfile);
-	local $othercfile = "/etc/clamd.conf";
+	my $othercfile = "/etc/clamd.conf";
 	if (!-r $othercfile) {
 		&symlink_logged($cfile, $othercfile);
 		}
@@ -661,7 +661,7 @@ elsif (&init::action_status("clamd-wrapper")) {
 
 	# Create directory for socket file
 	if ($socketfile) {
-		local $socketdir = $socketfile;
+		my $socketdir = $socketfile;
 		$socketdir =~ s/\/[^\/]+$//;
 		if (!-d $socketdir) {
 			&make_dir($socketdir, 0755);
@@ -671,14 +671,14 @@ elsif (&init::action_status("clamd-wrapper")) {
 		}
 
 	# Copy and fix the init wrapper script
-	local $srcifile = &init::action_filename("clamd-wrapper");
-	local $ifile = &init::action_filename("clamd-virtualmin");
+	my $srcifile = &init::action_filename("clamd-wrapper");
+	my $ifile = &init::action_filename("clamd-virtualmin");
 	&$first_print(&text('clamd_initscript', "<tt>$ifile</tt>"));
 	if (-r $srcifile && !-r $ifile) {
 		&copy_source_dest($srcifile, $ifile);
 		}
-	local $lref = &read_file_lines($ifile);
-	local ($already) = grep { /^CLAMD_SERVICE=/ } @$lref;
+	my $lref = &read_file_lines($ifile);
+	my ($already) = grep { /^CLAMD_SERVICE=/ } @$lref;
 	if ($already) {
 		&$second_print($text{'clamd_initalready'});
 		}
@@ -706,8 +706,8 @@ elsif (&init::action_status("clamd-wrapper")) {
 		}
 
 	# Link the clamd program
-	local $clamd = &has_command("clamd");
-	local $clamdcopy = $clamd.".".$service;
+	my $clamd = &has_command("clamd");
+	my $clamdcopy = $clamd.".".$service;
 	&$first_print(&text('clamd_linkbin', "<tt>$clamdcopy</tt>"));
 	&unlink_file($clamdcopy);
 	&symlink_logged($clamd, $clamdcopy);
@@ -722,7 +722,7 @@ elsif (&init::action_status("clamd-wrapper")) {
 	&$first_print(&text('clamd_start'));
 	&init::enable_at_boot("clamd-virtualmin");
 	&init::disable_at_boot("clamd-wrapper");
-	local ($ok, $out);
+	my ($ok, $out);
 	if (defined(&init::start_action)) {
 		($ok, $out) = &init::start_action($init);
 		}
@@ -741,8 +741,8 @@ elsif (&init::action_status("clamd-wrapper")) {
 
 elsif (-r "/opt/csw/etc/clamd.conf.CSW") {
 	# Solaris CSW package .. copy config file
-	local $cfile = "/opt/csw/etc/clamd.conf";
-	local $srcfile = "/opt/csw/etc/clamd.conf.CSW";
+	my $cfile = "/opt/csw/etc/clamd.conf";
+	my $srcfile = "/opt/csw/etc/clamd.conf.CSW";
 	&$first_print(&text('clamd_copyconf', "<tt>$cfile</tt>"));
 	if (-r $cfile) {
 		&$second_print($text{'clamd_esrcalready'});
@@ -754,8 +754,8 @@ elsif (-r "/opt/csw/etc/clamd.conf.CSW") {
 
 	# Create the log directory
 	&$first_print($text{'clamd_logdir'});
-	local $lref = &read_file_lines($cfile);
-	local ($logfile, $user);
+	my $lref = &read_file_lines($cfile);
+	my ($logfile, $user);
 	foreach my $l (@$lref) {
 		if ($l =~ /^\s*LogFile\s+(\S+)/i) {
 			$logfile = $1;
@@ -768,7 +768,7 @@ elsif (-r "/opt/csw/etc/clamd.conf.CSW") {
 		&$second_print($text{'clamd_logalready'});
 		}
 	elsif ($logfile) {
-		local $logdir = $logfile;
+		my $logdir = $logfile;
 		$logdir =~ s/\/[^\/]+$//;
 		&make_dir($logdir, 0700);
 		if ($user) {
@@ -785,14 +785,14 @@ elsif (-r "/opt/csw/etc/clamd.conf.CSW") {
 
 	# Create or enable bootup action
 	&$first_print(&text('clamd_start'));
-	local $init = "clamd-csw";
-	local $clamd = &has_command("clamd") ||
+	my $init = "clamd-csw";
+	my $clamd = &has_command("clamd") ||
 		       &has_command("/opt/csw/sbin/clamd");
 	&init::enable_at_boot($init, "Start ClamAV server",
 			      $clamd,
 			      "ps -ef | grep clamd | grep -v grep | grep -v \$\$ | awk '{ print \$2 }' | xargs kill");
-	local $ifile = &init::action_filename($init);
-	local $out = &backquote_logged("$ifile start 2>&1");
+	my $ifile = &init::action_filename($init);
+	my $out = &backquote_logged("$ifile start 2>&1");
 	if ($? || $out =~ /failed|error/i) {
 		&$second_print(&text('clamd_estart',
 				"<tt>".&html_escape($out)."</tt>"));
@@ -816,7 +816,7 @@ foreach my $init ("clamdscan-clamd", "clamav-daemon", "clamd-virtualmin",
 	if (&init::action_status($init)) {
 		&$first_print(&text('clamd_stop'));
 		&init::disable_at_boot($init);
-		local ($ok, $out) = &init::stop_action($init);
+		my ($ok, $out) = &init::stop_action($init);
 		if (!$ok || $out =~ /failed|error/i) {
 			&$second_print(&text('clamd_estop',
 					"<tt>".&html_escape($out)."</tt>"));
@@ -834,13 +834,13 @@ return 0;
 # and long descriptions for the action to switch statuses
 sub startstop_virus
 {
-local ($scanner, $host) = &get_global_virus_scanner();
+my ($scanner, $host) = &get_global_virus_scanner();
 if (!($scanner eq 'clamdscan' ||
       $scanner eq 'clamd-stream-client' && !$host)) {
 	# Clamd isn't being used
 	return ( );
 	}
-local @pids = grep { $_ != $$ } &find_byname("clamd");
+my @pids = grep { $_ != $$ } &find_byname("clamd");
 if (@pids) {
 	return ( { 'status' => 1,
 		   'name' => $text{'index_clamname'},
@@ -863,7 +863,7 @@ sub start_service_virus
 {
 &push_all_print();
 &set_all_null_print();
-local $rv = &enable_clamd();
+my $rv = &enable_clamd();
 &pop_all_print();
 return $rv ? undef : $text{'clamd_estartmsg'};
 }
@@ -878,11 +878,11 @@ foreach my $init ("clamdscan-clamd", "clamav-daemon", "clamd-virtualmin",
 		  "clamd-wrapper", "clamd-csw", "clamav-clamd", "clamd",
 		  "clamd\@scan") {
 	if (&init::action_status($init)) {
-		local ($ok, $out) = &init::stop_action($init);
+		my ($ok, $out) = &init::stop_action($init);
 		return $ok ? undef : "<tt>".&html_escape($out)."</tt>";
 		}
 	}
-local @pids = grep { $_ != $$ } &find_byname("clamd");
+my @pids = grep { $_ != $$ } &find_byname("clamd");
 if (@pids) {
 	if (&kill_logged('TERM', @pids)) {
 		return undef;

--- a/feature-web.pl
+++ b/feature-web.pl
@@ -495,7 +495,7 @@ if ($mode eq "fpm") {
 	}
 
 # Update session dir and upload path in php.ini files
-local @fixes = (
+my @fixes = (
 	[ "session.save_path", $oldd->{'home'}, $d->{'home'}, 1 ],
 	[ "upload_tmp_dir", $oldd->{'home'}, $d->{'home'}, 1 ],
 	);
@@ -1059,7 +1059,7 @@ if ($d->{'alias'} && $d->{'alias_mode'} == 1) {
 &require_apache();
 &obtain_lock_web($d);
 my ($virt, $vconf) = &get_apache_virtual($d->{'dom'}, $d->{'web_port'});
-local $ok;
+my $ok;
 if ($virt) {
 	&create_disable_directives($virt, $vconf, $d);
 	&$second_print($text{'setup_done'});
@@ -1306,7 +1306,7 @@ my ($dname, $port, $errorlog) = @_;
 &require_apache();
 my ($virt, $vconf) = &get_apache_virtual($dname, $port);
 if ($virt) {
-	local $log;
+	my $log;
 	if ($errorlog) {
 		# Looking for error log
 		$log = &apache::find_directive("ErrorLog", $vconf);
@@ -1412,7 +1412,7 @@ foreach my $v (&apache::find_directive_struct("VirtualHost", $conf)) {
 					        lc($sn) eq "www.$dname");
 	foreach my $n (&apache::find_directive_struct(
 			"ServerAlias", $v->{'members'})) {
-		local @lcw = map { lc($_) } @{$n->{'words'}};
+		my @lcw = map { lc($_) } @{$n->{'words'}};
 		return ($v, $v->{'members'}, $conf)
 			if (&indexof($dname, @lcw) >= 0 ||
 			    &indexof("www.$dname", @lcw) >= 0);
@@ -2153,15 +2153,15 @@ return undef;	# won't happen!
 sub sysinfo_web
 {
 &require_apache();
-local $ver = $apache::httpd_modules{'core'};
+my $ver = $apache::httpd_modules{'core'};
 $ver =~ s/^(\d+)\.(\d)(\d+)$/$1.$2.$3/;
-local @rv = ( [ $text{'sysinfo_apache'}, $ver ] );
+my @rv = ( [ $text{'sysinfo_apache'}, $ver ] );
 if (defined(&list_available_php_versions)) {
-	local @avail = &list_available_php_versions();
-	local @vers;
+	my @avail = &list_available_php_versions();
+	my @vers;
 	foreach my $a (grep { $_->[1] } @avail) {
 		&clean_environment();
-		local $out = &backquote_command(quotemeta($a->[1]).
+		my $out = &backquote_command(quotemeta($a->[1]).
 						" -v 2>&1 </dev/null");
 		&reset_environment();
 		if ($out =~ /PHP\s+([0-9\.]+)/) {
@@ -2186,15 +2186,15 @@ return @rv;
 # Returns 1 if there is a NameVirtualHost directive for *, 0 if not.
 sub add_name_virtual
 {
-local ($d, $conf, $web_port, $no_star_match, $ip) = @_;
+my ($d, $conf, $web_port, $no_star_match, $ip) = @_;
 &require_apache();
 if ($apache::httpd_modules{'core'} >= 2.4) {
 	# Apache 2.4 doesn't need NameVirtualHost any more.
 	# However, check if all existing <VirtualHost>s uses *, which means that
 	# subsequent ones should as well. Otherwise, they can just use IPs.
-	local @virt = &apache::find_directive_struct("VirtualHost", $conf);
-	local $starcount = 0;
-	local $ipcount = 0;
+	my @virt = &apache::find_directive_struct("VirtualHost", $conf);
+	my $starcount = 0;
+	my $ipcount = 0;
 	foreach my $v (@virt) {
 		foreach my $w (@{$v->{'words'}}) {
 			if ($w =~ /^(\*|_DEFAULT_)(:(\d+))?/i &&
@@ -2215,13 +2215,13 @@ if ($apache::httpd_modules{'core'} >= 2.4) {
 		}
 	return $ipcount ? 0 : 1;
 	}
-local $nvstar;
+my $nvstar;
 if ($d->{'name'}) {
-	local ($found, $found_no_port);
-	local $defport = &apache::find_directive("Port", $conf);
+	my ($found, $found_no_port);
+	my $defport = &apache::find_directive("Port", $conf);
 	$defport ||= 80;
-	local @nv = &apache::find_directive("NameVirtualHost", $conf);
-	local $canstar = $apache::httpd_modules{'core'} < 2.2;
+	my @nv = &apache::find_directive("NameVirtualHost", $conf);
+	my $canstar = $apache::httpd_modules{'core'} < 2.2;
 	foreach my $nv (@nv) {
 		$found++ if ($nv =~ /^([0-9\.]+):(\S+)/ &&   # Like x.x.x.x:80
 			      $1 eq $ip &&
@@ -2255,13 +2255,13 @@ return $nvstar;
 # Adds a Listen directive for some domain's port, if needed
 sub add_listen
 {
-local ($d, $conf, $web_port) = @_;
+my ($d, $conf, $web_port) = @_;
 &require_apache();
 foreach my $dip ($d->{'ip'} ? ( $d->{'ip'} ) : ( ),
 		 $d->{'ip6'} ? ( $d->{'ip6'} ) : ( )) {
-	local $defport = &apache::find_directive("Port", $conf) || 80;
-	local @listen = &apache::find_directive("Listen", $conf);
-	local $lfound;
+	my $defport = &apache::find_directive("Port", $conf) || 80;
+	my @listen = &apache::find_directive("Listen", $conf);
+	my $lfound;
 	foreach my $l (@listen) {
 		$l =~ s/\s\S+$//;	# Remove trailing port name
 		$lfound++ if (($l eq '*' && $web_port == $defport) ||
@@ -2281,7 +2281,7 @@ foreach my $dip ($d->{'ip'} ? ( $d->{'ip'} ) : ( ),
 		# the needed one. Add a listen for that IP specifically.
 		# Listening on * is no longer done, as it can cause conflicts
 		# with other servers on port 443 or 80 and other IPs.
-		local $ip = &check_ip6address($dip) ? "[$dip]" : $dip;
+		my $ip = &check_ip6address($dip) ? "[$dip]" : $dip;
 		&apache::save_directive("Listen", [ @listen, "$ip:$web_port" ],
 					$conf, $conf);
 		&flush_file_lines();
@@ -2294,10 +2294,10 @@ foreach my $dip ($d->{'ip'} ? ( $d->{'ip'} ) : ( ),
 # given port, if and only if the domain has a private IP address
 sub remove_listen
 {
-local ($d, $conf, $web_port) = @_;
+my ($d, $conf, $web_port) = @_;
 if ($d->{'virt'} && !$d->{'name'}) {
-	local @listen = &apache::find_directive("Listen", $conf);
-	local @newlisten = grep { $_ ne "$d->{'ip'}:$web_port" } @listen;
+	my @listen = &apache::find_directive("Listen", $conf);
+	my @newlisten = grep { $_ ne "$d->{'ip'}:$web_port" } @listen;
 	if ($d->{'ip6'}) {
 		@newlisten = grep { $_ ne "[$d->{'ip6'}]:$web_port" } @listen;
 		}
@@ -2311,9 +2311,9 @@ if ($d->{'virt'} && !$d->{'name'}) {
 
 sub links_web
 {
-local ($d) = @_;
+my ($d) = @_;
 return () if ($d->{'alias'});
-local @rv;
+my @rv;
 my $link = $d->{'dom'}.":".$d->{'web_port'};
 my $slink = $d->{'dom'}.":".$d->{'web_sslport'};
 
@@ -2335,10 +2335,10 @@ if ($d->{'ssl'}) {
 # Links to logs
 foreach my $log ([ 0, $text{'links_alog'} ],
 		 [ 1, $text{'links_elog'} ]) {
-	local $lf = &get_apache_log($d->{'dom'},
+	my $lf = &get_apache_log($d->{'dom'},
 				    $d->{'web_port'}, $log->[0]);
 	if ($lf) {
-		local $param = &master_admin() ? "file" : "extra";
+		my $param = &master_admin() ? "file" : "extra";
 		push(@rv, { 'mod' => 'logviewer',
 			    'desc' => $log->[1],
 			    'page' => "view_log.cgi?view=1&nonavlinks=1".
@@ -2404,13 +2404,13 @@ return @rv;
 # and long descriptions for the action to switch statuses
 sub startstop_web
 {
-local ($typestatus) = @_;
-local $apid = defined($typestatus->{'apache'}) ?
+my ($typestatus) = @_;
+my $apid = defined($typestatus->{'apache'}) ?
 		$typestatus->{'apache'} == 1 : &get_apache_pid();
-local @links = ( { 'link' => '/apache/',
+my @links = ( { 'link' => '/apache/',
 		   'desc' => $text{'index_amanage'},
 		   'manage' => 1 } );
-local @rv;
+my @rv;
 if ($apid) {
 	push(@rv, { 'status' => 1,
 		    'name' => $text{'index_aname'},
@@ -2444,7 +2444,7 @@ return &apache::start_apache();
 sub stop_service_web
 {
 &require_apache();
-local $err = &apache::stop_apache();
+my $err = &apache::stop_apache();
 sleep(1) if (!$err);
 return $err;
 }
@@ -2501,13 +2501,13 @@ return $ok ? undef : $err;
 # Outputs HTML for editing webserver related template options
 sub show_template_web
 {
-local ($tmpl) = @_;
+my ($tmpl) = @_;
 
 my $hr;
 my @cgimodes = &has_cgi_support();
 if ($config{'web'}) {
 	# Work out fields to disable when Apache is in default mode
-	local @webfields = ( "web", "web_ssl", "user_def",
+	my @webfields = ( "web", "web_ssl", "user_def",
 			     "html_dir", "html_dir_def", "html_perms",
 			     "web_port", "web_sslport",
 			     "web_ssi", "web_ssi_suffix",
@@ -2524,7 +2524,7 @@ if ($config{'web'}) {
 		}
 
 	# Apache directives
-	local $ndi = &none_def_input(
+	my $ndi = &none_def_input(
 		"web", $tmpl->{'web'}, $text{'tmpl_webbelow'}, 1,
 		0, undef, \@webfields);
 	print &ui_table_row(&hlink($text{'tmpl_web'}, "template_web"),
@@ -2567,7 +2567,7 @@ print &ui_table_row(&hlink($text{'newweb_htmldir'}, "template_html_dir_def"),
 			"$text{'default'} (<tt>public_html</tt>)<br>",
 			$text{'newweb_htmldir0'})."<wbr>\n".
 			&vui_note($text{'newweb_htmldir0suf'}));
-local $hdir = $tmpl->{'web_html_dir'} || "public_html";
+my $hdir = $tmpl->{'web_html_dir'} || "public_html";
 
 # HTML directory permissions
 print &ui_table_row(&hlink($text{'newweb_htmlperms'}, "template_html_perms"),
@@ -2633,9 +2633,9 @@ if ($config{'web'} && $config{'webalizer'}) {
 	print &ui_table_hr();
 
 	# Webalizer stats sub-directory input
-	local $smode = $tmpl->{'web_stats_hdir'} ? 2 :
+	my $smode = $tmpl->{'web_stats_hdir'} ? 2 :
 		       $tmpl->{'web_stats_dir'} ? 1 : 0;
-	local ($hdir) = ($tmpl->{'web_html_dir'} || 'public_html');
+	my ($hdir) = ($tmpl->{'web_html_dir'} || 'public_html');
 	print &ui_table_row(&hlink($text{'newweb_statsdir'}, "template_stats_dir"),
 		&ui_radio("stats_mode", $smode,
 		  [ [ 0, "$text{'default'} (<tt>$hdir/stats</tt>)<br>" ],
@@ -2774,7 +2774,7 @@ print &ui_table_row(&hlink($text{'newweb_redirects'}, 'template_web_redirects'),
 # Updates webserver related template options from %in
 sub parse_template_web
 {
-local ($tmpl) = @_;
+my ($tmpl) = @_;
 
 # Save web-related settings
 $old_web_port = $web_port;
@@ -3074,14 +3074,14 @@ print &ui_table_row(
 print &ui_table_hr();
 
 # PHP variables for scripts
-local $i = 0;
-local @pv = $tmpl->{'php_vars'} eq "none" ? ( ) :
+my $i = 0;
+my @pv = $tmpl->{'php_vars'} eq "none" ? ( ) :
 	split(/\t+/, $tmpl->{'php_vars'});
-local @pfields;
-local @table;
+my @pfields;
+my @table;
 foreach $pv (@pv, "", "") {
-	local ($n, $v) = split(/=/, $pv, 2);
-	local $diff = $n =~ s/^(\+|\-)// ? $1 : undef;
+	my ($n, $v) = split(/=/, $pv, 2);
+	my $diff = $n =~ s/^(\+|\-)// ? $1 : undef;
 	push(@table, [ &ui_textbox("phpname_$i", $n, 25),
 		       &ui_select("phpdiff_$i", $diff,
 				  [ [ '', $text{'tmpl_phpexact'} ],
@@ -3091,7 +3091,7 @@ foreach $pv (@pv, "", "") {
 	push(@pfields, "phpname_$i", "phpdiff_$i", "phpval_$i");
 	$i++;
 	}
-local $ptable = &ui_columns_table(
+my $ptable = &ui_columns_table(
 	[ $text{'tmpl_phpname'}, $text{'tmpl_phpdiff'}, $text{'tmpl_phpval'} ],
 	undef,
 	\@table,
@@ -3109,7 +3109,7 @@ print &ui_table_row(
 # Updates PHP related template options from %in
 sub parse_template_php
 {
-local ($tmpl) = @_;
+my ($tmpl) = @_;
 
 # Save PHP settings
 &require_apache();
@@ -3210,13 +3210,13 @@ return @rv;
 # Outputs HTML for setting custom PHP wrapper scripts
 sub show_template_phpwrappers
 {
-local ($tmpl) = @_;
+my ($tmpl) = @_;
 foreach my $w (&unique(&list_php_wrapper_templates(1))) {
-	local $ndi = &none_def_input($w, $tmpl->{$w},
+	my $ndi = &none_def_input($w, $tmpl->{$w},
 				     $text{'tmpl_wrapperbelow'}, 0, 0,
 				     $text{'tmpl_wrappernone'}, [ $w ]);
 	$w =~ /^php([0-9\.]+)(cgi|fcgi)/ || next;
-	local ($v, $t) = ($1, $2);
+	my ($v, $t) = ($1, $2);
 	print &ui_table_row(&hlink(&text('tmpl_php'.$t, $v), "template_php".$t),
 			    $ndi."<br>".
 		&ui_textarea($w, $tmpl->{$w} eq "none" ? "" :
@@ -3229,10 +3229,10 @@ foreach my $w (&unique(&list_php_wrapper_templates(1))) {
 # Update the template with inputs from show_template_phpwrappers
 sub parse_template_phpwrappers
 {
-local ($tmpl) = @_;
+my ($tmpl) = @_;
 foreach my $w (&unique(&list_php_wrapper_templates(1))) {
 	$w =~ /^php([0-9\.]+)(cgi|fcgi)/ || next;
-	local ($v, $t) = ($1, $2);
+	my ($v, $t) = ($1, $2);
 	if ($in{$w."_mode"} == 0) {
 		$tmpl->{$w} = 'none';
 		}
@@ -3252,11 +3252,11 @@ foreach my $w (&unique(&list_php_wrapper_templates(1))) {
 # Returns 1 if some virtual host is setup to use suexec
 sub get_domain_suexec
 {
-local ($d) = @_;
+my ($d) = @_;
 &require_apache();
-local ($virt, $vconf) = &get_apache_virtual($d->{'dom'}, $d->{'web_port'});
+my ($virt, $vconf) = &get_apache_virtual($d->{'dom'}, $d->{'web_port'});
 return 0 if (!$virt);
-local $su = &apache::find_directive("SuexecUserGroup", $vconf);
+my $su = &apache::find_directive("SuexecUserGroup", $vconf);
 return $su ? 1 : 0;
 }
 
@@ -3275,7 +3275,7 @@ return $mmap->{int($tmpl->{'web_php_suexec'})};
 # <virtualhost> for some new domain.
 sub add_script_language_directives
 {
-local ($d, $tmpl, $port) = @_;
+my ($d, $tmpl, $port) = @_;
 my $err;
 
 # Find a usable PHP mode
@@ -3476,21 +3476,21 @@ return @rv;
 # exists with a granted value for anything
 sub add_require_all_granted_directives
 {
-local ($d, $oneport) = @_;
-local @ports = $oneport ? ( $oneport ) :
+my ($d, $oneport) = @_;
+my @ports = $oneport ? ( $oneport ) :
 	       $d->{'ssl'} ? ( $d->{'web_port'}, $d->{'web_sslport'} ) :
 			     ( $d->{'web_port'} );
 foreach my $port (@ports) {
-	local ($virt, $vconf, $conf) = &get_apache_virtual($d->{'dom'}, $port);
+	my ($virt, $vconf, $conf) = &get_apache_virtual($d->{'dom'}, $port);
 	if ($virt && $apache::httpd_modules{'core'} >= 2.4) {
 		foreach my $pdir (&public_html_dir($d), &cgi_bin_dir($d)) {
-			local ($dir) = grep { $_->{'words'}->[0] eq $pdir ||
+			my ($dir) = grep { $_->{'words'}->[0] eq $pdir ||
 					      $_->{'words'}->[0] eq $pdir."/" }
 			    &apache::find_directive_struct("Directory", $vconf);
 			if ($dir) {
-				local @req = &apache::find_directive("Require",
+				my @req = &apache::find_directive("Require",
 							$dir->{'members'});
-				local ($g) = grep { /granted|valid-user/i } @req;
+				my ($g) = grep { /granted|valid-user/i } @req;
 				if (!$g) {
 					push(@req, "all granted");
 					&apache::save_directive("Require",\@req,
@@ -3508,15 +3508,15 @@ foreach my $port (@ports) {
 # their paths from Apache.
 sub find_html_cgi_dirs
 {
-local ($d) = @_;
-local $p = &domain_has_website($d);
+my ($d) = @_;
+my $p = &domain_has_website($d);
 if ($p ne "web") {
 	return &plugin_call($p, "feature_find_web_html_cgi_dirs", $d);
 	}
-local ($virt, $vconf) = &get_apache_virtual($d->{'dom'}, $d->{'web_port'});
+my ($virt, $vconf) = &get_apache_virtual($d->{'dom'}, $d->{'web_port'});
 if ($virt) {
 	# Set public_html directory from document root
-	local $str = &apache::find_directive_struct("DocumentRoot", $vconf);
+	my $str = &apache::find_directive_struct("DocumentRoot", $vconf);
 	if ($str && !$d->{'public_html_correct'}) {
 		$d->{'public_html_path'} = $str->{'words'}->[0];
 		if ($d->{'public_html_path'} =~ /^\Q$d->{'home'}\E\/(.*)$/) {
@@ -3532,7 +3532,7 @@ if ($virt) {
 		}
 
 	# Set CGI directory from ScriptAlias for /cgi-bin/
-	local @str = &apache::find_directive_struct("ScriptAlias", $vconf);
+	my @str = &apache::find_directive_struct("ScriptAlias", $vconf);
 	@str = grep { $_->{'words'}->[0] eq '/cgi-bin/' ||
 		      $_->{'words'}->[0] eq '/cgi-bin' } @str;
 	if (@str && !$d->{'cgi_bin_correct'}) {
@@ -3553,12 +3553,12 @@ if ($virt) {
 # indicating that it can read files that are group-readable only
 sub apache_in_domain_group
 {
-local ($d) = @_;
-local $tmpl = &get_template($d->{'template'});
-local $web_user = &get_apache_user($d);
+my ($d) = @_;
+my $tmpl = &get_template($d->{'template'});
+my $web_user = &get_apache_user($d);
 if ($tmpl->{'web_user'} ne 'none' && $web_user) {
 	# An Apache user is defined.. but is it a group member?
-	local @uinfo = getpwnam($web_user);
+	my @uinfo = getpwnam($web_user);
 	if ($uinfo[3] == $d->{'gid'} ||
             &indexof($d->{'group'}, &other_groups($web_user)) >= 0) {
 		return 1;
@@ -3571,13 +3571,13 @@ return 0;
 # Lock the Apache config file for some domain
 sub obtain_lock_web
 {
-local ($d) = @_;
+my ($d) = @_;
 return if (!$config{'web'});
 &obtain_lock_anything($d);
 
 # Where is the domain's .conf file? We have to guess, as actually checking could
 # mean reading the whole Apache config in twice.
-local $file = &get_website_file($d);
+my $file = &get_website_file($d);
 if ($main::got_lock_web_file{$file} == 0) {
 	&lock_file($file);
 	}
@@ -3586,7 +3586,7 @@ $main::got_lock_web_path{$d->{'id'}} = $file;
 
 # Always lock main config file too, as we may modify it with a Listen
 &require_apache();
-local ($conf) = &apache::find_httpd_conf();
+my ($conf) = &apache::find_httpd_conf();
 if ($conf) {
 	if ($main::got_lock_web_file{$conf} == 0) {
 		&lock_file($conf);
@@ -3600,16 +3600,16 @@ $main::got_lock_web_conf = $conf;
 # Un-lock the Apache config file for some domain
 sub release_lock_web
 {
-local ($d) = @_;
+my ($d) = @_;
 return if (!$config{'web'});
-local $file = $main::got_lock_web_path{$d->{'id'}};
+my $file = $main::got_lock_web_path{$d->{'id'}};
 if ($main::got_lock_web_file{$file} == 1) {
 	&unlock_file($file);
 	}
 $main::got_lock_web_file{$file}-- if ($main::got_lock_web_file{$file});
 
 # Unlock main config file too
-local $conf = $main::got_lock_web_conf;
+my $conf = $main::got_lock_web_conf;
 if ($conf) {
 	if ($main::got_lock_web_file{$conf} == 1) {
 		&unlock_file($conf);
@@ -3624,8 +3624,8 @@ if ($conf) {
 # sub-domain under the domain, with a *.domain.com serveralias
 sub get_domain_web_star
 {
-local ($d) = @_;
-local $p = &domain_has_website($d);
+my ($d) = @_;
+my $p = &domain_has_website($d);
 if ($p && $p ne 'web') {
 	return &plugin_call($p, "feature_get_web_domain_star", $d);
 	}
@@ -3633,8 +3633,8 @@ elsif (!$p) {
 	return "Virtual server does not have a website";
 	}
 &require_apache();
-local ($virt, $vconf) = &get_apache_virtual($d->{'dom'}, $d->{'web_port'});
-local @sa = &apache::find_directive("ServerAlias", $vconf);
+my ($virt, $vconf) = &get_apache_virtual($d->{'dom'}, $d->{'web_port'});
+my @sa = &apache::find_directive("ServerAlias", $vconf);
 my $withstar = "*.".$d->{'dom'};
 foreach my $sa (@sa) {
 	my @saw = split(/\s+/, $sa);
@@ -3647,8 +3647,8 @@ return 0;
 # Toggle accepting of *.domain.com requests on or off
 sub save_domain_web_star
 {
-local ($d, $star) = @_;
-local $p = &domain_has_website($d);
+my ($d, $star) = @_;
+my $p = &domain_has_website($d);
 if ($p && $p ne 'web') {
 	return &plugin_call($p, "feature_save_web_domain_star", $d, $star);
 	}
@@ -3666,7 +3666,7 @@ foreach my $p (@ports) {
 	my @sa = &apache::find_directive("ServerAlias", $vconf);
 	my $found;
 	foreach my $sa (@sa) {
-		local @saw = split(/\s+/, $sa);
+		my @saw = split(/\s+/, $sa);
 		$found++ if (&indexoflc($withstar, @saw) >= 0);
 		}
 	my $done;
@@ -3678,7 +3678,7 @@ foreach my $p (@ports) {
 	elsif (!$star && $found) {
 		# Take away
 		foreach my $sa (@sa) {
-			local @saw = split(/\s+/, $sa);
+			my @saw = split(/\s+/, $sa);
 			@saw = grep { lc($_) ne $withstar } @saw;
 			$sa = join(" ", @saw);
 			}
@@ -3853,7 +3853,7 @@ else {
 sub get_suexec_path
 {
 &require_apache();
-local $httpd_dir = &apache::find_httpd();
+my $httpd_dir = &apache::find_httpd();
 $httpd_dir =~ s/\/[^\/]+$//;
 foreach my $p ("suexec",			# In path
 	       "/usr/lib/apache2/suexec",	# Debian
@@ -3864,7 +3864,7 @@ foreach my $p ("suexec",			# In path
 	       "/opt/csw/apache/sbin/suexec",
 	       "$httpd_dir/suexec",		# Same dir as httpd
 	      ) {
-	local $fp = &has_command($p) || &has_command($p."2");
+	my $fp = &has_command($p) || &has_command($p."2");
 	return $fp if ($fp);
 	}
 return undef;
@@ -3875,15 +3875,15 @@ return undef;
 # if unknown
 sub get_suexec_document_root
 {
-local $suexec = &get_suexec_path();
+my $suexec = &get_suexec_path();
 return ( ) if (!$suexec);
-local $out = &backquote_command(quotemeta($suexec)." -V 2>&1 </dev/null");
+my $out = &backquote_command(quotemeta($suexec)." -V 2>&1 </dev/null");
 if ($out =~ /AP_DOC_ROOT="([^"]+)"/ ||
     $out =~ /AP_DOC_ROOT=(\S+)/) {
 	return split(/:/, $1);
 	}
 # Try new Debian-style suexec config files
-local $user = &get_apache_user();
+my $user = &get_apache_user();
 if ($out =~ /SUEXEC_CONFIG_DIR="([^"]+)"/ ||
     $out =~ /SUEXEC_CONFIG_DIR=(\S+)/) {
 	foreach my $cf ("$1/$user", "$1/www-data") {
@@ -3905,19 +3905,19 @@ return ( );
 # Returns an error message if suexec does not appear to be installed properly.
 sub check_suexec_install
 {
-local ($tmpl) = @_;
+my ($tmpl) = @_;
 &require_useradmin();
 
 # Make sure suexec is actually installed
-local $suexec = &get_suexec_path();
-local @suhome = &get_suexec_document_root();
+my $suexec = &get_suexec_path();
+my @suhome = &get_suexec_document_root();
 if (!$suexec) {
 	return $text{'check_ewebsuexecbin'};
 	}
 
 # Work out CGI base directory
-local @dirs = split(/\t/, $tmpl->{'web'});
-local $cgibase;
+my @dirs = split(/\t/, $tmpl->{'web'});
+my $cgibase;
 foreach my $l (@dirs) {
 	if ($l =~ /^\s*ScriptAlias\s+\/cgi-bin\/?\s+(\/[^\$]*)/) {
 		$cgibase = $1;
@@ -3946,7 +3946,7 @@ return undef;
 # thus it can run CGI scripts. Otherwise return 0.
 sub supports_suexec
 {
-local ($d) = @_;
+my ($d) = @_;
 
 # Does Apache even support suexec?
 &require_apache();
@@ -3956,14 +3956,14 @@ if ($apache::httpd_modules{'core'} >= 2.0 &&
 	}
 
 # Make sure suexec is actually installed
-local $suexec = &get_suexec_path();
+my $suexec = &get_suexec_path();
 return 0 if (!$suexec);
 
 # Is the domain's CGI directory under one of the roots?
 &require_useradmin();
-local @suhome = &get_suexec_document_root();
-local $cgi = $d ? &cgi_bin_dir($d) : $home_base;
-local $under = 0;
+my @suhome = &get_suexec_document_root();
+my $cgi = $d ? &cgi_bin_dir($d) : $home_base;
+my $under = 0;
 foreach my $suhome (@suhome) {
 	if (&is_under_directory($suhome, $cgi)) {
 		$under = 1;
@@ -3974,10 +3974,10 @@ return 0 if (!$under);
 
 if ($d) {
 	# Is suEXEC enabled in the Apache config?
-	local ($virt, $vconf) = &get_apache_virtual(
+	my ($virt, $vconf) = &get_apache_virtual(
 					$d->{'dom'}, $d->{'web_port'});
 	return 1 if (!$virt);
-	local ($suexec) = &apache::find_directive_struct(
+	my ($suexec) = &apache::find_directive_struct(
 					"SuexecUserGroup", $vconf);
 	return 1 if (!$suexec);
 	return 2;
@@ -4034,14 +4034,14 @@ return wantarray ? @rv : $rv[0];
 # Create empty Apache log files for a domain, and set their ownership
 sub setup_apache_logs
 {
-local ($d, $log, $elog) = @_;
+my ($d, $log, $elog) = @_;
 $log ||= &get_apache_log($d->{'dom'}, $d->{'web_port'}, 0);
 $elog ||= &get_apache_log($d->{'dom'}, $d->{'web_port'}, 1);
-local $auser = &get_apache_user($d);
-local $gid = $auser && $auser ne 'none' ? $auser : $d->{'gid'};
+my $auser = &get_apache_user($d);
+my $gid = $auser && $auser ne 'none' ? $auser : $d->{'gid'};
 foreach my $l ($log, $elog) {
 	if ($l && !-r $l) {
-		local $dir = $l;
+		my $dir = $l;
 		$dir =~ s/\/([^\/]+)$//;
 		if (&is_under_directory($d->{'home'}, $dir)) {
 			# If under home, create as the domain owner
@@ -4074,8 +4074,8 @@ foreach my $l ($log, $elog) {
 # Set correct ownership and permissions on an Apache log
 sub set_apache_log_permissions
 {
-local ($d, $l) = @_;
-local $auser = &get_apache_user($d);
+my ($d, $l) = @_;
+my $auser = &get_apache_user($d);
 if (&is_under_directory($d->{'home'}, $l)) {
 	&set_permissions_as_domain_user($d, 0660, $l);
 	}
@@ -4091,12 +4091,12 @@ else {
 # directory to the actual location.
 sub link_apache_logs
 {
-local ($d, $log, $elog) = @_;
+my ($d, $log, $elog) = @_;
 return if ($d->{'subdom'});	# Sub-domains have no separate logs
 $log ||= &get_apache_log($d->{'dom'}, $d->{'web_port'}, 0);
 $elog ||= &get_apache_log($d->{'dom'}, $d->{'web_port'}, 1);
-local $loglink = "$d->{'home'}/logs/access_log";
-local $eloglink = "$d->{'home'}/logs/error_log";
+my $loglink = "$d->{'home'}/logs/access_log";
+my $eloglink = "$d->{'home'}/logs/error_log";
 if ($log && (!-e $loglink || -l $loglink) &&
     !&is_under_directory($d->{'home'}, $log)) {
 	&lock_file($loglink);
@@ -4118,8 +4118,8 @@ if ($elog && (!-e $eloglink || -l $eloglink) &&
 # Only true for the master admin, or if he owns all the sites on that IP.
 sub can_default_website
 {
-local ($d) = @_;
-local $p = &domain_has_website($d);
+my ($d) = @_;
+my $p = &domain_has_website($d);
 if ($p ne 'web') {
 	# Does this website type support it?
 	return 0 if (!&plugin_defined($p, "feature_supports_web_default") ||
@@ -4152,18 +4152,18 @@ return 1;
 # XXX will a request to some IP match both domains on that IP, and * ?
 sub list_apache_domains_on_ip
 {
-local ($d, $port) = @_;
+my ($d, $port) = @_;
 $port ||= $d->{'web_port'};
 &require_apache();
-local ($virt, $vconf, $conf) = &get_apache_virtual($d->{'dom'}, $port);
+my ($virt, $vconf, $conf) = &get_apache_virtual($d->{'dom'}, $port);
 return ( ) if (!$virt);		# Cannot find our own site?
-local @rv;
+my @rv;
 foreach my $v (&apache::find_directive_struct("VirtualHost", $conf)) {
 	if (&indexof($virt->{'words'}->[0], @{$v->{'words'}}) >= 0) {
 		# Matches IP .. find the domain if we can
-		local $sn = &apache::find_directive("ServerName",
+		my $sn = &apache::find_directive("ServerName",
 						    $v->{'members'});
-		local $vd = &get_domain_by("dom", $sn);
+		my $vd = &get_domain_by("dom", $sn);
 		if (!$vd) {
 			# Search by ServerAlias
 			foreach my $sa (&apache::find_directive_struct(
@@ -4186,8 +4186,8 @@ return @rv;
 # default website on some domain's IP
 sub get_default_apache_website
 {
-local ($d, $port) = @_;
-local @onip = &list_apache_domains_on_ip($d, $port);
+my ($d, $port) = @_;
+my @onip = &list_apache_domains_on_ip($d, $port);
 return @onip ? @{$onip[0]} : ( );
 }
 
@@ -4304,13 +4304,13 @@ foreach my $dir (@$conf) {
 # default but only due to file ordering, 0 otherwise
 sub is_default_website
 {
-local ($d) = @_;
-local $p = &domain_has_website($d);
+my ($d) = @_;
+my $p = &domain_has_website($d);
 if ($p ne 'web') {
 	return &plugin_call($p, "feature_is_web_default", $d);
 	}
 else {
-	local ($defvirt, $defd) = &get_default_apache_website($d);
+	my ($defvirt, $defd) = &get_default_apache_website($d);
 	if (!$defd || $defd->{'id'} ne $d->{'id'}) {
 		# No default found, or not the default
 		return 0;
@@ -4333,10 +4333,10 @@ else {
 sub find_default_website
 {
 my ($d) = @_;
-local $p = &domain_has_website($d);
+my $p = &domain_has_website($d);
 if ($p eq 'web') {
 	# Can just use the default apache site function
-	local (undef, $defd) = &get_default_apache_website($d);
+	my (undef, $defd) = &get_default_apache_website($d);
 	return $defd;
 	}
 else {
@@ -4387,8 +4387,8 @@ return join(" ", @vips);
 sub list_apache_directives
 {
 &require_apache();
-local $httpd = &apache::find_httpd();
-local @rv;
+my $httpd = &apache::find_httpd();
+my @rv;
 open(DIRS, quotemeta($httpd)." -L 2>/dev/null </dev/null |");
 while(<DIRS>) {
 	if (/^(\S+)\s+\((\S+)\.c\)/) {
@@ -4404,15 +4404,15 @@ return @rv;
 # the new location, and update any links
 sub change_access_log
 {
-local ($d, $accesslog) = @_;
+my ($d, $accesslog) = @_;
 $accesslog =~ /^\/\S+$/ ||
 	return "Access log $accesslog must be an absolute path";
-local $p = &domain_has_website($d);
+my $p = &domain_has_website($d);
 if ($p ne "web") {
 	return &plugin_call($p, "feature_change_web_access_log",
 			    $d, $accesslog);
 	}
-local $err = &change_apache_log($d, $accesslog, "CustomLog");
+my $err = &change_apache_log($d, $accesslog, "CustomLog");
 if ($err) {
 	$err = &change_apache_log($d, $accesslog, "TransferLog");
 	}
@@ -4426,15 +4426,15 @@ return $err;
 # the new location, and update any links
 sub change_error_log
 {
-local ($d, $errorlog) = @_;
+my ($d, $errorlog) = @_;
 $errorlog =~ /^\/\S+$/ ||
 	return "Error log $errorlog must be an absolute path";
-local $p = &domain_has_website($d);
+my $p = &domain_has_website($d);
 if ($p ne "web") {
 	return &plugin_call($p, "feature_change_web_error_log",
 			    $d, $errorlog);
 	}
-local $err = &change_apache_log($d, $errorlog, "ErrorLog");
+my $err = &change_apache_log($d, $errorlog, "ErrorLog");
 &link_apache_logs($d);
 &register_post_action(\&restart_apache);
 return $err;
@@ -4445,22 +4445,22 @@ return $err;
 # the new location, and update any links
 sub change_apache_log
 {
-local ($d, $log, $dir) = @_;
+my ($d, $log, $dir) = @_;
 -d $log && return "Log file $log is a directory";
-local $logdir = $log;
+my $logdir = $log;
 $logdir =~ s/[^\/]+$//;
 -d $logdir || return "Log parent directory $logdir does not exist";
 
 # Update the Apache config
-local @ports = ( $d->{'web_port'},
+my @ports = ( $d->{'web_port'},
 		 $d->{'ssl'} ? ( $d->{'web_sslport'} ) : ( ) );
-local $movelog;
+my $movelog;
 foreach my $p (@ports) {
-	local ($virt, $vconf, $conf) = &get_apache_virtual($d->{'dom'}, $p);
+	my ($virt, $vconf, $conf) = &get_apache_virtual($d->{'dom'}, $p);
 	next if (!$virt);
-	local $oldlog = &apache::find_directive($dir, $vconf);
+	my $oldlog = &apache::find_directive($dir, $vconf);
 	next if (!$oldlog);
-	local $oldlogfile = &extract_logfile_path($oldlog, $d->{'dom'});
+	my $oldlogfile = &extract_logfile_path($oldlog, $d->{'dom'});
 	$oldlog =~ s/\Q$oldlogfile\E/$log/;
 	$movelog ||= $oldlogfile;
 	&apache::save_directive($dir, [ $oldlog ], $vconf, $conf);
@@ -4480,9 +4480,9 @@ if (!&same_file($log, $movelog) || -l $log) {
 
 # Fix logrotate config
 if ($d->{'logrotate'}) {
-	local $lconf = &get_logrotate_section($movelog);
+	my $lconf = &get_logrotate_section($movelog);
 	if ($lconf) {
-		local $parent = &logrotate::get_config_parent();
+		my $parent = &logrotate::get_config_parent();
 		foreach my $n (@{$lconf->{'name'}}) {
 			if ($n eq $movelog) {
 				$n = $log;
@@ -4503,7 +4503,7 @@ return undef;
 # Invalidates the Apache config cache.
 sub modify_web_home_directory
 {
-local ($d, $oldd, $virt, $vconf, $conf, $mode) = @_;
+my ($d, $oldd, $virt, $vconf, $conf, $mode) = @_;
 &recursive_fix_apache_config(
 	$vconf, $conf, $oldd->{'home'}, $d->{'home'});
 &flush_file_lines($virt->{'file'}, undef, 1);
@@ -4547,7 +4547,7 @@ if ($mode eq "fpm") {
 
 # Fix paths in .htaccess files
 my $filename = ".htaccess";
-local $out = &run_as_domain_user($d, "find ".quotemeta($d->{'home'}).
+my $out = &run_as_domain_user($d, "find ".quotemeta($d->{'home'}).
 				     " -type f -name ".quotemeta($filename).
 				     " 2>/dev/null");
 foreach my $file (split(/\r?\n/, $out)) {
@@ -4555,7 +4555,7 @@ foreach my $file (split(/\r?\n/, $out)) {
 	eval {
 		local $main::error_must_die = 1;
 		&lock_file($file);
-		local $lref = &read_file_lines_as_domain_user($d, $file);
+		my $lref = &read_file_lines_as_domain_user($d, $file);
 		foreach my $l (@$lref) {
 			if ($l =~ s/\Q$oldd->{'home'}\E/$d->{'home'}/g) {
 				$fixed++;
@@ -4607,8 +4607,8 @@ foreach my $ld ("ErrorLog", "TransferLog", "CustomLog") {
 			}
 		if ($l ne $oldl && $rlogs) {
 			# Rename log file too
-			local $wl = &apache::wsplit($l);
-			local $woldl = &apache::wsplit($oldl);
+			my $wl = &apache::wsplit($l);
+			my $woldl = &apache::wsplit($oldl);
 			&rename_file($woldl->[0], $wl->[0]);
 			}
 		}
@@ -4626,7 +4626,7 @@ sub modify_web_redirects
 my ($d, $oldd, $virt, $vconf, $conf) = @_;
 foreach my $ld ("RewriteCond", "RewriteRule",
 		"Redirect", "RedirectMatch") {
-	local @ldv = &apache::find_directive($ld, $vconf);
+	my @ldv = &apache::find_directive($ld, $vconf);
 	next if (!@ldv);
 	my $oqm = quotemeta($oldd->{'dom'});
 	my $qm = quotemeta($d->{'dom'});
@@ -4642,8 +4642,8 @@ foreach my $ld ("RewriteCond", "RewriteRule",
 # Update the Apache config for a virtual host to fix the user and group names
 sub modify_web_user_group
 {
-local ($d, $oldd, $virt, $vconf, $conf) = @_;
-local $suexec = &apache::find_directive_struct("SuexecUserGroup", $vconf);
+my ($d, $oldd, $virt, $vconf, $conf) = @_;
+my $suexec = &apache::find_directive_struct("SuexecUserGroup", $vconf);
 if ($suexec && ($suexec->{'words'}->[0] eq $oldd->{'user'} ||
 		$suexec->{'words'}->[0] eq '#'.$oldd->{'uid'})){
 	&apache::save_directive("SuexecUserGroup",
@@ -4658,27 +4658,27 @@ if ($suexec && ($suexec->{'words'}->[0] eq $oldd->{'user'} ||
 # set change them to SymLinksifOwnerMatch
 sub fix_symlink_security
 {
-local ($doms, $findonly) = @_;
+my ($doms, $findonly) = @_;
 $doms ||= [ &list_domains() ];
-local @flush;
-local @fixdoms;
+my @flush;
+my @fixdoms;
 &require_apache();
-local @lockdoms;
+my @lockdoms;
 foreach my $d (@$doms) {
         next if (!$d->{'web'} || $d->{'alias'});
-	local @ports = ( $d->{'web_port'},
+	my @ports = ( $d->{'web_port'},
 			 $d->{'ssl'} ? ( $d->{'web_sslport'} ) : ( ) );
-	local $domfixed = 0;
+	my $domfixed = 0;
 	if (!$findonly) {
 		&obtain_lock_web($d);
 		&obtain_lock_ssl($d) if ($d->{'ssl'});
 		push(@lockdoms, $d);
 		}
 	foreach my $p (@ports) {
-		local ($virt, $vconf, $conf) = &get_apache_virtual(
+		my ($virt, $vconf, $conf) = &get_apache_virtual(
 						$d->{'dom'}, $p);
 		next if (!$virt);
-		local @dirs = &apache::find_directive_struct("Directory",
+		my @dirs = &apache::find_directive_struct("Directory",
 							     $vconf);
 		foreach my $dir (@dirs) {
 			# Fix Options line
@@ -4732,11 +4732,11 @@ foreach my $d (@$doms) {
 		}
 
 	# Replace awstats symlinks with copies
-	local $htmldir = &public_html_dir($d);
-	local @dirs = ( "icon", "awstats-icon", "awstatsicons" );
+	my $htmldir = &public_html_dir($d);
+	my @dirs = ( "icon", "awstats-icon", "awstatsicons" );
 	if ($domfixed && !$findonly && $d->{'virtualmin-awstats'} &&
 	    -l "$htmldir/$dirs[0]") {
-		local $dest = readlink("$htmldir/$dirs[0]");
+		my $dest = readlink("$htmldir/$dirs[0]");
 		&unlink_logged_as_domain_user($d, "$htmldir/$dirs[0]");
 		&copy_source_dest($dest, "$htmldir/$dirs[0]");
 		&system_logged("chown -R $d->{'uid'}:$d->{'gid'} ".
@@ -4834,8 +4834,8 @@ else {
 # in effect.
 sub get_domain_web_ssi
 {
-local ($d) = @_;
-local $p = &domain_has_website($d);
+my ($d) = @_;
+my $p = &domain_has_website($d);
 if ($p && $p ne 'web') {
 	return &plugin_call($p, "feature_get_web_domain_ssi", $d);
 	}
@@ -4843,16 +4843,16 @@ elsif (!$p) {
 	return (0, "Virtual server does not have a website");
 	}
 &require_apache();
-local ($virt, $vconf) = &get_apache_virtual($d->{'dom'}, $d->{'web_port'});
+my ($virt, $vconf) = &get_apache_virtual($d->{'dom'}, $d->{'web_port'});
 return (0, "No Apache configuration found") if (!$virt);
 
 # Get options for public_html
-local @dirs = &apache::find_directive_struct("Directory", $vconf);
-local $phd = &public_html_dir($d);
-local ($dir) = grep { $_->{'words'}->[0] eq $phd } @dirs;
+my @dirs = &apache::find_directive_struct("Directory", $vconf);
+my $phd = &public_html_dir($d);
+my ($dir) = grep { $_->{'words'}->[0] eq $phd } @dirs;
 return (0, "No directory block for $phd found") if (!$dir);
-local @opts = &apache::find_directive("Options", $dir->{'members'});
-local $foundincludes;
+my @opts = &apache::find_directive("Options", $dir->{'members'});
+my $foundincludes;
 foreach my $o (@opts) {
 	if ($o =~ /(^|\s|\+)(Includes|IncludesNOEXEC)(\s|$)/) {
 		$foundincludes = 1;
@@ -4861,8 +4861,8 @@ foreach my $o (@opts) {
 return (0) if (!$foundincludes);
 
 # Look for AddOutputFilter INCLUDES suffix
-local @filters = &apache::find_directive("AddOutputFilter", $dir->{'members'});
-local $foundfilter;
+my @filters = &apache::find_directive("AddOutputFilter", $dir->{'members'});
+my $foundfilter;
 foreach my $f (@filters) {
 	if ($f =~ /^INCLUDES\s+(\S+)/) {
 		$foundfilter = $1;
@@ -4878,8 +4878,8 @@ return (1, $foundfilter);
 # on success or an error message on failure.
 sub save_domain_web_ssi
 {
-local ($d, $suffix) = @_;
-local $p = &domain_has_website($d);
+my ($d, $suffix) = @_;
+my $p = &domain_has_website($d);
 if ($p && $p ne 'web') {
 	return &plugin_call($p, "feature_save_web_domain_ssi", $d, $suffix);
 	}
@@ -4889,22 +4889,22 @@ elsif (!$p) {
 &require_apache();
 
 &obtain_lock_web($d);
-local @ports = ( $d->{'web_port'} );
+my @ports = ( $d->{'web_port'} );
 push(@ports, $d->{'web_sslport'}) if ($d->{'ssl'});
 
 foreach my $p (@ports) {
-	local ($virt, $vconf, $conf) = &get_apache_virtual($d->{'dom'}, $p);
+	my ($virt, $vconf, $conf) = &get_apache_virtual($d->{'dom'}, $p);
 	next if (!$virt);
 
 	# Fix options for public_html
-	local @dirs = &apache::find_directive_struct("Directory", $vconf);
-	local $phd = &public_html_dir($d);
-	local ($dir) = grep { $_->{'words'}->[0] eq $phd } @dirs;
+	my @dirs = &apache::find_directive_struct("Directory", $vconf);
+	my $phd = &public_html_dir($d);
+	my ($dir) = grep { $_->{'words'}->[0] eq $phd } @dirs;
 	next if (!$dir);
-	local @opts = &apache::find_directive("Options", $dir->{'members'});
+	my @opts = &apache::find_directive("Options", $dir->{'members'});
 	if ($suffix) {
 		# Adding to Options
-		local $foundincludes;
+		my $foundincludes;
 		foreach my $o (@opts) {
 			if ($o =~ /(^|\s|\+)(Includes|IncludesNOEXEC)(\s|$)/) {
 				$foundincludes = 1;
@@ -4923,10 +4923,10 @@ foreach my $p (@ports) {
 	&apache::save_directive("Options", \@opts, $dir->{'members'}, $conf);
 
 	# Add AddOutputFilter directive for the suffix
-	local @filters = &apache::find_directive("AddOutputFilter",
+	my @filters = &apache::find_directive("AddOutputFilter",
 						 $dir->{'members'});
-	local $idx;
-	local $oldsuffix;
+	my $idx;
+	my $oldsuffix;
 	for(my $i=0; $i<@filters; $i++) {
 		if ($filters[$i] =~ /^INCLUDES\s+(\S+)/) {
 			$idx = $i;
@@ -4949,8 +4949,8 @@ foreach my $p (@ports) {
 				$dir->{'members'}, $conf);
 
 	# Add AddType directive for the suffix, if not .html
-	local @types = &apache::find_directive("AddType", $dir->{'members'});
-	local $idx;
+	my @types = &apache::find_directive("AddType", $dir->{'members'});
+	my $idx;
 	if ($oldsuffix) {
 		for(my $i=0; $i<@types; $i++) {
 			if ($types[$i] =~ /^(\S+)\s+\Q$oldsuffix\E/) {

--- a/fetch-script-files.pl
+++ b/fetch-script-files.pl
@@ -51,12 +51,12 @@ foreach $s (@scripts) {
 		foreach $f (grep { $_->{'url'} } @files) {
 			next if ($f->{'nofetch'});
 			next if ($f->{'virtualmin'});
-			local $url = &convert_osdn_url($f->{'url'}) ||
+			my $url = &convert_osdn_url($f->{'url'}) ||
 				     $f->{'url'};
-			local $destfile = "$dest/$f->{'file'}";
+			my $destfile = "$dest/$f->{'file'}";
 			next if (-r $destfile);		# Already gotten
-			local $temp = &transname($f->{'file'});
-			local $error;
+			my $temp = &transname($f->{'file'});
+			my $error;
 			print "script:$script->{'name'} version:$ver url:$url\n";
 			if ($url =~ /^http/) {
 				# Via HTTP

--- a/fix-domain-permissions.pl
+++ b/fix-domain-permissions.pl
@@ -32,7 +32,7 @@ if (!$module_name) {
 
 # Parse command-line args
 while(@ARGV > 0) {
-	local $a = shift(@ARGV);
+	my $a = shift(@ARGV);
 	if ($a eq "--domain") {
 		push(@dnames, shift(@ARGV));
 		}

--- a/fix-domain-quota.pl
+++ b/fix-domain-quota.pl
@@ -31,7 +31,7 @@ if (!$module_name) {
 
 # Parse command-line args
 while(@ARGV > 0) {
-	local $a = shift(@ARGV);
+	my $a = shift(@ARGV);
 	if ($a eq "--domain") {
 		push(@dnames, shift(@ARGV));
 		}

--- a/fix_symlinks.cgi
+++ b/fix_symlinks.cgi
@@ -56,7 +56,7 @@ else {
 	@dfound = ( );
 	foreach my $d (&list_domains()) {
 		next if ($d->{'alias'} || !$d->{'dir'});
-		local @dhtaccess = &fix_script_htaccess_files(
+		my @dhtaccess = &fix_script_htaccess_files(
                                         $d, &public_html_dir($d), 1);
 		push(@htaccess, @dhtaccess);
 		push(@dfound, [ $d, \@dhtaccess ]) if (@dhtaccess);

--- a/ftp-lib.pl
+++ b/ftp-lib.pl
@@ -5,7 +5,7 @@
 # Download data from a local file to an FTP site
 sub ftp_tryload
 {
-local $tries = $_[8] || 1;
+my $tries = $_[8] || 1;
 for(my $i=0; $i<$tries; $i++) {
 	&ftp_upload(@_);
 	return 1 if (!${$_[3]});
@@ -18,7 +18,7 @@ return 0;
 # Upload data from a local file to an FTP-over-TLS site
 sub ftp_encrypted_tryload
 {
-local $tries = $_[8] || 1;
+my $tries = $_[8] || 1;
 for(my $i=0; $i<$tries; $i++) {
 	&ftp_encrypted_upload(@_);
 	return 1 if (!${$_[3]});
@@ -31,7 +31,7 @@ return 0;
 # exit status.
 sub ftp_onecommand
 {
-local($buf, @n);
+my($buf, @n);
 
 $main::download_timed_out = undef;
 local $SIG{ALRM} = \&download_timeout;
@@ -47,7 +47,7 @@ if ($main::download_timed_out) {
 &ftp_command("", 2, $_[2]) || return 0;
 if ($_[3]) {
 	# Login as supplied user
-	local @urv = &ftp_command("USER $_[3]", [ 2, 3 ], $_[2]);
+	my @urv = &ftp_command("USER $_[3]", [ 2, 3 ], $_[2]);
 	@urv || return 0;
 	if (int($urv[1]/100) == 3) {
 		&ftp_command("PASS $_[4]", 2, $_[2]) || return 0;
@@ -55,7 +55,7 @@ if ($_[3]) {
 	}
 else {
 	# Login as anonymous
-	local @urv = &ftp_command("USER anonymous", [ 2, 3 ], $_[2]);
+	my @urv = &ftp_command("USER anonymous", [ 2, 3 ], $_[2]);
 	@urv || return 0;
 	if (int($urv[1]/100) == 3) {
 		&ftp_command("PASS root\@".&get_system_hostname(), 2,
@@ -64,7 +64,7 @@ else {
 	}
 
 # Run the command
-local @rv = &ftp_command($_[1], 2, $_[2]);
+my @rv = &ftp_command($_[1], 2, $_[2]);
 @rv || return 0;
 
 # finish off..
@@ -80,7 +80,7 @@ return $rv[1];
 # the filename)
 sub ftp_listdir
 {
-local($buf, @n);
+my($buf, @n);
 
 $main::download_timed_out = undef;
 local $SIG{ALRM} = \&download_timeout;
@@ -96,7 +96,7 @@ if ($main::download_timed_out) {
 &ftp_command("", 2, $_[2]) || return 0;
 if ($_[3]) {
 	# Login as supplied user
-	local @urv = &ftp_command("USER $_[3]", [ 2, 3 ], $_[2]);
+	my @urv = &ftp_command("USER $_[3]", [ 2, 3 ], $_[2]);
 	@urv || return 0;
 	if (int($urv[1]/100) == 3) {
 		&ftp_command("PASS $_[4]", 2, $_[2]) || return 0;
@@ -104,7 +104,7 @@ if ($_[3]) {
 	}
 else {
 	# Login as anonymous
-	local @urv = &ftp_command("USER anonymous", [ 2, 3 ], $_[2]);
+	my @urv = &ftp_command("USER anonymous", [ 2, 3 ], $_[2]);
 	@urv || return 0;
 	if (int($urv[1]/100) == 3) {
 		&ftp_command("PASS root\@".&get_system_hostname(), 2,
@@ -126,21 +126,21 @@ if ($v6) {
 	}
 else {
 	# request the listing over a PASV connection
-	local $pasv = &ftp_command("PASV", 2, $_[2]);
+	my $pasv = &ftp_command("PASV", 2, $_[2]);
 	defined($pasv) || return 0;
 	$pasv =~ /\(([0-9,]+)\)/ || return 0;
 	@n = split(/,/ , $1);
 	&open_socket("$n[0].$n[1].$n[2].$n[3]", $n[4]*256 + $n[5], "CON", $_[2]) || return 0;
 	}
 
-local @list;
+my @list;
 local $_;
 if ($_[6]) {
 	# Ask for full listing
 	&ftp_command("LIST $_[1]/", 1, $_[2]) || return 0;
 	while(<CON>) {
 		s/\r|\n//g;
-		local @st = &parse_lsl_line($_);
+		my @st = &parse_lsl_line($_);
 		push(@list, \@st) if (scalar(@st));
 		}
 	close(CON);
@@ -169,9 +169,9 @@ return \@list;
 # doesn't look like ls -l output.
 sub parse_lsl_line
 {
-local @w = split(/\s+/, $_[0]);
-local @now = localtime(time());
-local @st;
+my @w = split(/\s+/, $_[0]);
+my @now = localtime(time());
+my @st;
 return ( ) if ($w[0] !~ /^[rwxdlsSt\-]{10}(\+|@|\.)?$/);
 $st[3] = $w[1];			# Links
 $st[4] = $w[2];			# UID
@@ -179,9 +179,9 @@ $st[5] = $w[3];			# GID
 $st[7] = $w[4];			# Size
 if ($w[7] =~ /^(\d+):(\d+)$/) {
 	# Time is month day hour:minute
-	local @tm = ( 0, $2, $1, $w[6], &month_to_number($w[5]), $now[5] );
+	my @tm = ( 0, $2, $1, $w[6], &month_to_number($w[5]), $now[5] );
 	return ( ) if ($tm[4] eq '' || $tm[3] < 1 || $tm[3] > 31);
-	local $ut = timelocal(@tm);
+	my $ut = timelocal(@tm);
 	if ($ut > time()+(24*60*60)) {
 		# Must have been last year!
 		$tm[5]--;
@@ -192,7 +192,7 @@ if ($w[7] =~ /^(\d+):(\d+)$/) {
 	}
 elsif ($w[5] =~ /^(\d{4})\-(\d+)\-(\d+)$/) {
 	# Time is year-month-day hour:minute
-	local @tm = ( 0, 0, 0, $3, $2-1, $1 );
+	my @tm = ( 0, 0, 0, $3, $2-1, $1 );
 	if ($w[6] =~ /^(\d+):(\d+)$/) {
 		$tm[1] = $2;
 		$tm[2] = $1;
@@ -205,7 +205,7 @@ elsif ($w[5] =~ /^(\d{4})\-(\d+)\-(\d+)$/) {
 	}
 elsif ($w[7] =~ /^\d+$/ && $w[7] > 1000 && $w[7] < 10000) {
 	# Time is month day year
-	local @tm = ( 0, 0, 0, $w[6],
+	my @tm = ( 0, 0, 0, $w[6],
 		      &month_to_number($w[5]), $w[7] );
 	return ( ) if ($tm[4] eq '' || $tm[3] < 1 || $tm[3] > 31);
 	$st[8] = $st[9] = $st[10] = timelocal(@tm);
@@ -217,7 +217,7 @@ else {
 	}
 $st[2] = 0;			# Permissions
 $w[0] =~ s/(\+|@|\.)$//;	# Remove trailing + or @ or .
-local @p = reverse(split(//, $w[0]));
+my @p = reverse(split(//, $w[0]));
 for(my $i=0; $i<9; $i++) {
 	if ($p[$i] ne '-') {
 		$st[2] += (1<<$i);
@@ -273,16 +273,16 @@ return join('', $ftype, @permstrs);
 # if needed. Returns the size of any deleted sub-directories.
 sub ftp_deletefile
 {
-local ($host, $file, $err, $user, $pass, $port) = @_;
-local $sz = 0;
+my ($host, $file, $err, $user, $pass, $port) = @_;
+my $sz = 0;
 
 # Check if we can chdir to it
-local $cwderr;
-local $isdir = &ftp_onecommand($host, "CWD $file", \$cwderr,
+my $cwderr;
+my $isdir = &ftp_onecommand($host, "CWD $file", \$cwderr,
 			       $user, $pass, $port);
 if ($isdir) {
 	# Yes .. so delete recursively first
-	local $files = &ftp_listdir($host, $file, $err, $user, $pass, $port, 1);
+	my $files = &ftp_listdir($host, $file, $err, $user, $pass, $port, 1);
 	$files = [ grep { $_->[13] ne "." && $_->[13] ne ".." } @$files ];
 	if (!$err || !$$err) {
 		foreach my $f (@$files) {

--- a/functional-test.pl
+++ b/functional-test.pl
@@ -113,7 +113,7 @@ $web = 'web';
 $ssl = 'ssl';
 &load_plugin_libraries();
 while(@ARGV > 0) {
-	local $a = shift(@ARGV);
+	my $a = shift(@ARGV);
 	if ($a eq "--domain") {
 		$test_domain = shift(@ARGV);
 		}
@@ -13469,7 +13469,7 @@ TESTS: foreach $tt (@tests) {
 	$count = 0;
 	$failed = 0;
 	$total = 0;
-	local $i = 0;
+	my $i = 0;
 	foreach $t (@tts) {
 		$t->{'index'} = $i++;
 		}
@@ -13533,14 +13533,14 @@ exit($total_failed);
 
 sub run_test
 {
-local ($t) = @_;
+my ($t) = @_;
 if ($t->{'wait'}) {
 	# Wait for a background process to exit
-	local @waits = ref($t->{'wait'}) ? @{$t->{'wait'}} : ( $t->{'wait'} );
-	local $ok = 1;
+	my @waits = ref($t->{'wait'}) ? @{$t->{'wait'}} : ( $t->{'wait'} );
+	my $ok = 1;
 	foreach my $w (@waits) {
 		print "    Waiting for background process $w ..\n";
-		local $pid = $backgrounds{$w};
+		my $pid = $backgrounds{$w};
 		if (!$pid) {
 			print "    .. already exited, or never started!\n";
 			$ok = 0;
@@ -13574,13 +13574,13 @@ if ($t->{'wait'}) {
 elsif ($t->{'background'}) {
 	# Run a test, but in the background
 	print "    Backgrounding test ..\n";
-	local $pid = fork();
+	my $pid = fork();
 	if ($pid < 0) {
 		print "    .. fork failed : $!\n";
 		return 0;
 		}
 	if (!$pid) {
-		local $rv = &run_test_command($t);
+		my $rv = &run_test_command($t);
 		exit($rv ? 0 : 1);
 		}
 	$backgrounds{$t->{'background'}} = $pid;
@@ -13595,7 +13595,7 @@ else {
 
 sub run_test_command
 {
-local $cmd = $t->{'command'};
+my $cmd = $t->{'command'};
 foreach my $a (@{$t->{'args'}}) {
 	my ($flag, @vals) = @$a;
 	$cmd .= " --".$flag;
@@ -13624,11 +13624,11 @@ if ($gconfig{'os_type'} !~ /-linux$/ && &has_command("bash")) {
 	# Force use of bash
 	$cmd = "bash -c ".quotemeta($cmd);
 	}
-local $to = $t->{'timeout'} || $timeout;
-local ($out, $timed_out) = &backquote_with_timeout(
+my $to = $t->{'timeout'} || $timeout;
+my ($out, $timed_out) = &backquote_with_timeout(
 				"($cmd) 2>&1 </dev/null", $to);
-local @lout = split(/\r?\n/, $out);
-local $shortout = $out;
+my @lout = split(/\r?\n/, $out);
+my $shortout = $out;
 if (length($shortout) > $max_output) {
 	$shortout = substr($shortout, 0, $max_output);
 	$shortout .= "\n" if ($shortout !~ /\n$/);
@@ -13651,10 +13651,10 @@ if (!$t->{'ignorefail'}) {
 	}
 if ($t->{'grep'}) {
 	# One line must match all regexps
-	local @greps = ref($t->{'grep'}) ? @{$t->{'grep'}} : ( $t->{'grep'} );
+	my @greps = ref($t->{'grep'}) ? @{$t->{'grep'}} : ( $t->{'grep'} );
 	foreach my $grep (@greps) {
 		$grep = &substitute_template($grep, \%saved_vars);
-		local $match = 0;
+		my $match = 0;
 		if ($t->{'grepall'}) {
 			$match = ($out =~ /$grep/);
 			}
@@ -13674,11 +13674,11 @@ if ($t->{'grep'}) {
 	}
 if ($t->{'antigrep'}) {
 	# No line must match all regexps
-	local @greps = ref($t->{'antigrep'}) ? @{$t->{'antigrep'}}
+	my @greps = ref($t->{'antigrep'}) ? @{$t->{'antigrep'}}
 					     : ( $t->{'antigrep'} );
 	foreach my $grep (@greps) {
 		$grep = &substitute_template($grep, \%saved_vars);
-		local $match = 0;
+		my $match = 0;
 		foreach my $l (split(/\r?\n/, $out)) {
 			if ($l =~ /$grep/) {
 				$match = 1;
@@ -13709,7 +13709,7 @@ return 1;
 sub usage
 {
 print "$_[0]\n\n" if ($_[0]);
-local $mig = join("|", @migration_types);
+my $mig = join("|", @migration_types);
 print "Runs some or all Virtualmin functional tests.\n";
 print "\n";
 print "usage: functional-tests.pl [--domain test.domain]\n";
@@ -13755,12 +13755,12 @@ return (
 # a key
 sub convert_to_encrypted
 {
-local ($tests) = @_;
+my ($tests) = @_;
 if (!defined(&list_backup_keys)) {
 	return [ ];
 	}
-local ($key) = &list_backup_keys();
-local $rv = [ ];
+my ($key) = &list_backup_keys();
+my $rv = [ ];
 foreach my $t (@$tests) {
 	my $nt = { %$t };
 	if ($nt->{'command'} eq 'backup-domain.pl' ||
@@ -13776,8 +13776,8 @@ return $rv;
 # convert_to_dnscloud(&tests, cloud)
 sub convert_to_dnscloud
 {
-local ($tests, $cloud) = @_;
-local $rv = [ ];
+my ($tests, $cloud) = @_;
+my $rv = [ ];
 foreach my $t (@$tests) {
         my $nt = { %$t };
 	my @a;
@@ -13800,8 +13800,8 @@ return $rv;
 # EU S3 location
 sub convert_to_location
 {
-local ($tests, $location) = @_;
-local $rv = [ ];
+my ($tests, $location) = @_;
+my $rv = [ ];
 foreach my $t (@$tests) {
 	my $nt = { %$t };
 	my @na;

--- a/generate-acme-cert.pl
+++ b/generate-acme-cert.pl
@@ -71,7 +71,7 @@ if (!$module_name) {
 
 # Parse command-line args
 while(@ARGV > 0) {
-	local $a = shift(@ARGV);
+	my $a = shift(@ARGV);
 	if ($a eq "--domain") {
 		$dname = shift(@ARGV);
 		}

--- a/generate-cert.pl
+++ b/generate-cert.pl
@@ -72,7 +72,7 @@ if (!$module_name) {
 
 # Parse command-line args
 while(@ARGV > 0) {
-	local $a = shift(@ARGV);
+	my $a = shift(@ARGV);
 	if ($a eq "--domain") {
 		$dname = shift(@ARGV);
 		}
@@ -124,7 +124,7 @@ my $merr = &making_changes();
 if ($self) {
 	# Break SSL linkages that no longer work with this cert
 	@beforecerts = &get_all_domain_service_ssl_certs($d);
-	local $newcert = { 'cn' => $subject{'cn'} || "*.$d->{'dom'}",
+	my $newcert = { 'cn' => $subject{'cn'} || "*.$d->{'dom'}",
 			   'alt' => \@alts };
 	&break_invalid_ssl_linkages($d, $newcert);
 

--- a/generate-script-sites.pl
+++ b/generate-script-sites.pl
@@ -43,7 +43,7 @@ foreach $s (@scripts) {
 		foreach $url (map { $_->{'url'} } @files) {
 			# Work out URLs
 			@urls = ( $url );
-			local $ourl = &convert_osdn_url($url);
+			my $ourl = &convert_osdn_url($url);
 			if ($ourl && $ourl ne $url) {
 				push(@orls, $ourl);
 				}

--- a/get-command.pl
+++ b/get-command.pl
@@ -30,7 +30,7 @@ if (!$module_name) {
 my $short = 1;
 &parse_common_cli_flags(\@ARGV);
 while(@ARGV > 0) {
-	local $a = shift(@ARGV);
+	my $a = shift(@ARGV);
 	if ($a eq "--command") {
 		$cmd = shift(@ARGV);
 		}

--- a/get-dns.pl
+++ b/get-dns.pl
@@ -43,7 +43,7 @@ if (!$module_name) {
 # Parse command line
 &parse_common_cli_flags(\@ARGV);
 while(@ARGV > 0) {
-	local $a = shift(@ARGV);
+	my $a = shift(@ARGV);
 	if ($a eq "--domain") {
 		$dname = shift(@ARGV);
 		}

--- a/get-logs.pl
+++ b/get-logs.pl
@@ -31,7 +31,7 @@ if (!$module_name) {
 # Parse command line
 $logtype = "alog";
 while(@ARGV > 0) {
-	local $a = shift(@ARGV);
+	my $a = shift(@ARGV);
 	if ($a eq "--domain") {
 		$dname = shift(@ARGV);
 		}

--- a/get-ssl.pl
+++ b/get-ssl.pl
@@ -30,7 +30,7 @@ if (!$module_name) {
 
 # Parse command line
 while(@ARGV > 0) {
-	local $a = shift(@ARGV);
+	my $a = shift(@ARGV);
 	if ($a eq "--domain") {
 		$dname = shift(@ARGV);
 		}

--- a/get-template.pl
+++ b/get-template.pl
@@ -42,7 +42,7 @@ if (!$module_name) {
 # Parse command-line args
 $owner = 1;
 while(@ARGV > 0) {
-	local $a = shift(@ARGV);
+	my $a = shift(@ARGV);
 	if ($a eq "--name") {
 		$tmplname = shift(@ARGV);
 		}

--- a/import-database.pl
+++ b/import-database.pl
@@ -34,7 +34,7 @@ if (!$module_name) {
 
 # Parse command-line args
 while(@ARGV > 0) {
-	local $a = shift(@ARGV);
+	my $a = shift(@ARGV);
 	if ($a eq "--domain") {
 		$domain = shift(@ARGV);
 		}

--- a/import.cgi
+++ b/import.cgi
@@ -562,7 +562,7 @@ else {
 	@alldbs = &all_databases();
 	foreach $t ('mysql', 'postgres') {
 		foreach $db (split(/\s+/, $in{'db_'.$t})) {
-			local ($got) = grep { $_->{'type'} eq $t &&
+			my ($got) = grep { $_->{'type'} eq $t &&
 					      $_->{'name'} eq $db } @alldbs;
 			if ($got) {
 				$found{$t}++;

--- a/index.cgi
+++ b/index.cgi
@@ -220,7 +220,7 @@ if (&can_view_sysinfo()) {
 	print "<table width=100%>\n";
 	foreach my $f ("virtualmin", @features) {
 		if ($config{$f} || $f eq "virtualmin") {
-			local $ifunc = "sysinfo_$f";
+			my $ifunc = "sysinfo_$f";
 			push(@info, &$ifunc()) if (defined(&$ifunc));
 			}
 		}
@@ -273,9 +273,9 @@ PAGEEND:
 # create_links(num)
 sub create_links
 {
-local ($num) = @_;
-local ($dleft, $dreason, $dmax, $dhide) = &count_domains("realdoms");
-local ($cannot_add, $limit_reason);
+my ($num) = @_;
+my ($dleft, $dreason, $dmax, $dhide) = &count_domains("realdoms");
+my ($cannot_add, $limit_reason);
 if ($dleft == 0) {
 	# Need to show reason for hitting the limit
 	$cannot_add = &text('index_noadd'.$dreason, $dmax);

--- a/info.pl
+++ b/info.pl
@@ -41,7 +41,7 @@ if (!$module_name) {
 	}
 
 while(@ARGV > 0) {
-	local $a = shift(@ARGV);
+	my $a = shift(@ARGV);
 	if ($a eq "--help") {
 		&usage();
 		}
@@ -92,7 +92,7 @@ foreach my $k (keys %$info) {
 
 sub recursive_info_dump
 {
-local ($info, $indent) = @_;
+my ($info, $indent) = @_;
 
 # Dump object, depending on type
 if (ref($info) eq "ARRAY") {
@@ -126,7 +126,7 @@ else {
 
 sub info_search_match
 {
-local ($i) = @_;
+my ($i) = @_;
 if (@searches && !ref($i)) {
 	foreach my $s (@searches) {
 		return 1 if ($i =~ /\Q$s\E/i);

--- a/install-cert.pl
+++ b/install-cert.pl
@@ -49,7 +49,7 @@ if (!$module_name) {
 
 # Parse command-line args
 while(@ARGV > 0) {
-	local $a = shift(@ARGV);
+	my $a = shift(@ARGV);
 	if ($a eq "--domain") {
 		$dname = shift(@ARGV);
 		}

--- a/install-script.pl
+++ b/install-script.pl
@@ -76,7 +76,7 @@ if (!$module_name) {
 
 # Parse command-line args
 while(@ARGV > 0) {
-	local $a = shift(@ARGV);
+	my $a = shift(@ARGV);
 	if ($a eq "--domain") {
 		$domain = shift(@ARGV);
 		}
@@ -488,7 +488,7 @@ else {
 
 # Run post commands
 &set_domain_envs($d, "SCRIPT_DOMAIN", undef, \%envs);
-local $merr = &made_changes();
+my $merr = &made_changes();
 &$second_print(&text('setup_emade', "<tt>$merr</tt>")) if (defined($merr));
 &reset_domain_envs($d);
 

--- a/install-service-cert.pl
+++ b/install-service-cert.pl
@@ -40,7 +40,7 @@ if (!$module_name) {
 
 # Parse command-line args
 while(@ARGV > 0) {
-	local $a = shift(@ARGV);
+	my $a = shift(@ARGV);
 	if ($a eq "--domain") {
 		$dname = shift(@ARGV);
 		}

--- a/letsencrypt.cgi
+++ b/letsencrypt.cgi
@@ -260,7 +260,7 @@ else {
 
 		# Run the after command
 		&set_domain_envs($d, "SSL_DOMAIN");
-		local $merr = &made_changes();
+		my $merr = &made_changes();
 		&$second_print(&text('setup_emade', "<tt>$merr</tt>"))
 			if (defined($merr));
 		&reset_domain_envs($d);

--- a/licence-info.pl
+++ b/licence-info.pl
@@ -27,7 +27,7 @@ if (!$module_name) {
 	}
 
 while(@ARGV > 0) {
-	local $a = shift(@ARGV);
+	my $a = shift(@ARGV);
 	if ($a eq "--multiline") {
 		$multiline = 1;
 		}

--- a/link.cgi
+++ b/link.cgi
@@ -87,9 +87,9 @@ close($fh);
 sub open_target_connection
 {
 my ($req, $method) = @_;
-local $oldproxy = $gconfig{'http_proxy'};
-local $con;
-local $httphost = $req->{'host'};
+my $oldproxy = $gconfig{'http_proxy'};
+my $con;
+my $httphost = $req->{'host'};
 $gconfig{'http_proxy'} = '';
 $con = &make_http_connection(
 	$req->{'ip'}, $req->{'port'}, $req->{'ssl'}, $method,

--- a/list-admins.pl
+++ b/list-admins.pl
@@ -31,7 +31,7 @@ if (!$module_name) {
 # Parse command-line args
 &parse_common_cli_flags(\@ARGV);
 while(@ARGV > 0) {
-	local $a = shift(@ARGV);
+	my $a = shift(@ARGV);
 	if ($a eq "--domain") {
 		$domain = shift(@ARGV);
 		}

--- a/list-aliases.pl
+++ b/list-aliases.pl
@@ -48,7 +48,7 @@ if (!$module_name) {
 # Parse command-line args
 &parse_common_cli_flags(\@ARGV);
 while(@ARGV > 0) {
-	local $a = shift(@ARGV);
+	my $a = shift(@ARGV);
 	if ($a eq "--domain") {
 		push(@dnames, shift(@ARGV));
 		}
@@ -121,7 +121,7 @@ foreach $d (@doms) {
 
 sub nice_from
 {
-local $f = $_[0];
+my $f = $_[0];
 $f =~ s/\@\Q$d->{'dom'}\E$//;
 return $f eq "" ? "*" : $f;
 }

--- a/list-available-scripts.pl
+++ b/list-available-scripts.pl
@@ -37,7 +37,7 @@ if (!$module_name) {
 @types = ( );
 &parse_common_cli_flags(\@ARGV);
 while(@ARGV > 0) {
-	local $a = shift(@ARGV);
+	my $a = shift(@ARGV);
 	if ($a eq "--source") {
 		$source = shift(@ARGV);
 		}

--- a/list-available-shells.pl
+++ b/list-available-shells.pl
@@ -36,7 +36,7 @@ if (!$module_name) {
 # Parse command-line args
 &parse_common_cli_flags(\@ARGV);
 while(@ARGV > 0) {
-	local $a = shift(@ARGV);
+	my $a = shift(@ARGV);
 	if ($a eq "--owner") {
 		$type = "owner";
 		}

--- a/list-backup-logs.pl
+++ b/list-backup-logs.pl
@@ -47,7 +47,7 @@ if (!$module_name) {
 # Parse command-line args
 &parse_common_cli_flags(\@ARGV);
 while(@ARGV > 0) {
-	local $a = shift(@ARGV);
+	my $a = shift(@ARGV);
 	if ($a eq "--domain") {
 		$domain = shift(@ARGV);
 		}

--- a/list-bandwidth.pl
+++ b/list-bandwidth.pl
@@ -40,7 +40,7 @@ if (!$module_name) {
 $owner = 1;
 &parse_common_cli_flags(\@ARGV);
 while(@ARGV > 0) {
-	local $a = shift(@ARGV);
+	my $a = shift(@ARGV);
 	if ($a eq "--domain") {
 		push(@domains, shift(@ARGV));
 		}
@@ -94,7 +94,7 @@ foreach my $d (@doms) {
 	foreach my $sd (@subdoms) {
 		$bwinfo = &get_bandwidth($sd);
 		foreach my $k (keys %$bwinfo) {
-			local ($f, $dt) = split(/_/, $k);
+			my ($f, $dt) = split(/_/, $k);
 			next if ($dt !~ /^\d+$/);
 			$daymap{$dt}->{$f} += $bwinfo->{$k};
 			$allfeatures{$f} = 1;

--- a/list-certs-expiry.pl
+++ b/list-certs-expiry.pl
@@ -39,7 +39,7 @@ if (!$module_name) {
 # Parse command-line args
 &parse_common_cli_flags(\@ARGV);
 while (@ARGV > 0) {
-	local $a = shift(@ARGV);
+	my $a = shift(@ARGV);
 	if ($a eq "--all-domains") {
 		$all_doms = 1;
 		}

--- a/list-certs.pl
+++ b/list-certs.pl
@@ -46,7 +46,7 @@ if (!$module_name) {
 @alltypes = ( "cert", "key", "ca", "csr", "newkey" );
 &parse_common_cli_flags(\@ARGV);
 while(@ARGV > 0) {
-	local $a = shift(@ARGV);
+	my $a = shift(@ARGV);
 	if ($a eq "--domain") {
 		push(@dnames, shift(@ARGV));
 		}

--- a/list-commands.pl
+++ b/list-commands.pl
@@ -31,7 +31,7 @@ if (!$module_name) {
 my $short = 1;
 &parse_common_cli_flags(\@ARGV);
 while(@ARGV > 0) {
-	local $a = shift(@ARGV);
+	my $a = shift(@ARGV);
 	if ($a eq "--short") {
 		$short = 1;
 		}

--- a/list-custom.pl
+++ b/list-custom.pl
@@ -35,7 +35,7 @@ if (!$module_name) {
 $owner = 1;
 &parse_common_cli_flags(\@ARGV);
 while(@ARGV > 0) {
-	local $a = shift(@ARGV);
+	my $a = shift(@ARGV);
 	if ($a eq "--domain") {
 		push(@domains, shift(@ARGV));
 		}

--- a/list-databases.pl
+++ b/list-databases.pl
@@ -31,7 +31,7 @@ if (!$module_name) {
 # Parse command-line args
 &parse_common_cli_flags(\@ARGV);
 while(@ARGV > 0) {
-	local $a = shift(@ARGV);
+	my $a = shift(@ARGV);
 	if ($a eq "--domain") {
 		$domain = shift(@ARGV);
 		}

--- a/list-domains.pl
+++ b/list-domains.pl
@@ -77,7 +77,7 @@ $owner = 1;
 @allplans = &list_plans();
 &parse_common_cli_flags(\@ARGV);
 while(@ARGV > 0) {
-	local $a = shift(@ARGV);
+	my $a = shift(@ARGV);
 	if ($a eq "--user-only") {
 		$useronly = 1;
 		}
@@ -302,8 +302,8 @@ if ($multiline) {
 		$recipient_bcc = &get_all_domains_recipient_bcc();
 		}
 	foreach $d (@doms) {
-		local @users = &list_domain_users($d, 0, 1, 0, 1);
-		local ($duser) = grep { $_->{'user'} eq $d->{'user'} } @users;
+		my @users = &list_domain_users($d, 0, 1, 0, 1);
+		my ($duser) = grep { $_->{'user'} eq $d->{'user'} } @users;
 		print "$d->{'dom'}\n";
 		print "    ID: $d->{'id'}\n";
 		print "    File: $d->{'file'}\n";
@@ -431,7 +431,7 @@ if ($multiline) {
 				print "    IP address: $d->{'ip'} (Private)\n";
 				}
 			else {
-				local $iface = &get_address_iface($d->{'ip'});
+				my $iface = &get_address_iface($d->{'ip'});
 				print "    IP address: $d->{'ip'} ",
 				      "(On $iface)\n";
 				}
@@ -444,7 +444,7 @@ if ($multiline) {
 				print "    IP address: $d->{'ip6'} (Private)\n";
 				}
 			else {
-				local $iface = &get_address_iface($d->{'ip6'});
+				my $iface = &get_address_iface($d->{'ip6'});
 				print "    IP address: $d->{'ip6'} ",
 				      "(On $iface)\n";
 				}

--- a/list-dropbox-files.pl
+++ b/list-dropbox-files.pl
@@ -34,7 +34,7 @@ $state->{'ok'} || &usage("Dropbox has not been configured yet");
 # Parse command-line args
 &parse_common_cli_flags(\@ARGV);
 while(@ARGV > 0) {
-	local $a = shift(@ARGV);
+	my $a = shift(@ARGV);
 	if ($a eq "--path") {
 		$path = shift(@ARGV);
 		}

--- a/list-features.pl
+++ b/list-features.pl
@@ -41,7 +41,7 @@ if (!$module_name) {
 $owner = 1;
 &parse_common_cli_flags(\@ARGV);
 while(@ARGV > 0) {
-	local $a = shift(@ARGV);
+	my $a = shift(@ARGV);
 	if ($a eq "--parent") {
 		$parentname = shift(@ARGV);
 		}

--- a/list-gcs-buckets.pl
+++ b/list-gcs-buckets.pl
@@ -35,7 +35,7 @@ $state->{'ok'} || &usage("Google Cloud Storage has not been configured yet");
 # Parse command-line args
 &parse_common_cli_flags(\@ARGV);
 while(@ARGV > 0) {
-	local $a = shift(@ARGV);
+	my $a = shift(@ARGV);
 	if ($a eq "--bucket") {
 		$bucket = shift(@ARGV);
 		}

--- a/list-gcs-files.pl
+++ b/list-gcs-files.pl
@@ -34,7 +34,7 @@ $state->{'ok'} || &usage("Google Cloud Storage has not been configured yet");
 # Parse command-line args
 &parse_common_cli_flags(\@ARGV);
 while(@ARGV > 0) {
-	local $a = shift(@ARGV);
+	my $a = shift(@ARGV);
 	if ($a eq "--bucket") {
 		$bucket = shift(@ARGV);
 		}

--- a/list-mailbox.pl
+++ b/list-mailbox.pl
@@ -41,7 +41,7 @@ if (!$module_name) {
 $owner = 1;
 &parse_common_cli_flags(\@ARGV);
 while(@ARGV > 0) {
-	local $a = shift(@ARGV);
+	my $a = shift(@ARGV);
 	if ($a eq "--domain") {
 		$dname = shift(@ARGV);
 		}

--- a/list-mysql-servers.pl
+++ b/list-mysql-servers.pl
@@ -29,7 +29,7 @@ if (!$module_name) {
 # Parse command-line args
 &parse_common_cli_flags(\@ARGV);
 while(@ARGV > 0) {
-	local $a = shift(@ARGV);
+	my $a = shift(@ARGV);
 	&usage("Unknown parameter $a");
 	}
 @mods = &list_remote_mysql_modules();

--- a/list-php-directories.pl
+++ b/list-php-directories.pl
@@ -35,7 +35,7 @@ if (!$module_name) {
 $owner = 1;
 &parse_common_cli_flags(\@ARGV);
 while(@ARGV > 0) {
-	local $a = shift(@ARGV);
+	my $a = shift(@ARGV);
 	if ($a eq "--domain") {
 		$domain = shift(@ARGV);
 		}

--- a/list-php-ini.pl
+++ b/list-php-ini.pl
@@ -40,7 +40,7 @@ if (!$module_name) {
 # Parse command-line args
 &parse_common_cli_flags(\@ARGV);
 while(@ARGV > 0) {
-	local $a = shift(@ARGV);
+	my $a = shift(@ARGV);
 	if ($a eq "--domain") {
 		push(@domains, shift(@ARGV));
 		}

--- a/list-php-versions.pl
+++ b/list-php-versions.pl
@@ -37,7 +37,7 @@ if (!$module_name) {
 $owner = 1;
 &parse_common_cli_flags(\@ARGV);
 while(@ARGV > 0) {
-	local $a = shift(@ARGV);
+	my $a = shift(@ARGV);
 	if ($a eq "--domain") {
 		$dname = shift(@ARGV);
 		}

--- a/list-plans.pl
+++ b/list-plans.pl
@@ -32,7 +32,7 @@ if (!$module_name) {
 # Parse command-line args
 &parse_common_cli_flags(\@ARGV);
 while(@ARGV > 0) {
-	local $a = shift(@ARGV);
+	my $a = shift(@ARGV);
 	if ($a eq "--id") {
 		$planid = shift(@ARGV);
 		}

--- a/list-ports.pl
+++ b/list-ports.pl
@@ -30,7 +30,7 @@ if (!$module_name) {
 # Parse command-line args
 &parse_common_cli_flags(\@ARGV);
 while(@ARGV > 0) {
-	local $a = shift(@ARGV);
+	my $a = shift(@ARGV);
 	if ($a eq "--domain") {
 		$domain = shift(@ARGV);
 		}

--- a/list-proxies.pl
+++ b/list-proxies.pl
@@ -31,7 +31,7 @@ if (!$module_name) {
 # Parse command-line args
 &parse_common_cli_flags(\@ARGV);
 while(@ARGV > 0) {
-	local $a = shift(@ARGV);
+	my $a = shift(@ARGV);
 	if ($a eq "--domain") {
 		$domain = shift(@ARGV);
 		}

--- a/list-redirects.pl
+++ b/list-redirects.pl
@@ -40,7 +40,7 @@ if (!$module_name) {
 # Parse command-line args
 &parse_common_cli_flags(\@ARGV);
 while(@ARGV > 0) {
-	local $a = shift(@ARGV);
+	my $a = shift(@ARGV);
 	if ($a eq "--domain") {
 		$domain = shift(@ARGV);
 		}

--- a/list-rs-containers.pl
+++ b/list-rs-containers.pl
@@ -36,7 +36,7 @@ if (!$module_name) {
 $owner = 1;
 &parse_common_cli_flags(\@ARGV);
 while(@ARGV > 0) {
-	local $a = shift(@ARGV);
+	my $a = shift(@ARGV);
 	if ($a eq "--user") {
 		$user = shift(@ARGV);
 		}

--- a/list-rs-files.pl
+++ b/list-rs-files.pl
@@ -37,7 +37,7 @@ if (!$module_name) {
 $owner = 1;
 &parse_common_cli_flags(\@ARGV);
 while(@ARGV > 0) {
-	local $a = shift(@ARGV);
+	my $a = shift(@ARGV);
 	if ($a eq "--user") {
 		$user = shift(@ARGV);
 		}

--- a/list-s3-accounts.pl
+++ b/list-s3-accounts.pl
@@ -33,7 +33,7 @@ if (!$module_name) {
 $owner = 1;
 &parse_common_cli_flags(\@ARGV);
 while(@ARGV > 0) {
-	local $a = shift(@ARGV);
+	my $a = shift(@ARGV);
 	&usage("Unknown parameter $a");
 	}
 @s3s = &list_s3_accounts();

--- a/list-s3-buckets.pl
+++ b/list-s3-buckets.pl
@@ -36,7 +36,7 @@ if (!$module_name) {
 $owner = 1;
 &parse_common_cli_flags(\@ARGV);
 while(@ARGV > 0) {
-	local $a = shift(@ARGV);
+	my $a = shift(@ARGV);
 	if ($a eq "--access-key") {
 		$akey = shift(@ARGV);
 		}
@@ -68,7 +68,7 @@ if ($multiline) {
 	# Full details
 	foreach $f (@$files) {
 		print $f->{'Name'},"\n";
-		local $ctime = &s3_parse_date($f->{'CreationDate'});
+		my $ctime = &s3_parse_date($f->{'CreationDate'});
 		print "    Created: ",&make_date($ctime),"\n";
 		print "    Created time: ",$ctime,"\n";
 		$loc = &s3_get_bucket_location($akey, $skey, $f->{'Name'});
@@ -126,14 +126,14 @@ else {
 	printf $fmt, "Bucket name", "Created";
 	printf $fmt, ("-" x 45), ("-" x 30);
 	foreach $f (@$files) {
-		local $ctime = &s3_parse_date($f->{'CreationDate'});
+		my $ctime = &s3_parse_date($f->{'CreationDate'});
 		printf $fmt, $f->{'Name'}, &make_date($ctime);
 		}
 	}
 
 sub show_lifecycle_period
 {
-local ($obj, $txt) = @_;
+my ($obj, $txt) = @_;
 if ($obj && $obj->{'Date'}) {
 	print "    Lifecycle ${txt}: On date $obj->{'Date'}\n";
 	}

--- a/list-s3-files.pl
+++ b/list-s3-files.pl
@@ -36,7 +36,7 @@ if (!$module_name) {
 $owner = 1;
 &parse_common_cli_flags(\@ARGV);
 while(@ARGV > 0) {
-	local $a = shift(@ARGV);
+	my $a = shift(@ARGV);
 	if ($a eq "--bucket") {
 		$bucket = shift(@ARGV);
 		}
@@ -70,7 +70,7 @@ if ($multiline) {
 		if ($f->{'Owner'}) {
 			print "    Owner: $f->{'Owner'}->{'DisplayName'}\n";
 			}
-		local $ctime = &s3_parse_date($f->{'LastModified'});
+		my $ctime = &s3_parse_date($f->{'LastModified'});
 		print "    Last modified: ",&make_date($ctime),"\n";
 		print "    Last modified time: ",$ctime,"\n";
 		print "    Storage class: $f->{'StorageClass'}\n";
@@ -89,7 +89,7 @@ else {
 	printf $fmt, "Filename", "Size", "Last modified";
 	printf $fmt, ("-" x 35), ("-" x 12), ("-" x 30);
 	foreach $f (@$files) {
-		local $ctime = &s3_parse_date($f->{'LastModified'});
+		my $ctime = &s3_parse_date($f->{'LastModified'});
 		printf $fmt, $f->{'Key'}, &nice_size($f->{'Size'}),
 			     &make_date($ctime);
 		}

--- a/list-scheduled-backups.pl
+++ b/list-scheduled-backups.pl
@@ -36,7 +36,7 @@ if (!$module_name) {
 # Parse command-line args
 &parse_common_cli_flags(\@ARGV);
 while(@ARGV > 0) {
-	local $a = shift(@ARGV);
+	my $a = shift(@ARGV);
 	if ($a eq "--domain") {
 		$domain = shift(@ARGV);
 		}
@@ -197,8 +197,8 @@ exit(1);
 
 sub make_nice_dnames
 {
-local ($s) = @_;
-local @dnames = ( );
+my ($s) = @_;
+my @dnames = ( );
 foreach my $did (split(/\s+/, $s->{'doms'})) {
 	$d = &get_domain($did);
 	push(@dnames, $d->{'dom'}) if ($d);

--- a/list-scripts.pl
+++ b/list-scripts.pl
@@ -39,7 +39,7 @@ if (!$module_name) {
 # Parse command-line args
 &parse_common_cli_flags(\@ARGV);
 while(@ARGV > 0) {
-	local $a = shift(@ARGV);
+	my $a = shift(@ARGV);
 	if ($a eq "--domain") {
 		push(@dnames, shift(@ARGV));
 		}

--- a/list-server-statuses.pl
+++ b/list-server-statuses.pl
@@ -28,7 +28,7 @@ if (!$module_name) {
 
 &parse_common_cli_flags(\@ARGV);
 while(@ARGV > 0) {
-        local $a = shift(@ARGV);
+        my $a = shift(@ARGV);
 	&usage("Unknown parameter $a");
 	}
 

--- a/list-service-certs.pl
+++ b/list-service-certs.pl
@@ -29,7 +29,7 @@ if (!$module_name) {
 # Parse command line to get domains
 &parse_common_cli_flags(\@ARGV);
 while(@ARGV > 0) {
-	local $a = shift(@ARGV);
+	my $a = shift(@ARGV);
 	if ($a eq "--domain") {
 		$dname = shift(@ARGV);
 		}

--- a/list-shared-addresses.pl
+++ b/list-shared-addresses.pl
@@ -38,7 +38,7 @@ $owner = 1;
 $ipv4 = 1;
 $ipv6 = 0;
 while(@ARGV > 0) {
-	local $a = shift(@ARGV);
+	my $a = shift(@ARGV);
 	if ($a eq "--ipv6") {
 		$ipv6 = 1;
 		}

--- a/list-simple-aliases.pl
+++ b/list-simple-aliases.pl
@@ -30,7 +30,7 @@ if (!$module_name) {
 # Parse command-line args
 &parse_common_cli_flags(\@ARGV);
 while(@ARGV > 0) {
-	local $a = shift(@ARGV);
+	my $a = shift(@ARGV);
 	if ($a eq "--domain") {
 		push(@dnames, shift(@ARGV));
 		}
@@ -119,7 +119,7 @@ foreach $d (@doms) {
 
 sub nice_from
 {
-local $f = $_[0];
+my $f = $_[0];
 $f =~ s/\@$domain$//;
 return $f eq "%1" || !$f ? "*" : $f;
 }

--- a/list-templates.pl
+++ b/list-templates.pl
@@ -37,7 +37,7 @@ $owner = 1;
 $deleted = 0;
 &parse_common_cli_flags(\@ARGV);
 while(@ARGV > 0) {
-	local $a = shift(@ARGV);
+	my $a = shift(@ARGV);
 	if ($a eq "--deleted") {
 		$deleted = 1;
 		}

--- a/list-users.pl
+++ b/list-users.pl
@@ -53,7 +53,7 @@ if (!$module_name) {
 $owner = 1;
 &parse_common_cli_flags(\@ARGV);
 while(@ARGV > 0) {
-	local $a = shift(@ARGV);
+	my $a = shift(@ARGV);
 	if ($a eq "--domain") {
 		push(@dnames, shift(@ARGV));
 		}

--- a/list_databases.cgi
+++ b/list_databases.cgi
@@ -130,7 +130,7 @@ $can_scripts = $can_scripts && @phpmyadmin;
 print &ui_tabs_start_tab("databasemode", "list") if (@tabs > 1);
 print "$text{'databases_desc1'}<p>\n";
 foreach $db (sort { $a->{'name'} cmp $b->{'name'} } @dbs) {
-	local $action;
+	my $action;
 	if ($db->{'link'}) {
 		$action = "<a href='$db->{'link'}'>".
 			  "$text{'databases_man'}</a>";
@@ -142,7 +142,7 @@ foreach $db (sort { $a->{'name'} cmp $b->{'name'} } @dbs) {
 				"$text{'databases_login_pma_link'}</a>";
 			}
 		}
-	local $dis = $db->{'name'} eq $d->{'db'} && !&can_edit_database_name();
+	my $dis = $db->{'name'} eq $d->{'db'} && !&can_edit_database_name();
 	push(@table, [
 		{ 'type' => 'checkbox', 'name' => 'd',
 		  'value' => $db->{'type'}.'_'.$db->{'name'},

--- a/list_users.cgi
+++ b/list_users.cgi
@@ -13,7 +13,7 @@ $utotal = scalar(@users);
 if (!$d->{'parent'}) {
 	# Sum up users from all sub-domains
 	foreach my $sd (&get_domain_by("parent", $d->{'id'})) {
-		local @susers = &list_domain_users($sd, 0, 1, 1, 1, 1);
+		my @susers = &list_domain_users($sd, 0, 1, 1, 1, 1);
 		$utotal += scalar(@susers);
 		}
 	}

--- a/log_parser.pl
+++ b/log_parser.pl
@@ -7,7 +7,7 @@ do 'virtual-server-lib.pl';
 # Converts logged information from this module into human-readable form
 sub parse_webmin_log
 {
-local ($user, $script, $action, $type, $object, $p, $long) = @_;
+my ($user, $script, $action, $type, $object, $p, $long) = @_;
 if ($type eq "user") {
 	return &text('log_'.$action.'_user', "<tt>$object</tt>",
 					     "<tt>$p->{'dom'}</tt>");
@@ -58,7 +58,7 @@ elsif ($type eq "record" && $p->{'defttl'}) {
 	return &text('log_'.$action.'_defttl', "<tt>$object</tt>");
 	}
 elsif ($type eq "record") {
-	local $n = $p->{'name'};
+	my $n = $p->{'name'};
 	$n =~ s/\.$//;
 	$n =~ s/\.\Q$object\E$//;
 	return &text('log_'.$action.'_record', "<tt>$object</tt>",
@@ -100,7 +100,7 @@ elsif ($type eq "scripts" && ($action eq "upgrade" || $action eq "uninstall" ||
 	return &text('log_'.$action.'_scripts', $object);
 	}
 elsif ($type eq "scripts") {
-	local @scripts = map { /^(.*)\.pl$/ ? "<tt>$1</tt>" : "<tt>$_</tt>" }
+	my @scripts = map { /^(.*)\.pl$/ ? "<tt>$1</tt>" : "<tt>$_</tt>" }
 			     split(/\0/, $p->{'scripts'});
 	return &text('log_'.$action.'_scripts', join(" ", @scripts));
 	}
@@ -119,7 +119,7 @@ elsif ($action eq "start" || $action eq "stop" || $action eq "restart") {
 	return $text{'log_'.$action.'_'.$type};
 	}
 elsif ($action eq "backup" || $action eq "restore") {
-	local @doms = split(/\0/, $p->{'doms'});
+	my @doms = split(/\0/, $p->{'doms'});
 	$action .= '_failed' if ($p->{'failed'});
 	if ($long) {
 		return &text('log_'.$action.'_l', join(" ", map { "<tt>$_</tt>" } @doms));
@@ -129,7 +129,7 @@ elsif ($action eq "backup" || $action eq "restore") {
 		}
 	}
 elsif ($type eq "sched") {
-	local $msg = $object eq 'all' ? $text{'log_sched_all'} :
+	my $msg = $object eq 'all' ? $text{'log_sched_all'} :
 		     $object eq 'none' ? $text{'log_sched_none'} :
 		     $object eq 'virtualmin' ? $text{'log_sched_virtualmin'} :
 					       &text('log_sched_doms', $object);

--- a/lookup-domain-daemon.pl
+++ b/lookup-domain-daemon.pl
@@ -84,7 +84,7 @@ while(1) {
 	($peerp, $peera) = unpack_sockaddr_in($acptaddr);
 
 	# Truncate the log if too big (10MB)
-	local @st = stat($daemon_logfile);
+	my @st = stat($daemon_logfile);
 	if ($st[7] > 10*1024*1024) {
 		close(STDERR);
 		open(STDERR, ">$daemon_logfile");
@@ -129,7 +129,7 @@ while(1) {
 		
 		# Maintain list of child processes
 		push(@childpids, $pid);
-		local $expid;
+		my $expid;
 		do {	$expid = waitpid(-1, WNOHANG);
 			} while($expid != 0 && $expid != -1);
 		@childpids = grep { kill(0, $_) } @childpids;
@@ -169,24 +169,24 @@ if (!$user) {
 # send_response(&domain, &user)
 sub send_response
 {
-local ($d, $user) = @_;
-local $now = localtime(time());
+my ($d, $user) = @_;
+my $now = localtime(time());
 if ($d && $user) {
 	# Get the user's quota
-	local $qmode = &has_home_quotas() ? "home" : undef;
-	local ($quota, $uquota);
+	my $qmode = &has_home_quotas() ? "home" : undef;
+	my ($quota, $uquota);
 	if ($qmode eq "home") {
 		($quota, $uquota) = ($user->{'quota'}, $user->{'uquota'});
 		}
-	local $quotadiff = $quota ? ($quota - $uquota) : undef;
+	my $quotadiff = $quota ? ($quota - $uquota) : undef;
 
 	# Get the domain's quota, in case it is less
-	local $qd = $d->{'parent'} ? &get_domain($d->{'parent'}) : $d;
-	local $dquota = $qd->{'quota'};
-	local $duquota;
+	my $qd = $d->{'parent'} ? &get_domain($d->{'parent'}) : $d;
+	my $dquota = $qd->{'quota'};
+	my $duquota;
 	if ($dquota && &has_group_quotas()) {
 		($duquota) = &get_domain_quota($qd, 0);
-		local $dquotadiff = $dquota - $duquota;
+		my $dquotadiff = $dquota - $duquota;
 		if ($dquotadiff < $quotadiff) {
 			# Domain has less space free than user!
 			$quotadiff = $dquotadiff;
@@ -198,7 +198,7 @@ if ($d && $user) {
 		$quotadiff = undef;
 		}
 
-	local $client = &get_domain_spam_client($d);
+	my $client = &get_domain_spam_client($d);
 	print join("\t", $d->{'id'},
 			 $d->{'dom'},
 			 $d->{'spam'} && !$user->{'nospam'},

--- a/mass_aedit.cgi
+++ b/mass_aedit.cgi
@@ -30,7 +30,7 @@ $count = $ecount = $mcount = $dcount = 0;
 USER: foreach $line (@lines) {
 	$lnum++;
 	next if ($line !~ /\S/);
-	local ($name, $desc, @dests) = split(/:/, $line, -1);
+	my ($name, $desc, @dests) = split(/:/, $line, -1);
 
 	# Make sure needed parameters are given
 	if ($name =~ /^\@\S*$/) {
@@ -182,7 +182,7 @@ print &text('aedit_complete', $count, $ecount, $mcount, $dcount),"<br>\n";
 
 sub line_error
 {
-local ($msg) = @_;
+my ($msg) = @_;
 print "<font color=#ff0000>";
 if (!$name) {
 	print &text('cmass_eline', $lnum, $msg);

--- a/mass_create.cgi
+++ b/mass_create.cgi
@@ -60,7 +60,7 @@ $sep = "\t" if ($sep eq "tab");
 foreach $line (@lines) {
 	$lnum++;
 	next if ($line !~ /\S/);
-	local ($dname, $owner, $pass, $user, $pname, $ip, $aname) = split($sep, $line, -1);
+	my ($dname, $owner, $pass, $user, $pname, $ip, $aname) = split($sep, $line, -1);
 	$dname = lc(&parse_domain_name($dname));
 	$user = lc($user);
 
@@ -85,7 +85,7 @@ foreach $line (@lines) {
 					$text{'setup_edomain4'});
 		next;
 		}
-	local $parentdom;
+	my $parentdom;
 	if ($pname) {
 		$parentdom = &get_domain_by("dom", $pname);
 		if (!$parentdom) {
@@ -100,7 +100,7 @@ foreach $line (@lines) {
 	elsif (!&can_create_master_servers()) {
 		&line_error($text{'cmass_emustparent'});
 		}
-	local $aliasdom;
+	my $aliasdom;
 	if ($aname) {
 		$aliasdom = &get_domain_by("dom", $aname);
 		if (!$aliasdom) {
@@ -113,16 +113,16 @@ foreach $line (@lines) {
 		}
 
 	# Get the reseller
-	local $resel = $parentdom ? $parentdom->{'reseller'} : $defresel;
+	my $resel = $parentdom ? $parentdom->{'reseller'} : $defresel;
 
 	# Get the template
-	local $tmpl = &get_template($parentdom ? $in{'stemplate'}
+	my $tmpl = &get_template($parentdom ? $in{'stemplate'}
 					       : $in{'ptemplate'});
 
 	# Validate IP address
-	local $defip = &get_default_ip($resel);
-	local $defip6 = &get_default_ip6($resel);
-	local ($virt, $virtalready, $ip6, $virt6, $allocated);
+	my $defip = &get_default_ip($resel);
+	my $defip6 = &get_default_ip6($resel);
+	my ($virt, $virtalready, $ip6, $virt6, $allocated);
 	if ($aliasdom) {
 		$ip = $aliasdom->{'ip'};
 		$ip6 = $aliasdom->{'ip6'};
@@ -218,7 +218,7 @@ foreach $line (@lines) {
 		}
 
 	# Work out username
-	local $group;
+	my $group;
 	if (!$parentdom) {
 		if (!$user) {
 			# Select a username
@@ -253,7 +253,7 @@ foreach $line (@lines) {
 			}
 
 		# Check username restrictions
-		local $uerr = &useradmin::check_username_restrictions($user);
+		my $uerr = &useradmin::check_username_restrictions($user);
 		if ($uerr) {
 			&line_error(&text('setup_eusername', $user, $uerr));
 			next;
@@ -261,7 +261,7 @@ foreach $line (@lines) {
 		}
 
 	# Check if domains limit has been exceeded
-	local ($dleft, $dreason, $dmax) =
+	my ($dleft, $dreason, $dmax) =
 		&count_domains($aliasdom ? "aliasdoms" :
 			       $parentdom ? "realdoms" : "topdoms");
 	if ($dleft == 0) {
@@ -271,15 +271,15 @@ foreach $line (@lines) {
 
 	# Make sure domain is under parent, if required
 	if ($parentdom) {
-		local $derr = &allowed_domain_name($parentdom, $dname);
+		my $derr = &allowed_domain_name($parentdom, $dname);
 		if ($derr) {
 			&line_error($derr);
 			next;
 			}
 		}
 
-	local (%gtaken, %ggtaken, %taken, %utaken);
-	local ($gid, $ugid, $uid);
+	my (%gtaken, %ggtaken, %taken, %utaken);
+	my ($gid, $ugid, $uid);
 	if ($parentdom) {
 		# User and group IDs come from parent
 		$gid = $parentdom->{'gid'};
@@ -293,7 +293,7 @@ foreach $line (@lines) {
 		$gid = $gid = $uid = undef;
 		$ugroup = $group;
 		}
-	local $prefix = &compute_prefix($dname, $group, $parentdom, 1);
+	my $prefix = &compute_prefix($dname, $group, $parentdom, 1);
 
 	# Work out the plan
 	if ($parentdom) {
@@ -308,7 +308,7 @@ foreach $line (@lines) {
 		}
 
 	# Build up domain object
-	local %dom;
+	my %dom;
 	%dom = ( 'id', &domain_id(),
 		 'dom', $dname,
 		 'user', $user,
@@ -372,19 +372,19 @@ foreach $line (@lines) {
 	&complete_domain(\%dom);
 
 	# Check for various clashes
-	local $derr = &virtual_server_depends(\%dom);
+	my $derr = &virtual_server_depends(\%dom);
 	if ($derr) {
 		&line_error($derr);
 		next;
 		}
-	local $cerr = &virtual_server_clashes(\%dom);
+	my $cerr = &virtual_server_clashes(\%dom);
 	if ($cerr) {
 		&line_error($cerr);
 		next;
 		}
 
 	# Check if this new domain would exceed any limits
-	local $lerr = &virtual_server_limits(\%dom);
+	my $lerr = &virtual_server_limits(\%dom);
 	if ($lerr) {
 		&line_error($lerr);
 		next;
@@ -407,7 +407,7 @@ foreach $line (@lines) {
 	else {
 		&set_all_null_print();
 		}
-	local $err = &create_virtual_server(\%dom, $parentdom,
+	my $err = &create_virtual_server(\%dom, $parentdom,
 			      $parentdom ? $parentdom->{'user'} : undef, 0, 1,
 			      $parentdom ? undef : $pass);
 
@@ -458,7 +458,7 @@ print &text('cmass_complete', $count, $ecount),"<br>\n";
 
 sub line_error
 {
-local ($msg) = @_;
+my ($msg) = @_;
 print "<font color=#ff0000>";
 if (!$dname) {
 	print &text('cmass_eline', $lnum, $msg);

--- a/mass_create_form.cgi
+++ b/mass_create_form.cgi
@@ -91,7 +91,7 @@ foreach $f (@opt_features) {
 		next;
 		}
 
-	local $txt = $text{'form_'.$f};
+	my $txt = $text{'form_'.$f};
 	push(@grid_order, $f);
 	push(@grid, &ui_checkbox($f, 1, "", $config{$f} == 1, undef,
 			  !$config{$f} && defined($config{$f}))." ".

--- a/mass_scripts.cgi
+++ b/mass_scripts.cgi
@@ -87,7 +87,7 @@ if ($in{'confirm'}) {
 		&obtain_lock_cron($d);
 
 		# Check if we have PHP
-		local $phpver;
+		my $phpver;
 		if (&indexof("php", @{$script->{'uses'}}) >= 0) {
 			($phpver, $phperr) = &setup_php_version(
 				$d, $script, $ver, $opts->{'path'});

--- a/mass_ucreate.cgi
+++ b/mass_ucreate.cgi
@@ -38,7 +38,7 @@ $source =~ s/\r//g;
 ($nologin_shell, $ftp_shell, $jailed_shell) = &get_common_available_shells();
 
 # Build taken lists
-local (%taken, %utaken);
+my (%taken, %utaken);
 &obtain_lock_unix();
 &obtain_lock_mail();
 &build_taken(\%taken, \%utaken);
@@ -58,7 +58,7 @@ $sep = "\t" if ($sep eq "tab");
 USER: foreach $line (@lines) {
 	$lnum++;
 	next if ($line !~ /\S/);
-	local ($username, $real, $pass, $ftp, $email, $quota, $extras, $forwards, $dbs) = split($sep, $line, -1);
+	my ($username, $real, $pass, $ftp, $email, $quota, $extras, $forwards, $dbs) = split($sep, $line, -1);
 	if (!$config{'allow_upper'}) {
 		$username = lc($username);
 		}
@@ -84,14 +84,14 @@ USER: foreach $line (@lines) {
 		}
 
 	# Check if this user has hit his mailbox limit
-	local ($mleft, $mreason, $mmax) = &count_feature("mailboxes");
+	my ($mleft, $mreason, $mmax) = &count_feature("mailboxes");
 	if ($mleft == 0) {
 		&line_error($text{'user_emailboxlimit'});
 		next USER;
 		}
 
 	# Validate extra addresses
-	local @extra = split(/,/, $extras);
+	my @extra = split(/,/, $extras);
 	foreach $e (@extra) {
 		if ($user->{'noextra'}) {
 			&line_error($text{'umass_eextra'});
@@ -105,8 +105,8 @@ USER: foreach $line (@lines) {
 			&line_error(&text('user_eextra1', $e));
 			next USER;
 			}
-		local ($eu, $ed) = ($1, $2);
-		local $edom = &get_domain_by("dom", $ed);
+		my ($eu, $ed) = ($1, $2);
+		my $edom = &get_domain_by("dom", $ed);
 		if (!$edom || !$edom->{'mail'}) {
 			&line_error(&text('user_eextra2', $ed));
 			next USER;
@@ -118,7 +118,7 @@ USER: foreach $line (@lines) {
 		}
 
 	# Validate forwarding addresses
-	local @forward = split(/,/, $forwards);
+	my @forward = split(/,/, $forwards);
 	foreach $f (@forward) {
 		if ($f !~ /\@/) {
 			$f .= "\@$d->{'dom'}";
@@ -130,7 +130,7 @@ USER: foreach $line (@lines) {
 		}
 
 	# Check if extras would exceed limit
-	local ($mleft, $mreason, $mmax) = &count_feature("aliases");
+	my ($mleft, $mreason, $mmax) = &count_feature("aliases");
 	if ($mleft >= 0 &&
 	    $mleft - @extra + (%old ? @{$old{'extraemail'}} : 0) < 0) {
 		&line_error($text{'alias_ealiaslimit'});
@@ -138,12 +138,12 @@ USER: foreach $line (@lines) {
 		}
 
 	# Validate databases
-	local @dbs;
+	my @dbs;
 	foreach my $dbi (split(/,/, $dbs)) {
-		local ($dbtype, $dbname) = split(/\s+/, $dbi);
+		my ($dbtype, $dbname) = split(/\s+/, $dbi);
 		push(@dbs, { 'type' => $dbtype, 'name' => $dbname });
 		}
-	local @alldbs = &domain_databases($d);
+	my @alldbs = &domain_databases($d);
 	foreach my $db (@dbs) {
 		($got) = grep { $_->{'type'} eq $db->{'type'} &&
 				$_->{'name'} eq $db->{'name'} } @alldbs;
@@ -154,7 +154,7 @@ USER: foreach $line (@lines) {
 		}
 
 	# Populate the user object
-	local $user = &create_initial_user($d, 0, $ftp == 3);
+	my $user = &create_initial_user($d, 0, $ftp == 3);
 	if (!$user->{'webowner'}) {
 		$user->{'uid'} = &allocate_uid(\%taken);
 		}
@@ -245,7 +245,7 @@ USER: foreach $line (@lines) {
 		}
 
 	# Check for clash within this domain
-	local ($clash) = grep { &remove_userdom($_->{'user'}, $d) eq
+	my ($clash) = grep { &remove_userdom($_->{'user'}, $d) eq
 				  &remove_userdom($username, $d)
 			      } @users;
 	if ($clash) {
@@ -304,7 +304,7 @@ print &text('umass_complete', $count, $ecount),"<br>\n";
 
 sub line_error
 {
-local ($msg) = @_;
+my ($msg) = @_;
 print "<font color=#ff0000>";
 if (!$username) {
 	print &text('cmass_eline', $lnum, $msg);

--- a/mass_upgrade.cgi
+++ b/mass_upgrade.cgi
@@ -69,7 +69,7 @@ if ($in{'confirm'}) {
 			$opts->{'phpver'} = $phpver;
 			}
 
-		local $phpver = $opts->{'phpver'};
+		my $phpver = $opts->{'phpver'};
 		if ($derr = &check_script_depends($script, $d, $ver, $sinfo, $phpver)) {
 			# Failed depends
 			&$second_print(&text('massscript_edep', $derr));

--- a/migrate-domain.pl
+++ b/migrate-domain.pl
@@ -80,7 +80,7 @@ $outdent_print = \&outdent_text_print;
 $template = "";
 $ipinfo = { };
 while(@ARGV > 0) {
-	local $a = shift(@ARGV);
+	my $a = shift(@ARGV);
 	if ($a eq "--source") {
 		$src = shift(@ARGV);
 		}

--- a/migration-cpanel.pl
+++ b/migration-cpanel.pl
@@ -4,7 +4,7 @@
 # Make sure the given file is a cPanel backup, and contains the domain
 sub migration_cpanel_validate
 {
-local ($file, $dom, $user, $parent, $prefix, $pass) = @_;
+my ($file, $dom, $user, $parent, $prefix, $pass) = @_;
 
 # Password is needed for cPanel migrations
 if (!$parent && !$pass) {
@@ -12,26 +12,26 @@ if (!$parent && !$pass) {
 	}
 
 # Extract the backup and find paths inside it
-local ($ok, $root) = &extract_cpanel_dir($file);
+my ($ok, $root) = &extract_cpanel_dir($file);
 $ok || return ("Not a cPanel tar.gz file : $root");
-local $daily = glob("$root/backup*/cpbackup/daily");
-local ($homedir) = glob("$root/*/homedir");
+my $daily = glob("$root/backup*/cpbackup/daily");
+my ($homedir) = glob("$root/*/homedir");
 $homedir = "$root/homedir" if (!-d $homedir);
-local $datastore = "$root/.cpanel-datastore";
+my $datastore = "$root/.cpanel-datastore";
 $datastore = "$root/.cpanel/datastore" if (!-d $datastore);
 -d $daily || -d $homedir || -d $datastore ||
 	return ("Not a cPanel daily or home directory backup file");
 
 # Try to work out the domain
 if (!$dom) {
-	local @domfiles = glob("$root/*/vf/*");
+	my @domfiles = glob("$root/*/vf/*");
 	if (!@domfiles) {
 		@domfiles = glob("$root/vf/*");
 		}
-	local @doms = map { /\/vf\/([^\/]+)$/; $1 } @domfiles;
+	my @doms = map { /\/vf\/([^\/]+)$/; $1 } @domfiles;
 	if (@doms > 1) {
 		# Hack to work out primary domain
-		local $ds = "$homedir/.cpanel-datastore";
+		my $ds = "$homedir/.cpanel-datastore";
 		$ds = $datastore if (!-d $ds);
 		opendir(DATASTORE, $ds);
 		foreach my $gdi (readdir(DATASTORE)) {
@@ -46,9 +46,9 @@ if (!$dom) {
 			}
 		else {
 			# Look at the cp/username file
-			local ($cpfile) = glob("$root/*/cp/*");
+			my ($cpfile) = glob("$root/*/cp/*");
 			if ($cpfile && -r $cpfile) {
-				local %cp;
+				my %cp;
 				&read_env_file($cpfile, \%cp);
 				@doms = ( $cp{'DNS'} );
 				}
@@ -68,15 +68,15 @@ if (!$dom) {
 if (-d $daily) {
 	# Older style backup - check for user and Apache domain file
 	if (!$user) {
-		local ($tgz) = glob("$daily/*.tar.gz");
+		my ($tgz) = glob("$daily/*.tar.gz");
 		$tgz =~ /\/([^\/]+)\.tar\.gz$/ ||
 		    return ("Could not work out username from cPanel backup");
 		$user = $1;
 		}
 	-r "$daily/$user.tar.gz" ||
 		return ("Could not find directory for $user in backup");
-	local $httpd = &extract_cpanel_file("$daily/files/_etc_httpd_conf_httpd.conf.gz");
-	local ($vconf, $virt) = &get_apache_virtual($dom, undef, $httpd);
+	my $httpd = &extract_cpanel_file("$daily/files/_etc_httpd_conf_httpd.conf.gz");
+	my ($vconf, $virt) = &get_apache_virtual($dom, undef, $httpd);
 	$vconf ||
 	    return ("Could not find Apache virtual server $dom in backup");
 	}
@@ -93,7 +93,7 @@ elsif (-d $homedir) {
 		}
 	if (!$user) {
 		opendir(ROOT, $root);
-		local @rootfiles = grep { !/^\./ } readdir(ROOT);
+		my @rootfiles = grep { !/^\./ } readdir(ROOT);
 		closedir(ROOT);
 		$user = $rootfiles[0];
 		}
@@ -113,32 +113,32 @@ return (undef, $dom, $user, $pass);
 # created.
 sub migration_cpanel_migrate
 {
-local ($file, $dom, $user, $webmin, $template, $ipinfo, $pass, $parent,
+my ($file, $dom, $user, $webmin, $template, $ipinfo, $pass, $parent,
        $prefix, $email, $plan) = @_;
-local ($ok, $root) = &extract_cpanel_dir($file);
+my ($ok, $root) = &extract_cpanel_dir($file);
 $ok || &error("Failed to extract backup : $root");
-local $daily = glob("$root/backup*/cpbackup/daily");
-local $datastore = "$root/.cpanel-datastore";
+my $daily = glob("$root/backup*/cpbackup/daily");
+my $datastore = "$root/.cpanel-datastore";
 $datastore = "$root/.cpanel/datastore" if (!-d $datastore);
-local $tmpl = &get_template($template);
+my $tmpl = &get_template($template);
 
 # Check for prefix clash
 $prefix ||= &compute_prefix($dom, undef, $parent, 1);
-local $pclash = &get_domain_by("prefix", $prefix);
+my $pclash = &get_domain_by("prefix", $prefix);
 $pclash && &error("A virtual server using the prefix $prefix already exists");
 
 # Get shells for users
-local ($nologin_shell, $ftp_shell, undef, $def_shell) =
+my ($nologin_shell, $ftp_shell, undef, $def_shell) =
 	&get_common_available_shells();
 $nologin_shell ||= $def_shell;
 $ftp_shell ||= $def_shell;
 
 # Work out the username again if it wasn't supplied
-local $origuser;
-local ($homedir) = glob("$root/*/homedir");
+my $origuser;
+my ($homedir) = glob("$root/*/homedir");
 $homedir = "$root/homedir" if (!-d $homedir);
 if (-d $daily) {
-	local ($tgz) = glob("$daily/*.tar.gz");
+	my ($tgz) = glob("$daily/*.tar.gz");
 	$tgz =~ /\/([^\/]+)\.tar\.gz$/;
 	$origuser = $1;
 	}
@@ -148,26 +148,26 @@ elsif (-d $homedir) {
 	}
 $user ||= $origuser;
 $user || &error("Could not work out username automatically");
-local $group = $user;
-local $ugroup = $group;
+my $group = $user;
+my $ugroup = $group;
 
 # First work out what features we have ..
 &$first_print("Checking for cPanel features ..");
-local @got = ( "dir", $parent ? () : ("unix"), &domain_has_website(),
+my @got = ( "dir", $parent ? () : ("unix"), &domain_has_website(),
 	       "logrotate" );
 push(@got, "webmin") if ($webmin && !$parent);
-local $userdir;
-local $homesrc;
+my $userdir;
+my $homesrc;
 if (-d $daily) {
-	local $named = &extract_cpanel_file("$daily/files/_etc_named.conf.gz");
-	local $zone;
+	my $named = &extract_cpanel_file("$daily/files/_etc_named.conf.gz");
+	my $zone;
 	if ($named) {
 		push(@got, "dns");
 		}
-	local $localdomains = &extract_cpanel_file("$daily/files/_etc_localdomains.gz");
+	my $localdomains = &extract_cpanel_file("$daily/files/_etc_localdomains.gz");
 	if ($localdomains) {
 		# Check for mail domain
-		local $lref = &read_file_lines($localdomains);
+		my $lref = &read_file_lines($localdomains);
 		foreach my $l (@$lref) {
 			push(@got, "mail") if ($l eq $dom);
 			}
@@ -208,14 +208,14 @@ if (&indexof("mail", @got) >= 0 && -e "$homedir/.spamassassinenable") {
 	}
 
 # Work out if the original domain was a sub-server in cPanel
-local $waschild = 0;
-local $wasuser = $dom;
+my $waschild = 0;
+my $wasuser = $dom;
 $wasuser =~ s/\..*$//;
-local $aliasdom;
+my $aliasdom;
 if (-r "$datastore/apache_LISTMULTIPARKED_0") {
 	# Sub-servers are in this config file. We can also work out the original
 	# 'username' for the sub-directory.
-	local $subs = &read_file_contents(
+	my $subs = &read_file_contents(
 		"$datastore/apache_LISTMULTIPARKED_0");
 	if ($subs =~ /(\/[a-z0-9\.\-_\/]+)[^a-z0-9\.\-]+\Q$dom\E[^a-z0-9\.\-]+([a-z0-9\.\-]+)?/i) {
 		$waschild = 1;
@@ -237,7 +237,7 @@ else {
 	}
 
 # Check for Webalizer and AWstats
-local $webalizer = $waschild ? "$homesrc/tmp/webalizer/$dom"
+my $webalizer = $waschild ? "$homesrc/tmp/webalizer/$dom"
 			     : "$homesrc/tmp/webalizer";
 if (-d $webalizer) {
 	push(@got, "webalizer");
@@ -248,9 +248,9 @@ if (-r "$homesrc/tmp/awstats/awstats.$dom.conf") {
 
 if (-s "$userdir/mysql.sql" && !$waschild) {
 	# Check for mysql
-	local $mycount = 0;
-	local $mydir = "$userdir/mysql";
-	local %dblist = map { $_, 1 } &get_cpanel_db_list("$userdir/mysql.sql",
+	my $mycount = 0;
+	my $mydir = "$userdir/mysql";
+	my %dblist = map { $_, 1 } &get_cpanel_db_list("$userdir/mysql.sql",
 							  $user, $origuser);
 	opendir(MYDIR, $mydir);
 	while($myf = readdir(MYDIR)) {
@@ -272,7 +272,7 @@ if ($ipinfo->{'virt'} && -s "$userdir/sslcerts/www.$dom.crt" &&
 	}
 
 # Look for mailing lists
-local ($ml, @lists);
+my ($ml, @lists);
 opendir(MM, "$userdir/mm");
 foreach $ml (readdir(MM)) {
 	if ($ml =~ /^(\S+)_\Q$dom\E$/) {
@@ -286,10 +286,10 @@ if (@lists && &plugin_defined("virtualmin-mailman", "create_list")) {
 
 # Tell the user what we have got
 @got = &show_check_migration_features(@got);
-local %got = map { $_, 1 } @got;
+my %got = map { $_, 1 } @got;
 
 # Work out user and group IDs
-local ($gid, $ugid, $uid, $duser);
+my ($gid, $ugid, $uid, $duser);
 if ($parent) {
 	# UID and GID come from parent
 	$gid = $parent->{'gid'};
@@ -305,7 +305,7 @@ else {
 	$duser = $user;
 	}
 
-local $quota;
+my $quota;
 if (-r "$userdir/quota") {
 	# Get the quota (from home directory backup)
 	open(QUOTA, "<$userdir/quota");
@@ -326,7 +326,7 @@ elsif (-r "$datastore/quota_-v") {
 	}
 
 # Create the virtual server object
-local %dom;
+my %dom;
 $prefix ||= &compute_prefix($dom, $group, $parent, 1);
 $plan = $parent ? &get_plan($parent->{'plan'}) :
         $plan ? $plan : &get_default_plan();
@@ -386,11 +386,11 @@ if (open(MYSQL, "<$userdir/mysql.sql")) {
 	close(MYSQL);
 	}
 
-local $orighome;
+my $orighome;
 if (-d $daily) {
 	# Work out home directory (use cpanel home by default)
-	local $httpd = &extract_cpanel_file("$daily/files/_etc_httpd_conf_httpd.conf.gz");
-	local ($srcvconf, $srcvirt) = &get_apache_virtual($dom, undef, $httpd);
+	my $httpd = &extract_cpanel_file("$daily/files/_etc_httpd_conf_httpd.conf.gz");
+	my ($srcvconf, $srcvirt) = &get_apache_virtual($dom, undef, $httpd);
 	$orighome = &apache::find_directive("DocumentRoot", $srcvirt);
 	$orighome =~ s/\/public_html$//;
 	}
@@ -435,7 +435,7 @@ if ($cerr) {
 # Create the initial server
 &$first_print("Creating initial virtual server $dom ..");
 &$indent_print();
-local $err = &create_virtual_server(\%dom, $parent,
+my $err = &create_virtual_server(\%dom, $parent,
 				    $parent ? $parent->{'user'} : undef);
 &$outdent_print();
 if ($err) {
@@ -445,13 +445,13 @@ if ($err) {
 else {
 	&$second_print(".. done");
 	}
-local @rvdoms = ( \%dom );
+my @rvdoms = ( \%dom );
 
 # Extract homedir.tar if needed
-local $hometar = "$userdir/homedir.tar";
+my $hometar = "$userdir/homedir.tar";
 if (-r $hometar) {
 	&$first_print("Extracting home directory TAR file ..");
-	local $out;
+	my $out;
 	if (!-d $homesrc) {
 		&make_dir($homesrc, 0755);
 		}
@@ -472,9 +472,9 @@ if ($got{'web'} && -d $daily) {
 	&$first_print("Copying Apache directives ..");
 	if ($srcvconf) {
 		# Copy any directives not set by Virtualmin
-		local $conf = &apache::get_config();
-		local ($vconf, $virt) = &get_apache_virtual($dom, undef);
-		local %dirs;
+		my $conf = &apache::get_config();
+		my ($vconf, $virt) = &get_apache_virtual($dom, undef);
+		my %dirs;
 		foreach my $a (@$virt) {
 			next if ($a->{'type'});
 			$dirs{$a->{'name'}}++;
@@ -485,7 +485,7 @@ if ($got{'web'} && -d $daily) {
 		$dirs{'User'} = 1;		# Don't copy user-related
 		$dirs{'Group'} = 1;		# settings, as Virtualmin will
 		$dirs{'SuexecUserGroup'} = 1;	# have already set them
-		local %vals;
+		my %vals;
 		foreach my $a (@$srcvirt) {
 			next if ($a->{'type'} || $dirs{$a->{'name'}});
 			if ($dom{'home'} ne $orighome) {
@@ -505,8 +505,8 @@ if ($got{'web'} && -d $daily) {
 	}
 elsif ($got{'web'}) {
 	# Just adjust cgi-bin directory to match cPanel
-	local $conf = &apache::get_config();
-	local ($virt, $vconf) = &get_apache_virtual($dom, undef);
+	my $conf = &apache::get_config();
+	my ($virt, $vconf) = &get_apache_virtual($dom, undef);
 	if ($virt) {
 		&apache::save_directive("ScriptAlias",
 			[ "/cgi-bin $dom{'home'}/public_html/cgi-bin" ],
@@ -533,12 +533,12 @@ if ($got{&domain_has_ssl()}) {
 # Migrate DNS domain
 &cpanel_migrate_dns_zone(\%dom, $dom);
 
-local $out;
-local $ht = &public_html_dir(\%dom);
-local $qht = quotemeta($ht);
+my $out;
+my $ht = &public_html_dir(\%dom);
+my $qht = quotemeta($ht);
 if ($waschild) {
 	# Migrate web directory
-	local $qhtsrc = "$homesrc/public_html/$wasuser";
+	my $qhtsrc = "$homesrc/public_html/$wasuser";
 	&$first_print("Copying web pages to $ht ..");
 	&execute_command("cd $qhtsrc && ".
 			 "(".&make_tar_command("cf", "-", ".").
@@ -549,8 +549,8 @@ if ($waschild) {
 else {
 	# Migrate home directory contents (except logs and mail)
 	&$first_print("Copying home directory to $dom{'home'} ..");
-	local $qhome = quotemeta($dom{'home'});
-	local $xtemp = &transname();
+	my $qhome = quotemeta($dom{'home'});
+	my $xtemp = &transname();
 	&open_tempfile(XTEMP, ">$xtemp");
 	&print_tempfile(XTEMP, "./logs\n");
 	&print_tempfile(XTEMP, "./mail\n");
@@ -571,7 +571,7 @@ else {
 
 # If php.ini is migrated wrong, fix it
 if ($dom{'web'}) {
-	local $mode = &get_domain_php_mode(\%dom);
+	my $mode = &get_domain_php_mode(\%dom);
 	if ($mode eq "cgi" || $mode eq "fcgid") {
 		&fix_php_extension_dir(\%dom);
 		}
@@ -597,23 +597,23 @@ if (defined(&set_php_wrappers_writable)) {
 # Lock the user DB and build list of used IDs
 &obtain_lock_unix(\%dom);
 &obtain_lock_mail(\%dom);
-local (%taken, %utaken);
+my (%taken, %utaken);
 &build_taken(\%taken, \%utaken);
 
 &foreign_require("mailboxes");
 $mailboxes::no_permanent_index = 1;
-local %usermap;
+my %usermap;
 if ($got{'mail'}) {
 	# Migrate mail users
 	&cpanel_migrate_mailboxes($dom, \%dom, \%usermap);
 	}
 
 # Move server owner's inbox file
-local $owner = &get_domain_owner(\%dom);
+my $owner = &get_domain_owner(\%dom);
 if ($owner && !$parent) {
 	&$first_print("Moving server owner's mailbox ..");
-	local ($mfile, $mtype) = &user_mail_file($owner);
-	local $srcfolder;
+	my ($mfile, $mtype) = &user_mail_file($owner);
+	my $srcfolder;
 	if (-d "$homesrc/mail/cur" || -d "$homesrc/mail/new") {
 		# Maildir format
 		$srcfolder = { 'type' => 1, 'file' => "$homesrc/mail" };
@@ -624,7 +624,7 @@ if ($owner && !$parent) {
 			       'file' => "$homesrc/mail/inbox" };
 		}
 	if ($srcfolder) {
-		local $dstfolder = { 'type' => $mtype, 'file' => $mfile };
+		my $dstfolder = { 'type' => $mtype, 'file' => $mfile };
 		&mailboxes::mailbox_move_folder($srcfolder, $dstfolder);
 		&set_mailfolder_owner($dstfolder, $owner);
 		&mailboxes::mailbox_uncompress_folder($dstfolder)
@@ -637,7 +637,7 @@ if ($owner && !$parent) {
 	}
 
 # Build map from email addresses to users
-local %useremail;
+my %useremail;
 foreach my $uinfo (&list_domain_users(\%dom)) {
 	if ($uinfo->{'email'}) {
 		$useremail{$uinfo->{'email'}} = $uinfo;
@@ -646,11 +646,11 @@ foreach my $uinfo (&list_domain_users(\%dom)) {
 
 if ($got{'mail'}) {
 	# Copy mail aliases
-	local $acount = 0;
-	local $domfwd;
+	my $acount = 0;
+	my $domfwd;
 	&$first_print("Copying email aliases ..");
 	&set_alias_programs();
-	local %gotvirt = map { $_->{'from'}, $_ } &list_virtusers();
+	my %gotvirt = map { $_->{'from'}, $_ } &list_virtusers();
 	local $_;
 	open(VAD, "<$userdir/vad/$dom");
 	while(<VAD>) {
@@ -658,9 +658,9 @@ if ($got{'mail'}) {
 		s/^\s*#.*$//;
 		if (/^(\S+):\s*(\S+)$/) {
 			# A domain forward exists ..
-			local $virt = { 'from' => "\@$dom",
+			my $virt = { 'from' => "\@$dom",
 					'to' => [ "%1\@$2" ] };
-			local $clash = $gotvirt{$virt->{'from'}};
+			my $clash = $gotvirt{$virt->{'from'}};
 			&delete_virtuser($clash) if ($clash);
 			&create_virtuser($virt);
 			$acount++;
@@ -673,9 +673,9 @@ if ($got{'mail'}) {
 		s/\r|\n//g;
 		s/^\s*#.*$//;
 		if (/^(\S+):\s*(.*)$/) {
-			local ($name, $v) = ($1, $2);
+			my ($name, $v) = ($1, $2);
 			next if (!$name);
-			local @values;
+			my @values;
 			if ($v !~ /,/ && $v !~ /"/) {
 				# A single destination, not quoted!
 				@values = ( $v );
@@ -690,13 +690,13 @@ if ($got{'mail'}) {
 					$v = $3;
 					}
 				}
-			local $mailman = 0;
+			my $mailman = 0;
 			foreach my $v (@values) {
 				if ($v =~ /:fail:\s+(.*)/) {
 					# Fix bounce alias
 					$v = "BOUNCE $1";
 					}
-				local ($atype, $aname) = &alias_type($v, $name);
+				my ($atype, $aname) = &alias_type($v, $name);
 				if ($atype == 4 && $aname =~ /autorespond\s+(\S+)\@(\S+)\s+(\S+)/) {
 					# Turn into Virtualmin auto-responder
 					$v = "| $module_config_directory/autoreply.pl $3/$name $1";
@@ -723,9 +723,9 @@ if ($got{'mail'}) {
 				# This is an alias from a user. Preserve
 				# delivery to his mailbox though, as this is
 				# what cPanel seems to do.
-				local $uinfo = $useremail{$name};
-				local $olduinfo = { %$uinfo };
-				local $touser = $uinfo->{'user'};
+				my $uinfo = $useremail{$name};
+				my $olduinfo = { %$uinfo };
+				my $touser = $uinfo->{'user'};
 				if ($mail_system == 0 && $escuser =~ /\@/) {
 					$touser = &escape_replace_atsign_if_exists($touser);
 					}
@@ -738,10 +738,10 @@ if ($got{'mail'}) {
 				if ($name !~ /\@/) {
 					$name .= "\@".$dom;
 					}
-				local $virt = { 'from' => $name =~ /^\*/ ?
+				my $virt = { 'from' => $name =~ /^\*/ ?
 						  "\@".$dom : $name,
 						'to' => \@values };
-				local $clash = $gotvirt{$virt->{'from'}};
+				my $clash = $gotvirt{$virt->{'from'}};
 				&delete_virtuser($clash) if ($clash);
 				&create_virtuser($virt);
 				$acount++;
@@ -763,10 +763,10 @@ if ($got{'spam'}) {
 
 # Create mailing lists
 if ($got{'virtualmin-mailman'}) {
-	local $lcount = 0;
+	my $lcount = 0;
 	&$first_print("Re-creating mailing lists ..");
 	foreach $ml (@lists) {
-		local $err = &plugin_call("virtualmin-mailman", "create_list",
+		my $err = &plugin_call("virtualmin-mailman", "create_list",
 			     $ml, $dom, "Migrated cPanel mailing list",
 			     undef, $dom{'emailto_addr'}, $dom{'pass'});
 		if ($err) {
@@ -811,11 +811,11 @@ if (-r "$userdir/cron/$user" && !$waschild) {
 
 if ($got{'mysql'}) {
 	# Re-create all MySQL databases
-	local $mycount = 0;
+	my $mycount = 0;
 	&$first_print("Re-creating and loading MySQL databases ..");
 	&disable_quotas(\%dom);
-	local $mydir = "$userdir/mysql";
-	local %dblist = map { $_, 1 } &get_cpanel_db_list("$userdir/mysql.sql",
+	my $mydir = "$userdir/mysql";
+	my %dblist = map { $_, 1 } &get_cpanel_db_list("$userdir/mysql.sql",
 							  $user, $origuser);
 	opendir(MYDIR, $mydir);
 	while($myf = readdir(MYDIR)) {
@@ -824,11 +824,11 @@ if ($got{'mysql'}) {
 		    $myf =~ /^(\Q$user\E).sql$/ ||
 		    $myf =~ /^(\Q$origuser\E).sql$/ ||
 		    $myf =~ /^(\S+).sql$/ && $dblist{$1}) {
-			local $db = $1;
+			my $db = $1;
 			&$indent_print();
 			&create_mysql_database(\%dom, $db);
 			&save_domain(\%dom, 1);
-			local ($ex, $out) = &execute_dom_sql_file(\%dom, $db, "$mydir/$myf");
+			my ($ex, $out) = &execute_dom_sql_file(\%dom, $db, "$mydir/$myf");
 			if ($ex) {
 				&$first_print("Error loading $db : $out");
 				}
@@ -842,20 +842,20 @@ if ($got{'mysql'}) {
 
 	# Re-create MySQL users
 	if ($got{'mysql'}) {
-		local $myucount = 0;
+		my $myucount = 0;
 		&$first_print("Re-creating MySQL users ..");
-		local %myusers;
+		my %myusers;
 		local $_;
-		local (%donemysqluser, %donemysqlpriv);
+		my (%donemysqluser, %donemysqlpriv);
 		open(MYSQL, "<$userdir/mysql.sql");
 		while(<MYSQL>) {
 			s/\r|\n//g;
 			if (/^GRANT USAGE ON \*\.\* TO '(\S+)'\@'(\S+)' IDENTIFIED BY PASSWORD '(\S+)';/) {
 				# Creating a MySQL user
-				local ($myuser, $mypass) = ($1, $3);
+				my ($myuser, $mypass) = ($1, $3);
 				next if ($myuser eq $user);	# domain owner
 				next if ($donemysqluser{$myuser}++);
-				local $myuinfo = &create_initial_user(\%dom);
+				my $myuinfo = &create_initial_user(\%dom);
 				$myuinfo->{'user'} = $myuser;
 				$myuinfo->{'pass'} = "x";	# not needed
 				$myuinfo->{'mysql_pass'} = $mypass;
@@ -868,7 +868,7 @@ if ($got{'mysql'}) {
 				}
 			elsif (/GRANT ALL PRIVILEGES ON `(\S+)`\.\* TO '(\S+)'\@'(\S+)';/ || /GRANT SELECT.*\sON `(\S+)`\.\* TO '(\S+)'\@'(\S+)';/) {
 				# Granting access to a MySQL database
-				local ($mydb, $myuser) = ($1, $2);
+				my ($mydb, $myuser) = ($1, $2);
 				next if ($myuser eq $user);	# domain owner
 				next if ($donemysqlpriv{$mydb,$myuser}++);
 				$mydb =~ s/\\(.)/$1/g;
@@ -880,10 +880,10 @@ if ($got{'mysql'}) {
 			}
 		close(MYSQL);
 		foreach my $myuinfo (values %myusers) {
-			local $already = $usermap{$myuinfo->{'user'}};
+			my $already = $usermap{$myuinfo->{'user'}};
 			if ($already) {
 				# User already exists, so just give him the dbs
-				local $olduinfo = { %$already };
+				my $olduinfo = { %$already };
 				$already->{'dbs'} = $myuinfo->{'dbs'};
 				&modify_user($already, $olduinfo, \%dom);
 				}
@@ -903,34 +903,34 @@ if ($got{'mysql'}) {
 
 # Migrate or update FTP users
 if (-r "$userdir/proftpdpasswd" && !$waschild) {
-	local $fcount = 0;
+	my $fcount = 0;
 	&$first_print("Re-creating FTP users ..");
 	local $_;
 	open(FTP, "<$userdir/proftpdpasswd");
 	while(<FTP>) {
 		s/\r|\n//g;
 		s/^\s*#.*$//;
-		local ($fuser, $fpass, $fuid, $fgid, $fdummy, $fhome, $fshell) = split(/:/, $_);
+		my ($fuser, $fpass, $fuid, $fgid, $fdummy, $fhome, $fshell) = split(/:/, $_);
 		next if (!$fuser);
 		$fuser = &remove_userdom($fuser, \%dom);
 		next if ($fuser eq "ftp" || $fuser eq $user ||
 			 $fuser eq $user."_logs");	# skip cpanel users
-		local $fullfuser = &userdom_name(lc($fuser), \%dom);
+		my $fullfuser = &userdom_name(lc($fuser), \%dom);
 		if ($fhome eq "/dev/null" ||
 		    !&is_under_directory($dom{'home'}, $fhome)) {
 			$fhome = "$dom{'home'}/$config{'homes_dir'}/$fuser";
 			}
-		local $already = $usermap{$fuser} ||
+		my $already = $usermap{$fuser} ||
 				 $usermap{$fullfuser};
 		if ($already) {
 			# Turn on FTP for existing user
-			local $olduinfo = { %$already };
+			my $olduinfo = { %$already };
 			$already->{'shell'} = $ftp_shell->{'shell'};
 			&modify_user($already, $olduinfo, \%dom);
 			}
 		else {
 			# Create new FTP-only user
-			local $fuinfo = &create_initial_user(\%dom, 0,
+			my $fuinfo = &create_initial_user(\%dom, 0,
 			     $fhome eq $ht || $fhome eq $dom{'home'});
 			$fuinfo->{'user'} = $fullfuser;
 			$fuinfo->{'pass'} = $fpass;
@@ -964,13 +964,13 @@ if (-r "$userdir/proftpdpasswd" && !$waschild) {
 &release_lock_mail(\%dom);
 
 # Migrate any parked domains as alias domains
-local @parked;
+my @parked;
 if (!$waschild) {
 	local $_;
 	open(PARKED, "<$userdir/pds");
 	while(<PARKED>) {
 		s/\r|\n//g;
-		local ($pdom) = split(/\s+/, $_);
+		my ($pdom) = split(/\s+/, $_);
 		push(@parked, $pdom) if ($pdom && $pdom !~ /^\*/);
 		}
 	close(PARKED);
@@ -994,7 +994,7 @@ foreach my $pdom (&unique(@parked)) {
 		next;
 		}
 	&$indent_print();
-	local %alias = ( 'id', &domain_id(),
+	my %alias = ( 'id', &domain_id(),
 			 'dom', $pdom,
 			 'user', $dom{'user'},
 			 'group', $dom{'group'},
@@ -1024,7 +1024,7 @@ foreach my $pdom (&unique(@parked)) {
 	foreach my $f (@alias_features) {
 		$alias{$f} = $dom{$f};
 		}
-	local $parentdom = $dom{'parent'} ? &get_domain($dom{'parent'})
+	my $parentdom = $dom{'parent'} ? &get_domain($dom{'parent'})
 					  : \%dom;
 	$alias{'home'} = &server_home_directory(\%alias, $parentdom);
 	&generate_domain_password_hashes(\%alias, 1);
@@ -1046,8 +1046,8 @@ foreach my $pdom (&unique(@parked)) {
 	}
 
 # Read addons domain mapping file
-local %addons;
-local $lref = &read_file_lines("$userdir/addons");
+my %addons;
+my $lref = &read_file_lines("$userdir/addons");
 foreach my $l (@$lref) {
 	my ($a, $t) = split(/=/, $l);
 	if ($a && $t) {
@@ -1100,8 +1100,8 @@ return @rvdoms;
 # under which it was extracted, or an error message
 sub extract_cpanel_dir
 {
-local ($file) = @_;
-local $dir;
+my ($file) = @_;
+my $dir;
 if ($main::cpanel_dir_cache{$file} && -d $main::cpanel_dir_cache{$file}) {
 	# Use cached extract from this session
 	return (1, $main::cpanel_dir_cache{$file});
@@ -1116,7 +1116,7 @@ elsif (-d $file) {
 else {
 	$dir = &transname();
 	mkdir($dir, 0700);
-	local $err = &extract_compressed_file($file, $dir);
+	my $err = &extract_compressed_file($file, $dir);
 	if ($err) {
 		return (0, $err);
 		}
@@ -1130,9 +1130,9 @@ return (1, $dir);
 sub extract_cpanel_file
 {
 return undef if (!-r $_[0]);
-local $temp = &transname();
-local $qf = quotemeta($_[0]);
-local $out = &backquote_command("gunzip -c $qf >".quotemeta($temp));
+my $temp = &transname();
+my $qf = quotemeta($_[0]);
+my $out = &backquote_command("gunzip -c $qf >".quotemeta($temp));
 return $? ? undef : $temp;
 }
 
@@ -1140,17 +1140,17 @@ return $? ? undef : $temp;
 # Converts a userdata file into a perl hash ref
 sub read_cpanel_userdata_file
 {
-local ($file, $pos) = @_;
+my ($file, $pos) = @_;
 $pos ||= 0;
-local $lref = &read_file_lines($file, 1);
-local $startindent = 0;
+my $lref = &read_file_lines($file, 1);
+my $startindent = 0;
 if ($lref->[$pos] =~ /^(\s+)/) {
 	$startindent = length($1);
 	}
-local %rv;
-local $lastname;
+my %rv;
+my $lastname;
 while($pos < scalar(@$lref)) {
-	local $indent = 0;
+	my $indent = 0;
 	if ($lref->[$pos] =~ /^(\s+)/) {
 		$indent = length($1);
 		}
@@ -1163,14 +1163,14 @@ while($pos < scalar(@$lref)) {
 		if ($lref->[$pos] =~ /^\s*\-/) {
 			# Element in an array
 			$rv{$lastname} ||= [ ];
-			local ($subrv, $subpos) =
+			my ($subrv, $subpos) =
 				&read_cpanel_userdata_file($file, $pos+1);
 			push(@{$rv{$lastname}}, $subrv);
 			$pos = $subpos - 1;
 			}
 		else {
 			# Start of a section
-			local ($subrv, $subpos) =
+			my ($subrv, $subpos) =
 				&read_cpanel_userdata_file($file, $pos);
 			$rv{$lastname} = $subrv;
 			$pos = $subpos - 1;
@@ -1188,16 +1188,16 @@ return wantarray ? ( \%rv, $pos ) : \%rv;
 
 sub create_addon_domains
 {
-local ($skip_missing_target) = @_;
+my ($skip_missing_target) = @_;
 
 # Create addon domains as alias domains
 opendir(VF, "$userdir/vf");
 foreach my $vf (readdir(VF)) {
-	local ($clash) = grep { $_->{'dom'} eq $vf } @rvdoms;
+	my ($clash) = grep { $_->{'dom'} eq $vf } @rvdoms;
 	next if ($clash);
 	next if ($vf eq "." || $vf eq ".." || $clash);
 	next if (!$addons{$vf});
-	local $target = &get_domain_by("dom", $addons{$vf});
+	my $target = &get_domain_by("dom", $addons{$vf});
 	next if (!$target && $skip_missing_target);
 	&$first_print("Creating addon domain $vf ..");
 	if (!$target) {
@@ -1209,7 +1209,7 @@ foreach my $vf (readdir(VF)) {
 		next;
 		}
 	&$indent_print();
-	local %alias = ( 'id', &domain_id(),
+	my %alias = ( 'id', &domain_id(),
 			 'dom', $vf,
 			 'user', $dom{'user'},
 			 'group', $dom{'group'},
@@ -1237,7 +1237,7 @@ foreach my $vf (readdir(VF)) {
 	foreach my $f (@alias_features) {
 		$alias{$f} = $target->{$f};
 		}
-	local $parentdom = $dom{'parent'} ? &get_domain($dom{'parent'})
+	my $parentdom = $dom{'parent'} ? &get_domain($dom{'parent'})
 					  : \%dom;
 	$alias{'home'} = &server_home_directory(\%alias, $parentdom);
 	&generate_domain_password_hashes(\%alias, 1);
@@ -1260,15 +1260,15 @@ foreach my $vf (readdir(VF)) {
 
 sub create_sub_domains
 {
-local ($skip_missing_target) = @_;
+my ($skip_missing_target) = @_;
 
 # Create sub-domains as virtualmin sub-domains, from vf directory
 opendir(VF, "$userdir/vf");
 foreach my $vf (readdir(VF)) {
-	local ($clash) = grep { $_->{'dom'} eq $vf } @rvdoms;
+	my ($clash) = grep { $_->{'dom'} eq $vf } @rvdoms;
 	next if ($vf eq "." || $vf eq ".." || $clash);
 	next if ($addons{$vf});
-	local (%subof, $subprefix);
+	my (%subof, $subprefix);
 	foreach my $rv (grep { !$_->{'subdom'} } @rvdoms) {
 		if ($vf =~ /^(\S+)\.\Q$rv->{'dom'}\E$/) {
 			$subprefix = $1;
@@ -1295,7 +1295,7 @@ foreach my $vf (readdir(VF)) {
 		# of the main domain
 		&$first_print("Creating sub-server sub-domain $vf ..");
 		&$indent_print();
-		local %subs = ( 'id', &domain_id(),
+		my %subs = ( 'id', &domain_id(),
 				'dom', $vf,
 				'user', $dom{'user'},
 				'group', $dom{'group'},
@@ -1323,7 +1323,7 @@ foreach my $vf (readdir(VF)) {
 				$subs{$f} = $dom{$f};
 				}
 			}
-		local $parentdom = $dom{'parent'} ? &get_domain($dom{'parent'})
+		my $parentdom = $dom{'parent'} ? &get_domain($dom{'parent'})
 						  : \%dom;
 		$subs{'home'} = &server_home_directory(\%subs, $parentdom);
 		&generate_domain_password_hashes(\%subs, 1);
@@ -1332,11 +1332,11 @@ foreach my $vf (readdir(VF)) {
 				       $parentdom->{'user'});
 
 		# Copy files from parent
-		local $sdsrc = "$ht/$subprefix";
-		local $qsdsrc = quotemeta($sdsrc);
-		local $sddst = &public_html_dir(\%subs);
-		local $qsddst = quotemeta($sddst);
-		local $out;
+		my $sdsrc = "$ht/$subprefix";
+		my $qsdsrc = quotemeta($sdsrc);
+		my $sddst = &public_html_dir(\%subs);
+		my $qsddst = quotemeta($sddst);
+		my $out;
 		if (-d $sdsrc) {
 			&$first_print(
 				"Copying web pages from $sdsrc to $sddst ..");
@@ -1362,7 +1362,7 @@ foreach my $vf (readdir(VF)) {
 		# Sub-domain of a regular domain
 		&$first_print("Creating sub-domain $vf ..");
 		&$indent_print();
-		local %subd = ( 'id', &domain_id(),
+		my %subd = ( 'id', &domain_id(),
 				'dom', $vf,
 				'user', $dom{'user'},
 				'group', $dom{'group'},
@@ -1401,14 +1401,14 @@ foreach my $vf (readdir(VF)) {
 				$subd{$f} = $subof{$f};
 				}
 			}
-		local $parentdom = $dom{'parent'} ? &get_domain($dom{'parent'})
+		my $parentdom = $dom{'parent'} ? &get_domain($dom{'parent'})
 						  : \%dom;
 		$subd{'home'} = &server_home_directory(\%subd, $parentdom);
 		&generate_domain_password_hashes(\%subd, 1);
 		&complete_domain(\%subd);
 
 		# Extract correct sub-domain root dir
-		local $userdata = &read_cpanel_userdata_file(
+		my $userdata = &read_cpanel_userdata_file(
 					"$userdir/userdata/$vf");
 		if ($userdata->{'documentroot'} =~
 		    /^\/home\/([^\/]+)\/public_html\/(.*)/) {
@@ -1431,7 +1431,7 @@ foreach my $vf (readdir(VF)) {
 
 		# Cpanel sub-domains always seem to forward mail to the parent
 		if ($subd{'mail'}) {
-			local $virt = { 'from' => "\@$vf",
+			my $virt = { 'from' => "\@$vf",
 					'to' => [ "%1\@".$subof{'dom'} ] };
 			&create_virtuser($virt);
 			}
@@ -1448,25 +1448,25 @@ closedir(VF);
 # Re-create mailbox users from a cPanel backup
 sub cpanel_migrate_mailboxes
 {
-local ($dom, $d, $usermap) = @_;
+my ($dom, $d, $usermap) = @_;
 &foreign_require("mailboxes");
 &$first_print("Re-creating mail users for $dom ..");
-local $mcount = 0;
-local (%pass, %quota);
+my $mcount = 0;
+my (%pass, %quota);
 local $_;
 open(SHADOW, "<$homesrc/etc/$dom/shadow");
 while(<SHADOW>) {
 	s/\r|\n//g;
-	local ($suser, $spass) = split(/:/, $_);
+	my ($suser, $spass) = split(/:/, $_);
 	$pass{$suser} = $spass;
 	}
 close(SHADOW);
 local $_;
-local $bsize = &quota_bsize("home");
+my $bsize = &quota_bsize("home");
 open(QUOTA, "<$homesrc/etc/$dom/quota");
 while(<QUOTA>) {
 	s/\r|\n//g;
-	local ($quser, $qquota) = split(/:/, $_);
+	my ($quser, $qquota) = split(/:/, $_);
 	$quota{$quser} = $bsize ? int($qquota/$bsize) : 0;
 	}
 close(QUOTA);
@@ -1475,13 +1475,13 @@ open(PASSWD, "<$homesrc/etc/$dom/passwd");
 while(<PASSWD>) {
 	# Create the user
 	s/\r|\n//g;
-	local ($muser, $mdummy, $muid, $mgid, $mreal, $mdir, $mshell) =
+	my ($muser, $mdummy, $muid, $mgid, $mreal, $mdir, $mshell) =
 		split(/:/, $_);
 	next if (!$muser);
 	$muser = &remove_userdom($muser, $d);
 	next if ($muser =~ /_logs$/);		# Special logs user
 	next if ($muser eq $user && !$parent);	# Domain owner
-	local $uinfo = &create_initial_user($d);
+	my $uinfo = &create_initial_user($d);
 	$uinfo->{'user'} = &userdom_name(lc($muser), $d);
 	$uinfo->{'pass'} = $pass{$muser};
 	$uinfo->{'uid'} = &allocate_uid(\%taken);
@@ -1495,13 +1495,13 @@ while(<PASSWD>) {
 	&create_user_home($uinfo, $d, 1);
 	&create_user($uinfo, $d);
 	$taken{$uinfo->{'uid'}}++;
-	local ($crfile, $crtype) = &create_mail_file($uinfo, $d);
+	my ($crfile, $crtype) = &create_mail_file($uinfo, $d);
 
 	# Move his mail files
-	local $mailsrc = "$homesrc/mail/$dom/$muser";
-	local $sfdir = $mailboxes::config{'mail_usermin'};
-	local $sftype = $sfdir eq 'Maildir' ? 1 : 0;
-	local $sfpath = "$uinfo->{'home'}/$sfdir";
+	my $mailsrc = "$homesrc/mail/$dom/$muser";
+	my $sfdir = $mailboxes::config{'mail_usermin'};
+	my $sftype = $sfdir eq 'Maildir' ? 1 : 0;
+	my $sfpath = "$uinfo->{'home'}/$sfdir";
 	if (!-d $sfpath && !$sftype) {
 		# Create ~/mail if needed
 		&make_dir($sfpath, 0755);
@@ -1511,9 +1511,9 @@ while(<PASSWD>) {
 	if (-d "$mailsrc/cur" || -d "$mailsrc/new") {
 		# Mail directory is in Maildir format, and sub-folders
 		# are in Maildir++
-		local $srcfolder = { 'type' => 1,
+		my $srcfolder = { 'type' => 1,
 				     'file' => $mailsrc };
-		local $dstfolder = { 'file' => $crfile,
+		my $dstfolder = { 'file' => $crfile,
 				     'type' => $crtype };
 		&mailboxes::mailbox_move_folder($srcfolder, $dstfolder);
 		&set_mailfolder_owner($dstfolder, $uinfo);
@@ -1523,11 +1523,11 @@ while(<PASSWD>) {
 		while(my $mf = readdir(DIR)) {
 			next if ($mf eq "." || $mf eq ".." ||
 				 $mf !~ /^\./);
-			local $srcfolder = { 'type' => 1,
+			my $srcfolder = { 'type' => 1,
 				'file' => "$mailsrc/$mf" };
 			# Remove . if destination is not Maildir++
 			$mf =~ s/^\.// if (!$sftype);
-			local $dstfolder = { 'type' => $sftype,
+			my $dstfolder = { 'type' => $sftype,
 					     'file' => "$sfpath/$mf" };
 			&mailboxes::mailbox_move_folder($srcfolder,
 							$dstfolder);
@@ -1539,13 +1539,13 @@ while(<PASSWD>) {
 		}
 	elsif (-d "$mailsrc/storage") {
 		# Mail directory is in mdbox format .. convert to mbox then move
-		local $mdtemp = &transname();
+		my $mdtemp = &transname();
 		&copy_source_dest($mailsrc, $mdtemp);
-		local $temp = &transname();
+		my $temp = &transname();
 		&make_dir($temp, 0755);
 		my $err;
 		&execute_command("chown -R ".quotemeta($uinfo->{'user'}).": ".quotemeta($mdtemp)." ".quotemeta($temp), undef, \$err, \$err);
-		local $out = &backquote_command("dsync -u ".
+		my $out = &backquote_command("dsync -u ".
 			quotemeta($uinfo->{'user'})." -o ".
 			quotemeta("mail_location=mdbox:$mdtemp").
 			" backup mbox:".quotemeta($temp)." 2>&1");
@@ -1553,9 +1553,9 @@ while(<PASSWD>) {
 		opendir(DIR, $temp);
 		while(my $mf = readdir(DIR)) {
 			next if ($mf =~ /^\./);
-			local $srcfolder = { 'type' => 0,
+			my $srcfolder = { 'type' => 0,
 					     'file' => "$temp/$mf" };
-			local $dstfolder;
+			my $dstfolder;
 			if ($mf eq "inbox") {
 				$dstfolder = { 'file' => $crfile,
 					       'type' => $crtype };
@@ -1580,9 +1580,9 @@ while(<PASSWD>) {
 		opendir(DIR, $mailsrc);
 		while(my $mf = readdir(DIR)) {
 			next if ($mf =~ /^\./);
-			local $srcfolder = { 'type' => 0,
+			my $srcfolder = { 'type' => 0,
 					     'file' => "$mailsrc/$mf" };
-			local $dstfolder;
+			my $dstfolder;
 			if ($mf eq "inbox") {
 				$dstfolder = { 'file' => $crfile,
 					       'type' => $crtype };
@@ -1613,17 +1613,17 @@ close(PASSWD);
 # cpanel_migrate_addon_aliases(domain)
 sub cpanel_migrate_addon_aliases
 {
-local ($vf) = @_;
-local $acount = 0;
-local %gotvirt = map { $_->{'from'}, $_ } &list_virtusers();
+my ($vf) = @_;
+my $acount = 0;
+my %gotvirt = map { $_->{'from'}, $_ } &list_virtusers();
 open(VA, "<$userdir/va/$vf");
 while(<VA>) {
 	s/\r|\n//g;
 	s/^\s*#.*$//;
 	if (/^(\S+):\s*(.*)$/) {
-		local ($name, $v) = ($1, $2);
+		my ($name, $v) = ($1, $2);
 		next if (!$name);
-		local @values;
+		my @values;
 		if ($v !~ /,/ && $v !~ /"/) {
 			# A single destination, not quoted!
 			@values = ( $v );
@@ -1638,13 +1638,13 @@ while(<VA>) {
 				$v = $3;
 				}
 			}
-		local $mailman = 0;
+		my $mailman = 0;
 		foreach my $v (@values) {
 			if ($v =~ /:fail:\s+(.*)/) {
 				# Fix bounce alias
 				$v = "BOUNCE $1";
 				}
-			local ($atype, $aname) = &alias_type($v, $name);
+			my ($atype, $aname) = &alias_type($v, $name);
 			if ($atype == 4 && $aname =~ /autorespond\s+(\S+)\@(\S+)\s+(\S+)/) {
 				# Turn into Virtualmin auto-responder
 				$v = "| $module_config_directory/autoreply.pl $3/$name $1";
@@ -1666,10 +1666,10 @@ while(<VA>) {
 		if ($name !~ /\@/) {
 			$name .= "\@".$vf;
 			}
-		local $virt = { 'from' => $name =~ /^\*/ ? "\@".$vf
+		my $virt = { 'from' => $name =~ /^\*/ ? "\@".$vf
 							 : $name,
 				'to' => \@values };
-		local $clash = $gotvirt{$virt->{'from'}};
+		my $clash = $gotvirt{$virt->{'from'}};
 		&delete_virtuser($clash) if ($clash);
 		&create_virtuser($virt);
 		$acount++;
@@ -1713,7 +1713,7 @@ if ($zsrc) {
 		elsif ($r->{'name'} eq $dom."." &&
 		       $r->{'type'} eq 'NS') {
 			# Set NS record to this server
-			local $master = $bconfig{'default_prins'} ||
+			my $master = $bconfig{'default_prins'} ||
 					&get_system_hostname();
 			$master .= "." if ($master !~ /\.$/);
 			$r->{'values'} = [ $master ];

--- a/migration-directadmin.pl
+++ b/migration-directadmin.pl
@@ -5,7 +5,7 @@
 # Make sure the given file is a DirectAdmin backup, and contains the domain
 sub migration_directadmin_validate
 {
-local ($file, $dom, $user, $parent, $prefix, $pass) = @_;
+my ($file, $dom, $user, $parent, $prefix, $pass) = @_;
 
 # Password is needed for DirectAdmin migrations
 if (!$parent && !$pass) {
@@ -13,10 +13,10 @@ if (!$parent && !$pass) {
 	}
 
 # Extract the backup and verify it
-local ($ok, $root) = &extract_directadmin_dir($file);
+my ($ok, $root) = &extract_directadmin_dir($file);
 $ok || return ("Not a DirectAdmin tar.gz file : $root");
-local $domains = "$root/domains";
-local $backup = "$root/backup";
+my $domains = "$root/domains";
+my $backup = "$root/backup";
 if (!-r $domains && $dom && -d "$backup/$dom") {
 	$domains = $backup;
 	}
@@ -24,7 +24,7 @@ if (!-r $domains && $dom && -d "$backup/$dom") {
 
 if (!$dom) {
 	# Try to work out the default domain
-	local @domdirs;
+	my @domdirs;
 	if (opendir(DOMDIRS, $domains)) {
 		@domdirs = grep { !/^default$/ && -r "$backup/$_/domain.conf" }
 			   readdir(DOMDIRS);
@@ -43,7 +43,7 @@ else {
 
 # If no username was given, use the default
 if (!$user) {
-	local %uinfo;
+	my %uinfo;
 	&read_env_file("$backup/user.conf", \%uinfo) ||
 		return ("$backup/user.conf not found!");
 	$user = $uinfo{'username'};
@@ -59,53 +59,53 @@ return (undef, $dom, $user, $pass);
 # created.
 sub migration_directadmin_migrate
 {
-local ($file, $dom, $user, $webmin, $template, $ipinfo, $pass, $parent,
+my ($file, $dom, $user, $webmin, $template, $ipinfo, $pass, $parent,
        $prefix, $email, $plan) = @_;
-local ($ok, $root) = &extract_directadmin_dir($file);
+my ($ok, $root) = &extract_directadmin_dir($file);
 $ok || return ("Not a DirectAdmin tar.gz file : $root");
-local $domains = "$root/domains";
-local $backup = "$root/backup";
-local $imap = "$root/imap";
+my $domains = "$root/domains";
+my $backup = "$root/backup";
+my $imap = "$root/imap";
 if (!-r $domains && $dom && -d "$backup/$dom") {
 	$domains = $backup;
 	}
 -d $domains && -d $backup || return ("Not a DirectAdmin backup file");
-local $tmpl = &get_template($template);
+my $tmpl = &get_template($template);
 
 # Check for prefix clash
 $prefix ||= &compute_prefix($dom, undef, $parent, 1);
-local $pclash = &get_domain_by("prefix", $prefix);
+my $pclash = &get_domain_by("prefix", $prefix);
 $pclash && &error("A virtual server using the prefix $prefix already exists");
 
 # Get shells for users
-local ($nologin_shell, $ftp_shell, undef, $def_shell) =
+my ($nologin_shell, $ftp_shell, undef, $def_shell) =
 	&get_common_available_shells();
 $nologin_shell ||= $def_shell;
 $ftp_shell ||= $def_shell;
 
 # Work out the username again if it wasn't supplied
-local %uinfo;
+my %uinfo;
 &read_env_file("$backup/user.conf", \%uinfo) ||
 	&error("$backup/user.conf not found!");
-local $origuser = $uinfo{'username'};
+my $origuser = $uinfo{'username'};
 $user ||= $origuser;
 $user || &error("Could not work out username automatically");
-local $group = $user;
-local $ugroup = $group;
-local %dinfo;
+my $group = $user;
+my $ugroup = $group;
+my %dinfo;
 &read_env_file("$backup/$dom/domain.conf", \%dinfo) ||
 	&error("$backup/$dom/domain.conf not found!");
 
 # First work out what features we have ..
 &$first_print("Checking for DirectAdmin features ..");
-local @got = &directadmin_domain_features($dom, $domains, $backup, $imap);
+my @got = &directadmin_domain_features($dom, $domains, $backup, $imap);
 
 # Tell the user what we have got
 @got = &show_check_migration_features(@got);
-local %got = map { $_, 1 } @got;
+my %got = map { $_, 1 } @got;
 
 # Work out user and group IDs
-local ($gid, $ugid, $uid, $duser);
+my ($gid, $ugid, $uid, $duser);
 if ($parent) {
 	# UID and GID come from parent
 	$gid = $parent->{'gid'};
@@ -122,8 +122,8 @@ else {
 	}
 
 # Work out quota
-local $quota;
-local $bsize = &quota_bsize("home");
+my $quota;
+my $bsize = &quota_bsize("home");
 $bsize ||= 1024;
 if ($uinfo{'quota'} && $uinfo{'quota'} ne 'unlimited') {
 	# Assume in MB
@@ -131,7 +131,7 @@ if ($uinfo{'quota'} && $uinfo{'quota'} ne 'unlimited') {
 	}
 
 # Create the virtual server object
-local %dom;
+my %dom;
 $prefix ||= &compute_prefix($dom, $group, $parent, 1);
 $plan = $parent ? &get_plan($parent->{'plan'}) :
 	$plan ? $plan : &get_default_plan();
@@ -210,7 +210,7 @@ if ($cerr) {
 # Create the initial server
 &$first_print("Creating initial virtual server $dom ..");
 &$indent_print();
-local $err = &create_virtual_server(\%dom, $parent,
+my $err = &create_virtual_server(\%dom, $parent,
 				    $parent ? $parent->{'user'} : undef);
 &$outdent_print();
 if ($err) {
@@ -220,7 +220,7 @@ if ($err) {
 else {
 	&$second_print(".. done");
 	}
-local @rvdoms = ( \%dom );
+my @rvdoms = ( \%dom );
 
 # Copy over public_html and private_html dirs
 &copy_directadmin_html_dir(\%dom, $domains);
@@ -246,15 +246,15 @@ local @rvdoms = ( \%dom );
 # Lock the user DB and build list of used IDs
 &obtain_lock_unix(\%dom);
 &obtain_lock_mail(\%dom);
-local (%taken, %utaken);
+my (%taken, %utaken);
 &build_taken(\%taken, \%utaken);
 
 &foreign_require("mailboxes");
 $mailboxes::no_permanent_index = 1;
-local %usermap;
+my %usermap;
 if ($got{'mail'}) {
 	# Migrate mail users
-	local $mcount = 0;
+	my $mcount = 0;
 	&$first_print("Re-creating mail users ..");
 	&foreign_require("mailboxes");
 	my $lref = &read_file_lines("$backup/$dom/email/quota", 1);
@@ -269,7 +269,7 @@ if ($got{'mail'}) {
 		my ($muser, $crypt) = split(/:/, $l);
 		next if (!$muser);
 		next if ($muser eq $user);	# Domain owner
-		local $uinfo = &create_initial_user(\%dom);
+		my $uinfo = &create_initial_user(\%dom);
 		$uinfo->{'user'} = &userdom_name(lc($muser), \%dom);
 		$uinfo->{'pass'} = $crypt;
 		$uinfo->{'uid'} = &allocate_uid(\%taken);
@@ -282,18 +282,18 @@ if ($got{'mail'}) {
 		&create_user_home($uinfo, \%dom, 1);
 		&create_user($uinfo, \%dom);
 		$taken{$uinfo->{'uid'}}++;
-		local ($crfile, $crtype) = &create_mail_file($uinfo, \%dom);
+		my ($crfile, $crtype) = &create_mail_file($uinfo, \%dom);
 
 		# Move his Maildir directory
 		# XXX sub-folders??
-		local $mailsrc = "$backup/$dom/email/data/imap/$muser/Maildir";
+		my $mailsrc = "$backup/$dom/email/data/imap/$muser/Maildir";
 		if (!-d $mailsrc) {
 			$mailsrc = "$imap/$dom/$muser/Maildir";
 			}
 		if (-d $mailsrc) {
-			local $srcfolder = { 'type' => 1,
+			my $srcfolder = { 'type' => 1,
 					     'file' => $mailsrc };
-			local $dstfolder = { 'file' => $crfile,
+			my $dstfolder = { 'file' => $crfile,
 					     'type' => $crtype };
 			&mailboxes::mailbox_move_folder($srcfolder, $dstfolder);
 			&set_mailfolder_owner($dstfolder, $uinfo);
@@ -308,14 +308,14 @@ if ($got{'mail'}) {
 &copy_directadmin_mail_aliases(\%dom, $backup);
 
 # Migrate FTP users
-local $fcount = 0;
+my $fcount = 0;
 &$first_print("Copying FTP users ..");
 my $lref = &read_file_lines("$backup/$dom/ftp.passwd");
 foreach my $l (@$lref) {
 	$l =~ /^([^@]+)@[^=]+=passwd=([^=]+)&path=([^=\&]+)/ || next;
 	my ($fuser, $crypt, $path) = ($1, $2, $3);
 	next if ($fuser eq $user);      # Domain owner
-	local $uinfo = &create_initial_user(\%dom, 0, 1);
+	my $uinfo = &create_initial_user(\%dom, 0, 1);
 	$uinfo->{'user'} = &userdom_name(lc($fuser), \%dom);
 	$uinfo->{'pass'} = $crypt;
 	$uinfo->{'uid'} = $dom{'uid'};
@@ -348,31 +348,31 @@ foreach my $l (@$lref) {
 
 if ($got{'mysql'}) {
 	# Re-create all MySQL databases
-	local $mycount = 0;
-	local $myucount = 0;
+	my $mycount = 0;
+	my $myucount = 0;
 	&$first_print("Re-creating and loading MySQL databases ..");
 	&disable_quotas(\%dom);
 	foreach my $myf (glob("$backup/*.sql")) {
 		if ($myf =~ /\/([^\/]+)\.sql$/) {
-			local $db = $1;
+			my $db = $1;
 			&$indent_print();
 			&create_mysql_database(\%dom, $db);
 			&save_domain(\%dom, 1);
-			local ($ex, $out) = &execute_dom_sql_file(\%dom, $db, $myf);
+			my ($ex, $out) = &execute_dom_sql_file(\%dom, $db, $myf);
 			if ($ex) {
 				&$first_print("Error loading $db : $out");
 				}
 			&$outdent_print();
 
 			# Create extra DB users
-			local %dbusers;
+			my %dbusers;
 			&read_env_file("$backup/$db.conf", \%dbusers);
 			foreach my $myuser (keys %dbusers) {
 				next if ($myuser eq $user);
 				next if ($dbusers{$myuser} !~ /passwd=([^&]+)/);
 				my $mypass = $1;
 				$mypass =~ s/^%2A/\*/;
-				local $myuinfo = &create_initial_user(\%dom);
+				my $myuinfo = &create_initial_user(\%dom);
 				$myuinfo->{'user'} = $myuser;
 				$myuinfo->{'pass'} = "x";	# not needed
 				$myuinfo->{'mysql_pass'} = $mypass;
@@ -383,7 +383,7 @@ if ($got{'mysql'}) {
 				$myuinfo->{'dbs'} = [ { 'type' => 'mysql',
 							'name' => $db } ];
 				delete($myuinfo->{'email'});
-				local $already = $usermap{$myuinfo->{'user'}};
+				my $already = $usermap{$myuinfo->{'user'}};
 				if ($already) {
 					# User already exists, so just give him
 					# access to the dbs
@@ -422,7 +422,7 @@ foreach my $adom (keys %aliaslist) {
 		next;
 		}
 	&$indent_print();
-	local %alias = ( 'id', &domain_id(),
+	my %alias = ( 'id', &domain_id(),
 			 'dom', $adom,
 			 'user', $dom{'user'},
 			 'group', $dom{'group'},
@@ -451,7 +451,7 @@ foreach my $adom (keys %aliaslist) {
 	foreach my $f (@alias_features) {
 		$alias{$f} = $dom{$f};
 		}
-	local $parentdom = $dom{'parent'} ? &get_domain($dom{'parent'})
+	my $parentdom = $dom{'parent'} ? &get_domain($dom{'parent'})
 					  : \%dom;
 	$alias{'home'} = &server_home_directory(\%alias, $parentdom);
 	&generate_domain_password_hashes(\%alias, 1);
@@ -477,7 +477,7 @@ foreach my $sdom (@$sublist) {
 		next;
 		}
 	&$indent_print();
-	local %subd = ( 'id', &domain_id(),
+	my %subd = ( 'id', &domain_id(),
 			'dom', $sname,
 			'user', $dom{'user'},
 			'group', $dom{'group'},
@@ -507,7 +507,7 @@ foreach my $sdom (@$sublist) {
 	foreach my $f (@subdom_features) {
 		$subd{$f} = $dom{$f};
 		}
-	local $parentdom = $dom{'parent'} ? &get_domain($dom{'parent'})
+	my $parentdom = $dom{'parent'} ? &get_domain($dom{'parent'})
 					  : \%dom;
 	$subd{'home'} = &server_home_directory(\%subd, $parentdom);
 	&generate_domain_password_hashes(\%subd, 1);
@@ -535,7 +535,7 @@ if (!$dom{'parent'}) {
 			}
 		&$indent_print();
 
-		local %subd = ( 'id', &domain_id(),
+		my %subd = ( 'id', &domain_id(),
 				'dom', $dname,
 				'user', $dom{'user'},
 				'group', $dom{'group'},
@@ -567,7 +567,7 @@ if (!$dom{'parent'}) {
 			next if ($f eq "unix" || $f eq "webmin");
 			$subd{$f} = $got{$f} ? 1 : 0;
 			}
-		local $parentdom = $dom{'parent'} ? &get_domain($dom{'parent'})
+		my $parentdom = $dom{'parent'} ? &get_domain($dom{'parent'})
 						  : \%dom;
 		$subd{'home'} = &server_home_directory(\%subd, $parentdom);
 		$subd{'cgi_bin_dir'} = "public_html/cgi-bin";
@@ -627,8 +627,8 @@ return @rvdoms;
 # under which it was extracted, or an error message
 sub extract_directadmin_dir
 {
-local ($file) = @_;
-local $dir;
+my ($file) = @_;
+my $dir;
 if ($main::directadmin_dir_cache{$file} && -d $main::directadmin_dir_cache{$file}) {
 	# Use cached extract from this session
 	return (1, $main::directadmin_dir_cache{$file});
@@ -643,7 +643,7 @@ elsif (-d $file) {
 else {
 	$dir = &transname();
 	mkdir($dir, 0700);
-	local $err = &extract_compressed_file($file, $dir);
+	my $err = &extract_compressed_file($file, $dir);
 	if ($err) {
 		return (0, $err);
 		}
@@ -778,7 +778,7 @@ if ($d->{'dns'} && -r $dnsfile && !$d->{'dns_submode'}) {
 		elsif ($r->{'name'} eq $d->{'dom'}."." &&
 		       $r->{'type'} eq 'NS') {
 			# Set NS record to this server
-			local $master = $bconfig{'default_prins'} ||
+			my $master = $bconfig{'default_prins'} ||
 					&get_system_hostname();
 			$master .= "." if ($master !~ /\.$/);
 			$r->{'values'} = [ $master ];
@@ -878,10 +878,10 @@ sub copy_directadmin_mail_aliases
 my ($d, $backup) = @_;
 my $afile = "$backup/$d->{'dom'}/email/aliases";
 if ($d->{'mail'} && -r $afile) {
-	local $acount = 0;
+	my $acount = 0;
 	&$first_print("Copying email aliases ..");
 	&set_alias_programs();
-	local %gotvirt = map { $_->{'from'}, $_ } &list_virtusers();
+	my %gotvirt = map { $_->{'from'}, $_ } &list_virtusers();
 	my $lref = &read_file_lines($afile, 1);
 	foreach my $l (@$lref) {
 		my ($name, $values) = split(/:/, $l, 2);
@@ -892,7 +892,7 @@ if ($d->{'mail'} && -r $afile) {
 				$v = "BOUNCE";
 				}
 			}
-		local $virt = { 'from' => $name =~ /^\*/ ?
+		my $virt = { 'from' => $name =~ /^\*/ ?
 				  "\@".$d->{'dom'} :
 				  $name."\@".$d->{'dom'},
 				'to' => \@values };
@@ -915,11 +915,11 @@ my %dinfo;
 my @got = ( "dir", $parent ? () : ("unix"),
 	    &domain_has_website(), "logrotate" );
 push(@got, "webmin") if ($webmin && !$parent);
-local @sqlfiles = glob("$backup/*.sql");
+my @sqlfiles = glob("$backup/*.sql");
 if (@sqlfiles) {
 	push(@got, "mysql");
 	}
-local $zonefile = "$backup/$dom/$dom.db";
+my $zonefile = "$backup/$dom/$dom.db";
 if (-r $zonefile) {
 	push(@got, "dns");
 	}

--- a/migration-plesk.pl
+++ b/migration-plesk.pl
@@ -5,17 +5,17 @@
 # Make sure the given file is a Plesk 9-11 backup, and contains the domain
 sub migration_plesk_validate
 {
-local ($file, $dom, $user, $parent, $prefix, $pass) = @_;
-local ($ok, $root) = &extract_plesk_dir($file, 8);
+my ($file, $dom, $user, $parent, $prefix, $pass) = @_;
+my ($ok, $root) = &extract_plesk_dir($file, 8);
 $ok || return ("Not a Plesk 9, 10 or 11 backup file : $root");
-local ($xfile) = glob("$root/*.xml");
+my ($xfile) = glob("$root/*.xml");
 $xfile && -r $xfile || return ("Not a complete Plesk 9, 10 or 11 backup file - missing XML file");
 
 # Check if the domain is in there
-local $dump = &read_plesk_xml($xfile);
+my $dump = &read_plesk_xml($xfile);
 ref($dump) || return ($dump);
-local $domain;
-local $domains = $dump->{'admin'} ? $dump->{'admin'}->{'domains'}
+my $domain;
+my $domains = $dump->{'admin'} ? $dump->{'admin'}->{'domains'}
 				  : $dump->{'domains'};
 if ($domains) {
 	# Plesk 11 format
@@ -52,7 +52,7 @@ if ($domains) {
 	}
 else {
 	# Plesk 9 / 10 format, or Plesk 11 single-domain
-	local $mig = $dump->{'dump-format'} ? $dump :
+	my $mig = $dump->{'dump-format'} ? $dump :
 			$dump->{'Data'}->{'migration-dump'};
 	$mig || return ("Missing migration-dump section in XML file");
 	if (scalar(keys %{$mig->{'domain'}}) == 0 ||
@@ -96,27 +96,27 @@ return (undef, $dom, $user, $pass);
 # created.
 sub migration_plesk_migrate
 {
-local ($file, $dom, $user, $webmin, $template, $ipinfo, $pass, $parent,
+my ($file, $dom, $user, $webmin, $template, $ipinfo, $pass, $parent,
        $prefix, $email, $plan) = @_;
 
 # Check for prefix clash
 $prefix ||= &compute_prefix($dom, undef, $parent, 1);
-local $pclash = &get_domain_by("prefix", $prefix);
+my $pclash = &get_domain_by("prefix", $prefix);
 $pclash && &error("A virtual server using the prefix $prefix already exists");
 
 # Get shells for users
-local ($nologin_shell, $ftp_shell, undef, $def_shell) =
+my ($nologin_shell, $ftp_shell, undef, $def_shell) =
 	&get_common_available_shells();
 $nologin_shell ||= $def_shell;
 $ftp_shell ||= $def_shell;
 
 # Extract backup and read the dump file
-local ($ok, $root) = &extract_plesk_dir($file);
-local ($xfile) = glob("$root/*.xml");
-local $dump = &read_plesk_xml($xfile);
+my ($ok, $root) = &extract_plesk_dir($file);
+my ($xfile) = glob("$root/*.xml");
+my $dump = &read_plesk_xml($xfile);
 ref($dump) || &error($dump);
-local $domain;
-local $domains = $dump->{'admin'} ? $dump->{'admin'}->{'domains'}
+my $domain;
+my $domains = $dump->{'admin'} ? $dump->{'admin'}->{'domains'}
 				  : $dump->{'domains'};
 if ($domains) {
 	# Plesk 11 format
@@ -134,7 +134,7 @@ if ($domains) {
 	}
 else {
 	# Plesk 9 / 10 format, or Plesk 11 single domain
-	local $mig = $dump->{'dump-format'} ? $dump :
+	my $mig = $dump->{'dump-format'} ? $dump :
 			$dump->{'Data'}->{'migration-dump'};
 	if (!$mig->{'domain'}->{$dom} &&
 	    $mig->{'domain'}->{'name'} ne $dom) {
@@ -153,12 +153,12 @@ else {
 		$user = $domain->{'phosting'}->{'preferences'}->{'sysuser'}->{'name'};
 		}
 	}
-local $group = $user;
-local $ugroup = $group;
+my $group = $user;
+my $ugroup = $group;
 
 # Extract the tar.gz file containing additional content
 &$first_print("Finding contents files ..");
-local $cids = $domain->{'phosting'}->{'content'}->{'cid'};
+my $cids = $domain->{'phosting'}->{'content'}->{'cid'};
 if (!$cids) {
 	&$second_print(".. no contents data found!");
 #	return ( \%dom );
@@ -171,9 +171,9 @@ elsif (ref($cids) eq 'HASH') {
 
 # First work out what features we have
 &$first_print("Checking for Plesk features ..");
-local @got = ( "dir", $parent ? () : ("unix") );
+my @got = ( "dir", $parent ? () : ("unix") );
 push(@got, "webmin") if ($webmin && !$parent);
-local $mss = $domain->{'mailsystem'}->{'properties'}->{'status'};
+my $mss = $domain->{'mailsystem'}->{'properties'}->{'status'};
 if (exists($mss->{'enabled'}) ||
     $domain->{'mail'}) {
 	push(@got, "mail");
@@ -189,7 +189,7 @@ elsif (!$mss->{'disabled-by'}->{'admin'} &&
 if ($domain->{'properties'}->{'dns-zone'}) {
 	push(@got, "dns");
 	}
-local ($wwwcid) = grep { $_->{'type'} eq 'docroot' } @$cids;
+my ($wwwcid) = grep { $_->{'type'} eq 'docroot' } @$cids;
 if ($domain->{'www'} eq 'true' || $wwwcid) {
 	push(@got, &domain_has_website());
 	}
@@ -209,7 +209,7 @@ if ($domain->{'phosting'}->{'preferences'}->{'webalizer'} &&
 	}
 
 # Check for MySQL databases
-local $databases = $domain->{'databases'}->{'database'};
+my $databases = $domain->{'databases'}->{'database'};
 if (!$databases) {
 	$databases = { };
 	}
@@ -217,15 +217,15 @@ elsif ($databases->{'version'}) {
 	# Just one database
 	$databases = { $databases->{'name'} => $databases };
 	}
-local @mysqldbs = grep { $databases->{$_}->{'type'} eq 'mysql' }
+my @mysqldbs = grep { $databases->{$_}->{'type'} eq 'mysql' }
 		       (keys %$databases);
 if (@mysqldbs) {
 	push(@got, "mysql");
 	}
 
 # Check for mail users
-local ($has_spam, $has_virus);
-local $mailusers = $domain->{'mailsystem'}->{'mailusers'}->{'mailuser'};
+my ($has_spam, $has_virus);
+my $mailusers = $domain->{'mailsystem'}->{'mailusers'}->{'mailuser'};
 if (!$mailusers) {
 	$mailusers = { };
 	}
@@ -234,7 +234,7 @@ elsif ($mailusers->{'mailbox-quota'}) {
 	$mailusers = { $mailusers->{'name'} => $mailusers };
 	}
 foreach my $name (keys %$mailusers) {
-	local $mailuser = $mailusers->{$name};
+	my $mailuser = $mailusers->{$name};
 	if ($mailuser->{'spamassassin'}->{'status'} eq 'on') {
 		$has_spam++;
 		}
@@ -252,10 +252,10 @@ if (&indexof("mail", @got) >= 0) {
 
 # Tell the user what we have got
 @got = &show_check_migration_features(@got);
-local %got = map { $_, 1 } @got;
+my %got = map { $_, 1 } @got;
 
 # Work out user and group IDs
-local ($gid, $ugid, $uid, $duser);
+my ($gid, $ugid, $uid, $duser);
 if ($parent) {
 	# UID and GID come from parent
 	$gid = $parent->{'gid'};
@@ -272,8 +272,8 @@ else {
 	}
 
 # Get the quota and domain password (if not supplied)
-local $bsize = &has_home_quotas() ? &quota_bsize("home") : undef;
-local $quota;
+my $bsize = &has_home_quotas() ? &quota_bsize("home") : undef;
+my $quota;
 if (!$parent && &has_home_quotas()) {
 	$quota = $domain->{'phosting'}->{'sysuser'}->{'quota'} / $bsize;
 	}
@@ -283,7 +283,7 @@ if (!$parent && !$pass) {
 	}
 
 # Create the virtual server object
-local %dom;
+my %dom;
 $prefix ||= &compute_prefix($dom, $group, $parent, 1);
 $plan = $parent ? &get_plan($parent->{'plan'}) :
         $plan ? $plan : &get_default_plan();
@@ -355,7 +355,7 @@ if ($cerr) {
 # Create the initial server
 &$first_print("Creating initial virtual server $dom ..");
 &$indent_print();
-local $err = &create_virtual_server(\%dom, $parent,
+my $err = &create_virtual_server(\%dom, $parent,
 				    $parent ? $parent->{'user'} : undef);
 &$outdent_print();
 if ($err) {
@@ -371,14 +371,14 @@ else {
 if (defined(&set_php_wrappers_writable)) {
 	&set_php_wrappers_writable(\%dom, 1);
 	}
-local $hdir = &public_html_dir(\%dom);
-local $phdir = $hdir;
-local $user_data_files;
+my $hdir = &public_html_dir(\%dom);
+my $phdir = $hdir;
+my $user_data_files;
 if ($cids) {
 	$user_data_files = &extract_plesk_cid($root, $cids, "user-data");
-	local $docroot_files = &extract_plesk_cid($root, $cids, "docroot");
-	local $httpdocs = $domain->{'phosting'}->{'www-root'} || "httpdocs";
-	local $cgidocs = "cgi-bin";
+	my $docroot_files = &extract_plesk_cid($root, $cids, "docroot");
+	my $httpdocs = $domain->{'phosting'}->{'www-root'} || "httpdocs";
+	my $cgidocs = "cgi-bin";
 	if ($docroot_files) {
 		&copy_source_dest($docroot_files, $hdir);
 		&set_home_ownership(\%dom);
@@ -395,8 +395,8 @@ if ($cids) {
 
 	# Copy CGI files
 	&$first_print("Copying CGI scripts ..");
-	local $cdir = &cgi_bin_dir(\%dom);
-	local $cgi_files =  &extract_plesk_cid($root, $cids, "cgi");
+	my $cdir = &cgi_bin_dir(\%dom);
+	my $cgi_files =  &extract_plesk_cid($root, $cids, "cgi");
 	if ($cgi_files) {
 		&copy_source_dest($cgi_files, $cdir);
 		&set_home_ownership(\%dom);
@@ -416,11 +416,11 @@ if ($cids) {
 	}
 
 # Re-create DNS records
-local $oldip = $ip->{'ip-address'};
+my $oldip = $ip->{'ip-address'};
 if ($got{'dns'}) {
 	&$first_print("Copying and fixing DNS records ..");
-	local $zonexml = $domain->{'properties'}->{'dns-zone'};
-	local ($recs, $file) = &get_domain_dns_records_and_file(\%dom);
+	my $zonexml = $domain->{'properties'}->{'dns-zone'};
+	my ($recs, $file) = &get_domain_dns_records_and_file(\%dom);
 	if (!$file) {
 		&$second_print(".. could not find new DNS zone!");
 		}
@@ -428,16 +428,16 @@ if ($got{'dns'}) {
 		&$second_print(".. could not find zone in backup");
 		}
 	else {
-		local $rcount = 0;
+		my $rcount = 0;
 		foreach my $rec (@{$zonexml->{'dnsrec'}}) {
-			local $recname = $rec->{'src'};
+			my $recname = $rec->{'src'};
 			$recname .= ".".$dom."." if ($recname !~ /\.$/);
-			local ($oldrec) = grep { $_->{'name'} eq $recname }
+			my ($oldrec) = grep { $_->{'name'} eq $recname }
 					       @$recs;
 			if (!$oldrec) {
 				# Found one we need to add
-				local $recvalue = $rec->{'dst'};
-				local $rectype = $rec->{'type'};
+				my $recvalue = $rec->{'dst'};
+				my $rectype = $rec->{'type'};
 				if ($rectype eq "A" && $recvalue eq $oldip) {
 					# Use new IP address
 					$recvalue = $dom{'dns_ip'} ||
@@ -468,10 +468,10 @@ if ($got{'dns'}) {
 	}
 
 # Migrate SSL certs
-local $certificate = $domain->{'certificates'}->{'certificate'};
+my $certificate = $domain->{'certificates'}->{'certificate'};
 if ($certificate) {
 	&$first_print("Migrating SSL certificate and key ..");
-	local $cert = &cleanup_plesk_cert($certificate->{'certificate-data'});
+	my $cert = &cleanup_plesk_cert($certificate->{'certificate-data'});
 	&create_ssl_certificate_directories(\%dom);
 	if ($cert) {
 		$dom{'ssl_cert'} ||= &default_certificate_file(\%dom, 'cert');
@@ -479,14 +479,14 @@ if ($certificate) {
 		&print_tempfile(CERT, $cert);
 		&close_tempfile(CERT);
 		}
-	local $key = &cleanup_plesk_cert($certificate->{'private-key'});
+	my $key = &cleanup_plesk_cert($certificate->{'private-key'});
 	if ($key) {
 		$dom{'ssl_key'} ||= &default_certificate_file(\%dom, 'key');
 		&open_tempfile(CERT, ">$dom{'ssl_key'}");
 		&print_tempfile(CERT, $key);
 		&close_tempfile(CERT);
 		}
-	local $ca = &cleanup_plesk_cert($certificate->{'ca-certificate'});
+	my $ca = &cleanup_plesk_cert($certificate->{'ca-certificate'});
 	if ($ca) {
 		$dom{'ssl_chain'} ||= &default_certificate_file(\%dom, 'chain');
 		&open_tempfile(CERT, ">$dom{'ssl_chain'}");
@@ -502,20 +502,20 @@ if ($certificate) {
 # Lock the user DB and build list of used IDs
 &obtain_lock_unix(\%dom);
 &obtain_lock_mail(\%dom);
-local (%taken, %utaken);
+my (%taken, %utaken);
 &build_taken(\%taken, \%utaken);
 
 # Re-create mail users and copy mail files
 &$first_print("Re-creating mail users ..");
 &foreign_require("mailboxes");
 $mailboxes::no_permanent_index = 1;
-local $mcount = 0;
+my $mcount = 0;
 foreach my $name (keys %$mailusers) {
 	next if ($windows);
-	local $mailuser = $mailusers->{$name};
-	local $uinfo = &create_initial_user(\%dom);
+	my $mailuser = $mailusers->{$name};
+	my $uinfo = &create_initial_user(\%dom);
 	$uinfo->{'user'} = &userdom_name(lc($name), \%dom);
-	local $pinfo = $mailuser->{'properties'}->{'password'};
+	my $pinfo = $mailuser->{'properties'}->{'password'};
 	if ($pinfo->{'type'} eq 'plain') {
 		$uinfo->{'plainpass'} = $pinfo->{'content'};
 		$uinfo->{'pass'} = &encrypt_user_password(
@@ -531,7 +531,7 @@ foreach my $name (keys %$mailusers) {
 	$uinfo->{'to'} = [ ];
 	if ($mailuser->{'mailbox'}->{'enabled'} eq 'true') {
 		# Add delivery to user's mailbox
-		local $escuser = $uinfo->{'user'};
+		my $escuser = $uinfo->{'user'};
 		if ($mail_system == 0 && $escuser =~ /\@/) {
 			$escuser = &escape_replace_atsign_if_exists($escuser);
 			}
@@ -541,12 +541,12 @@ foreach my $name (keys %$mailusers) {
 		push(@{$uinfo->{'to'}}, "\\".$escuser);
 		}
 	if (&has_home_quotas()) {
-		local $q = $mailuser->{'mailbox-quota'} < 0 ? undef :
+		my $q = $mailuser->{'mailbox-quota'} < 0 ? undef :
 				$mailuser->{'mailbox-quota'};
 		$uinfo->{'quota'} = $q / &quota_bsize("home");
 		}
 	# Add mail aliases
-	local $alias = $mailuser->{'preferences'}->{'alias'};
+	my $alias = $mailuser->{'preferences'}->{'alias'};
 	if ($alias) {
 		$alias = [ $alias ] if (ref($alias) ne 'ARRAY');
 		foreach my $a (@$alias) {
@@ -556,7 +556,7 @@ foreach my $name (keys %$mailusers) {
 			}
 		}
 	# Add forwarding
-	local $redirect = $mailuser->{'preferences'}->{'redirect'};
+	my $redirect = $mailuser->{'preferences'}->{'redirect'};
 	if ($redirect) {
 		$redirect = [ $redirect ] if (ref($redirect) ne 'ARRAY');
 		foreach my $r (@$redirect) {
@@ -566,7 +566,7 @@ foreach my $name (keys %$mailusers) {
 			}
 		}
 	# Add mail group members (which are really just forwards)
-	local $mailgroup = $mailuser->{'preferences'}->{'mailgroup-member'};
+	my $mailgroup = $mailuser->{'preferences'}->{'mailgroup-member'};
 	if ($mailgroup) {
 		$mailgroup = [ $mailgroup ] if (ref($mailgroup) ne 'ARRAY');
 		foreach my $r (@$mailgroup) {
@@ -586,18 +586,18 @@ foreach my $name (keys %$mailusers) {
 	&create_user_home($uinfo, \%dom, 1);
 	&create_user($uinfo, \%dom);
 	$taken{$uinfo->{'uid'}}++;
-	local ($crfile, $crtype) = &create_mail_file($uinfo, \%dom);
+	my ($crfile, $crtype) = &create_mail_file($uinfo, \%dom);
 
 	# Copy mail into user's inbox
-	local $cids = [ $mailuser->{'preferences'}->{'mailbox'}->{'content'}->{'cid'} ];
+	my $cids = [ $mailuser->{'preferences'}->{'mailbox'}->{'content'}->{'cid'} ];
 	if (ref($cids->[0]) eq 'ARRAY') {
 		# Sometimes there are multiple mailboxes .. just use the first
 		$cids = [ $cids->[0]->[0] ];
 		}
-	local $srcdir = &extract_plesk_cid($root, $cids, "mailbox");
+	my $srcdir = &extract_plesk_cid($root, $cids, "mailbox");
 	if ($srcdir) {
-		local $srcfolder = { 'file' => $srcdir, 'type' => 1 };
-		local $dstfolder = { 'file' => $crfile, 'type' => $crtype };
+		my $srcfolder = { 'file' => $srcdir, 'type' => 1 };
+		my $dstfolder = { 'file' => $crfile, 'type' => $crtype };
 		&mailboxes::mailbox_move_folder($srcfolder, $dstfolder);
 		&set_mailfolder_owner($dstfolder, $uinfo);
 		}
@@ -607,12 +607,12 @@ foreach my $name (keys %$mailusers) {
 &$second_print(".. done (migrated $mcount users)");
 
 # Re-create mail aliases / catchall
-local $acount = 0;
+my $acount = 0;
 &$first_print("Re-creating mail aliases ..");
 &set_alias_programs();
-local $ca = $domain->{'mailsystem'}->{'preferences'}->{'catch-all'};
+my $ca = $domain->{'mailsystem'}->{'preferences'}->{'catch-all'};
 if ($ca) {
-	local @to;
+	my @to;
 	if ($ca =~ /^bounce:(.*)/) {
 		push(@to, "BOUNCE $1");
 		}
@@ -622,7 +622,7 @@ if ($ca) {
 	else {
 		push(@to, $ca);
 		}
-	local $virt = { 'from' => "\@$dom",
+	my $virt = { 'from' => "\@$dom",
 			'to' => \@to };
 	&create_virtuser($virt);
 	$acount++;
@@ -632,21 +632,21 @@ if ($ca) {
 # Re-create MySQL databases
 if ($got{'mysql'}) {
 	&require_mysql();
-	local $mcount = 0;
-	local $myucount = 0;
+	my $mcount = 0;
+	my $myucount = 0;
 	&$first_print("Migrating MySQL databases ..");
 	&disable_quotas(\%dom);
 	foreach my $name (keys %$databases) {
-		local $database = $databases->{$name};
+		my $database = $databases->{$name};
 		next if ($database->{'type'} ne 'mysql');
 
 		# Create and import the DB
 		&$indent_print();
 		&create_mysql_database(\%dom, $name);
 		&save_domain(\%dom, 1);
-		local $cids = [ $database->{'content'}->{'cid'} ];
-		local $sqldir = &extract_plesk_cid($root, $cids, "sqldump");
-		local ($sqlfile) = glob("$sqldir/*$name*");
+		my $cids = [ $database->{'content'}->{'cid'} ];
+		my $sqldir = &extract_plesk_cid($root, $cids, "sqldump");
+		my ($sqlfile) = glob("$sqldir/*$name*");
 		&$first_print("Restoring database $name ..");
 		if (!$sqlfile || !-f $sqlfile) {
 			($sqlfile) = glob("$sqldir/backup_*");
@@ -658,7 +658,7 @@ if ($got{'mysql'}) {
 			&$second_print(".. database content missing SQL file");
 			}
 		else {
-			local ($ex, $out) = &execute_dom_sql_file(\%dom, $name,
+			my ($ex, $out) = &execute_dom_sql_file(\%dom, $name,
 								  $sqlfile);
 			if ($ex) {
 				&$second_print(".. error loading $db : $out");
@@ -669,13 +669,13 @@ if ($got{'mysql'}) {
 			}
 
 		# Create any DB users as domain users
-		local $dbusers = $database->{'dbuser'};
+		my $dbusers = $database->{'dbuser'};
 		$dbusers = !$dbusers ? { } :
 		   $dbusers->{'password'} ? { $dbusers->{'name'} => $dbusers } :
 					    $dbusers;
 		foreach my $mname (keys %$dbusers) {
 			next if ($mname eq $user);	# Domain owner
-			local $myuinfo = &create_initial_user(\%dom);
+			my $myuinfo = &create_initial_user(\%dom);
 			$myuinfo->{'user'} = $mname;
 			$myuinfo->{'plainpass'} =
 				$dbusers->{$mname}->{'password'}->{'content'};
@@ -702,7 +702,7 @@ if ($got{'mysql'}) {
 		}
 
 	# Create DB users that are outside of databases
-	local $dbusers = $domain->{'databases'}->{'dbusers'}->{'dbuser'};
+	my $dbusers = $domain->{'databases'}->{'dbusers'}->{'dbuser'};
 	if (!$dbusers) {
 		$dbusers = { };
 		}
@@ -713,7 +713,7 @@ if ($got{'mysql'}) {
 	foreach my $mname (keys %$dbusers) {
 		my $dbuser = $dbusers->{$name};
 		next if ($mname eq $user);	# Domain owner
-		local $myuinfo = &create_initial_user(\%dom);
+		my $myuinfo = &create_initial_user(\%dom);
 		$myuinfo->{'user'} = $mname;
 		$myuinfo->{'plainpass'} =
 			$dbusers->{$mname}->{'password'}->{'content'};
@@ -745,12 +745,12 @@ if ($got{'mysql'}) {
 &sync_alias_virtuals(\%dom);
 
 # Migrate protected directories as .htaccess files
-local $pdir = $domain->{'phosting'}->{'preferences'}->{'pdir'};
+my $pdir = $domain->{'phosting'}->{'preferences'}->{'pdir'};
 if ($pdir && &foreign_check("htaccess-htpasswd")) {
 	&$first_print("Re-creating protected directories ..");
 	&foreign_require("htaccess-htpasswd");
-	local $hdir = &public_html_dir(\%dom);
-	local $etc = "$dom{'home'}/etc";
+	my $hdir = &public_html_dir(\%dom);
+	my $etc = "$dom{'home'}/etc";
 	if (!-d $etc) {
 		# Create ~/etc dir
 		&make_dir($etc, 0755);
@@ -759,19 +759,19 @@ if ($pdir && &foreign_check("htaccess-htpasswd")) {
 		}
 
 	# Migrate each one, by creating a .htaccess file
-	local $pcount = 0;
+	my $pcount = 0;
 	if ($pdir->{'name'}) {
 		$pdir = { $pdir->{'name'} => $pdir };
 		}
-	local @htdirs = &htaccess_htpasswd::list_directories();
+	my @htdirs = &htaccess_htpasswd::list_directories();
 	foreach my $name (keys %$pdir) {
 		# Make .htaccess file
-		local $p = $pdir->{$name};
-		local $dir = "$hdir/$name";
+		my $p = $pdir->{$name};
+		my $dir = "$hdir/$name";
 		next if (!-d $dir);	# Protected dir is missing
-		local $htaccess = "$dir/$htaccess_htpasswd::config{'htaccess'}";
+		my $htaccess = "$dir/$htaccess_htpasswd::config{'htaccess'}";
 		$name =~ s/\//-/g;
-		local $htpasswd = "$etc/.htpasswd-$name";
+		my $htpasswd = "$etc/.htpasswd-$name";
 		&open_tempfile(HTACCESS, ">$htaccess");
 		&print_tempfile(HTACCESS, "AuthName \"$p->{'title'}\"\n");
 		&print_tempfile(HTACCESS, "AuthType Basic\n");
@@ -782,13 +782,13 @@ if ($pdir && &foreign_check("htaccess-htpasswd")) {
 		# Add users to .htpasswd file
 		&open_tempfile(HTPASSWD, ">$htpasswd");
 		&close_tempfile(HTPASSWD);
-		local $pduser = $p->{'pduser'};
+		my $pduser = $p->{'pduser'};
 		if ($pduser) {
 			$pduser = [ $pduser ] if (ref($pduser) ne 'ARRAY');
 			foreach my $u (@$pduser) {
-				local $huinfo = { 'user' => $u->{'name'},
+				my $huinfo = { 'user' => $u->{'name'},
 						  'enabled' => 1 };
-				local $pass = $u->{'password'}->{'content'};
+				my $pass = $u->{'password'}->{'content'};
 				if ($u->{'password'}->{'type'} eq 'plain') {
 					$huinfo->{'pass'} = &htaccess_htpasswd::encrypt_password($pass);
 					}
@@ -811,7 +811,7 @@ if ($pdir && &foreign_check("htaccess-htpasswd")) {
 	}
 
 # Migrate alias domains
-local $aliasdoms = $domain->{'preferences'}->{'domain-alias'};
+my $aliasdoms = $domain->{'preferences'}->{'domain-alias'};
 if (!$aliasdoms) {
 	$aliasdoms = { };
 	}
@@ -819,16 +819,16 @@ elsif ($aliasdoms->{'web'}) {
 	# Just one alias
 	$aliasdoms = { $aliasdoms->{'name'} => $aliasdoms };
 	}
-local @rvdoms;
+my @rvdoms;
 foreach my $adom (keys %$aliasdoms) {
-	local $aliasdom = $aliasdoms->{$adom};
+	my $aliasdom = $aliasdoms->{$adom};
 	&$first_print("Creating alias domain $adom ..");
 	if (&domain_name_clash($adom)) {
 		&$second_print(".. the domain $adom already exists");
 		next;
 		}
 	&$indent_print();
-	local %alias = ( 'id', &domain_id(),
+	my %alias = ( 'id', &domain_id(),
 			 'dom', $adom,
 			 'user', $dom{'user'},
 			 'group', $dom{'group'},
@@ -855,11 +855,11 @@ foreach my $adom (keys %$aliasdoms) {
 			);
 	$alias{'dom'} =~ s/^www\.//;
 	foreach my $f (@alias_features) {
-		local $want = $f eq 'web' ? $aliasdom->{'web'} eq 'true' :
+		my $want = $f eq 'web' ? $aliasdom->{'web'} eq 'true' :
 			      $f eq 'dns' ? $aliasdom->{'dns'} eq 'true' : 1;
 		$alias{$f} = $dom{$f} && $want;
 		}
-	local $parentdom = $dom{'parent'} ? &get_domain($dom{'parent'})
+	my $parentdom = $dom{'parent'} ? &get_domain($dom{'parent'})
 					  : \%dom;
 	$alias{'home'} = &server_home_directory(\%alias, $parentdom);
 	&generate_domain_password_hashes(\%alias, 1);
@@ -872,7 +872,7 @@ foreach my $adom (keys %$aliasdoms) {
 	}
 
 # Migrate sub-domains (as Virtualmin sub-servers)
-local $subdoms;
+my $subdoms;
 if ($domain->{'phosting'}->{'sites'}) {
 	$subdoms = $domain->{'phosting'}->{'sites'}->{'site'};
 	}
@@ -887,8 +887,8 @@ elsif ($subdoms->{'name'}) {
 	$subdoms = { $subdoms->{'name'} => $subdoms };
 	}
 foreach my $sdom (keys %$subdoms) {
-	local $subdom = $subdoms->{$sdom};
-	local $sname = $sdom;
+	my $subdom = $subdoms->{$sdom};
+	my $sname = $sdom;
 	if ($sname !~ /\.\Q$dom{'dom'}\E$/) {
 		$sname .= ".".$dom{'dom'};
 		}
@@ -898,7 +898,7 @@ foreach my $sdom (keys %$subdoms) {
 		next;
 		}
 	&$indent_print();
-	local %subd = ( 'id', &domain_id(),
+	my %subd = ( 'id', &domain_id(),
 			'dom', $sname,
 			'user', $dom{'user'},
 			'group', $dom{'group'},
@@ -923,10 +923,10 @@ foreach my $sdom (keys %$subdoms) {
 			'nocreationscripts', 1,
 			);
 	foreach my $f (@subdom_features) {
-		local $want = $f eq 'ssl' ? 0 : 1;
+		my $want = $f eq 'ssl' ? 0 : 1;
 		$subd{$f} = $dom{$f} && $want;
 		}
-	local $parentdom = $dom{'parent'} ? &get_domain($dom{'parent'})
+	my $parentdom = $dom{'parent'} ? &get_domain($dom{'parent'})
 					  : \%dom;
 	$subd{'home'} = &server_home_directory(\%subd, $parentdom);
 	&generate_domain_password_hashes(\%subd, 1);
@@ -941,11 +941,11 @@ foreach my $sdom (keys %$subdoms) {
 	if (defined(&set_php_wrappers_writable)) {
 		&set_php_wrappers_writable(\%subd, 1);
 		}
-	local $hdir = &public_html_dir(\%subd);
-	local $cids = $subdom->{'phosting'}->{'content'}->{'cid'} ||
+	my $hdir = &public_html_dir(\%subd);
+	my $cids = $subdom->{'phosting'}->{'content'}->{'cid'} ||
 		      $subdom->{'content'}->{'cid'};
-	local $docroot_files = &extract_plesk_cid($root, $cids, "docroot");
-	local $wwwroot = $subdom->{'phosting'}->{'www-root'};
+	my $docroot_files = &extract_plesk_cid($root, $cids, "docroot");
+	my $wwwroot = $subdom->{'phosting'}->{'www-root'};
 	$wwwroot =~ s/^.*\///;
 	if ($docroot_files) {
 		&$first_print(
@@ -971,8 +971,8 @@ foreach my $sdom (keys %$subdoms) {
 		}
 
 	# Extract sub-domains CGI directory
-	local $cdir = &cgi_bin_dir(\%subd);
-	local $cgi_files = &extract_plesk_cid($root, $cids, "cgi");
+	my $cdir = &cgi_bin_dir(\%subd);
+	my $cgi_files = &extract_plesk_cid($root, $cids, "cgi");
 	if ($cgi_files) {
 		&$first_print(
 			"Copying CGI scripts for sub-domain $subd{'dom'} ..");
@@ -986,7 +986,7 @@ foreach my $sdom (keys %$subdoms) {
 
 	# Re-create users for sub-domains
 	&$first_print("Re-creating sub-domain users ..");
-	local $sysusers = $subdom->{'sysuser'};
+	my $sysusers = $subdom->{'sysuser'};
 	if (!$sysusers) {
 		$sysusers = { };
 		}
@@ -994,12 +994,12 @@ foreach my $sdom (keys %$subdoms) {
 		# Just one user
 		$sysusers = { $sysusers->{'name'} => $sysusers };
 		}
-	local $sucount = 0;
+	my $sucount = 0;
 	foreach my $name (keys %$sysusers) {
-		local $mailuser = $sysusers->{$name};
-		local $uinfo = &create_initial_user(\%dom, 0, 1);
+		my $mailuser = $sysusers->{$name};
+		my $uinfo = &create_initial_user(\%dom, 0, 1);
 		$uinfo->{'user'} = &userdom_name($name, \%dom);
-		local $pinfo = $mailuser->{'properties'}->{'password'} ||
+		my $pinfo = $mailuser->{'properties'}->{'password'} ||
 			       $mailuser->{'password'};
 		if ($pinfo->{'type'} eq 'plain') {
 			$uinfo->{'plainpass'} = $pinfo->{'content'};
@@ -1029,8 +1029,8 @@ return (\%dom, @rvdoms);
 # Extracts a Plesk 9 tar.gz file into a temporary directory
 sub extract_plesk_dir
 {
-local ($file, $version) = @_;
-local $dir;
+my ($file, $version) = @_;
+my $dir;
 if (-d $file) {
 	# Already extracted, so just use the directory
 	$dir = $file;
@@ -1043,12 +1043,12 @@ else {
 		}
 	$dir = &transname();
 	&make_dir($dir, 0700);
-	local $err = &extract_compressed_file($file, $dir);
+	my $err = &extract_compressed_file($file, $dir);
 	if ($err) {
 		return (0, $err);
 		}
 	}
-local ($disc) = glob("$dir/*/.discovered");
+my ($disc) = glob("$dir/*/.discovered");
 if ($disc =~ /\/([^\/]+)\/\.discovered$/) {
 	# Plesk 11 appears to use a sub-directory
 	$dir = "$dir/$1";
@@ -1062,8 +1062,8 @@ return (1, $dir);
 # or undef if not found
 sub extract_plesk_cid
 {
-local ($basedir, $cids, $type) = @_;
-local ($cid) = grep { $_->{'type'} eq $type } @$cids;
+my ($basedir, $cids, $type) = @_;
+my ($cid) = grep { $_->{'type'} eq $type } @$cids;
 return undef if (!$cid || ref($cid) ne 'HASH');
 my $cf = $cid->{'content-file'};
 if (ref($cf) eq 'ARRAY') {
@@ -1075,7 +1075,7 @@ if (!-r $file) {
 	$file = $basedir."/".$cf->{'content'};
 	}
 -r $file || return undef;
-local $dir = $main::extract_plesk_cid_cache{$file};
+my $dir = $main::extract_plesk_cid_cache{$file};
 if (!$dir) {
 	# Need to extract
 	$dir = &transname();
@@ -1092,14 +1092,14 @@ return $cid->{'offset'} ? $dir."/".$cid->{'offset'} : $dir;
 # an error message on failure.
 sub read_plesk_xml
 {
-local ($file) = @_;
+my ($file) = @_;
 eval "use XML::Simple";
 if ($@) {
 	return "XML::Simple Perl module is not installed";
 	}
-local $ref;
+my $ref;
 eval {
-	local $xs = XML::Simple->new();
+	my $xs = XML::Simple->new();
 	$ref = $xs->XMLin($file);
 	};
 $ref || return "Failed to read XML file : $@";
@@ -1114,8 +1114,8 @@ return $ref;
 # Removes extra spacing from a Plesk cert
 sub cleanup_plesk_cert
 {
-local ($data) = @_;
-local @lines = grep { /\S/ } split(/\n/, $data);
+my ($data) = @_;
+my @lines = grep { /\S/ } split(/\n/, $data);
 foreach my $l (@lines) {
 	$l =~ s/^\s+//;
 	}
@@ -1126,19 +1126,19 @@ return join("", map { $_."\n" } @lines);
 # Called after a Plesk migration to save the original data files
 sub save_plesk_xml_files
 {
-local ($d, $xmlfile, $xmldata) = @_;
-local $etcdir = "$d->{'home'}/etc";
+my ($d, $xmlfile, $xmldata) = @_;
+my $etcdir = "$d->{'home'}/etc";
 if (!-d $etcdir) {
 	# Make sure ~/etc exists
  	&make_dir($etcdir, 0750);
 	&set_ownership_permissions($d->{'uid'}, $d->{'gid'}, undef, $etcdir);
 	}
-local $xmldump = "$etcdir/plesk.xml";
+my $xmldump = "$etcdir/plesk.xml";
 &copy_source_dest($xmlfile, $xmldump);
 &set_ownership_permissions($d->{'uid'}, $d->{'gid'}, 0700, $xmldump);
 eval "use Data::Dumper";
 if (!$@) {
-	local $perldump = "$etcdir/plesk.perl";
+	my $perldump = "$etcdir/plesk.perl";
 	&open_tempfile(PERLDUMP, ">$perldump");
 	&print_tempfile(PERLDUMP, Dumper($xmldata));
 	&close_tempfile(PERLDUMP);

--- a/modify-admin.pl
+++ b/modify-admin.pl
@@ -62,7 +62,7 @@ if (!$module_name) {
 # Parse command-line args
 $append = $config{'appendadmin'};
 while(@ARGV > 0) {
-	local $a = shift(@ARGV);
+	my $a = shift(@ARGV);
 	if ($a eq "--domain") {
 		$domain = shift(@ARGV);
 		}

--- a/modify-all-ips.pl
+++ b/modify-all-ips.pl
@@ -41,7 +41,7 @@ if (!$module_name) {
 
 # Parse command-line args
 while(@ARGV > 0) {
-	local $a = shift(@ARGV);
+	my $a = shift(@ARGV);
 	if ($a eq "--old-ip") {
 		$oldip = shift(@ARGV);
 		&check_ipaddress($oldip) || &usage("--old-ip must be followed ".

--- a/modify-custom.pl
+++ b/modify-custom.pl
@@ -37,7 +37,7 @@ if (!$module_name) {
 # Parse command-line args
 $owner = 1;
 while(@ARGV > 0) {
-	local $a = shift(@ARGV);
+	my $a = shift(@ARGV);
 	if ($a eq "--domain") {
 		$domain = shift(@ARGV);
 		}

--- a/modify-database-hosts.pl
+++ b/modify-database-hosts.pl
@@ -44,7 +44,7 @@ if (!$module_name) {
 
 # Parse command-line args
 while(@ARGV > 0) {
-	local $a = shift(@ARGV);
+	my $a = shift(@ARGV);
 	if ($a eq "--domain") {
 		push(@dnames, shift(@ARGV));
 		}
@@ -133,7 +133,7 @@ sub usage
 print "$_[0]\n\n" if ($_[0]);
 print "Modifies the allowed remote database hosts for some domains.\n";
 print "\n";
-local $types = join("|", @database_features);
+my $types = join("|", @database_features);
 print "virtualmin modify-database-hosts --domain name | --all-domains\n";
 print "                                 --type $types\n";
 print "                                [--add-host ip]\n";

--- a/modify-database-pass.pl
+++ b/modify-database-pass.pl
@@ -37,7 +37,7 @@ if (!$module_name) {
 
 # Parse command-line args
 while(@ARGV > 0) {
-	local $a = shift(@ARGV);
+	my $a = shift(@ARGV);
 	if ($a eq "--domain") {
 		$dname = shift(@ARGV);
 		}
@@ -105,7 +105,7 @@ sub usage
 print "$_[0]\n\n" if ($_[0]);
 print "Changes the MySQL or PostgreSQL password for some domain.\n";
 print "\n";
-local $types = join("|", @database_features);
+my $types = join("|", @database_features);
 print "virtualmin modify-database-pass --domain name\n";
 print "                                --type $types\n";
 print "                                --pass new password\n";

--- a/modify-database-user.pl
+++ b/modify-database-user.pl
@@ -37,7 +37,7 @@ if (!$module_name) {
 
 # Parse command-line args
 while(@ARGV > 0) {
-	local $a = shift(@ARGV);
+	my $a = shift(@ARGV);
 	if ($a eq "--domain") {
 		$dname = shift(@ARGV);
 		}
@@ -110,7 +110,7 @@ sub usage
 print "$_[0]\n\n" if ($_[0]);
 print "Changes the MySQL or PostgreSQL login for some domain.\n";
 print "\n";
-local $types = join("|", @database_features);
+my $types = join("|", @database_features);
 print "virtualmin modify-database-user --domain name\n";
 print "                                --type $types\n";
 print "                                --user new-name\n";

--- a/modify-dns.pl
+++ b/modify-dns.pl
@@ -137,7 +137,7 @@ $config{'dns'} || &usage("The BIND DNS server is not enabled for Virtualmin");
 
 # Parse command-line args
 while(@ARGV > 0) {
-	local $a = shift(@ARGV);
+	my $a = shift(@ARGV);
 	if ($a eq "--domain") {
 		push(@dnames, shift(@ARGV));
 		}
@@ -592,19 +592,19 @@ foreach $d (@doms) {
 		}
 
 	# Remove records from the domain
-	local ($recs, $file);
-	local $changed;
+	my ($recs, $file);
+	my $changed;
 	if (@delrecs && !&copy_alias_records($d)) {
 		&$first_print(&text('spf_delrecs', scalar(@delrecs)));
 		if (!$recs) {
 			&pre_records_change($d);
 			($recs, $file) = &get_domain_dns_records_and_file($d);
 			}
-		local @alld;
+		my @alld;
 		foreach my $rn (@delrecs) {
 			my ($name, $type, @values) = @$rn;
 			$name = &expand_dns_record($name, $d);
-			local @d = grep { $_->{'name'} eq $name &&
+			my @d = grep { $_->{'name'} eq $name &&
 					 lc($_->{'type'}) eq lc($type) } @$recs;
 			if (@values) {
 				# Also filter by values

--- a/modify-domain.pl
+++ b/modify-domain.pl
@@ -102,7 +102,7 @@ if (!$module_name) {
 $name = 1;
 $virt = 0;
 while(@ARGV > 0) {
-	local $a = shift(@ARGV);
+	my $a = shift(@ARGV);
 	if ($a eq "--domain") {
 		$domain = lc(shift(@ARGV));
 		}
@@ -854,7 +854,7 @@ for(my $i=0; $i<@doms; $i++) {
 	print "Updating virtual server $d->{'dom'} ..\n\n";
 	foreach $f (@features) {
 		if ($config{$f} && $d->{$f}) {
-			local $mfunc = "modify_$f";
+			my $mfunc = "modify_$f";
 			&try_function($f, $mfunc, $d, $od);
 			}
 		}
@@ -996,7 +996,7 @@ if ($dom->{'template'} ne $old->{'template'}) {
 # Run the after command
 &run_post_actions();
 &set_domain_envs($dom, "MODIFY_DOMAIN", undef, $old);
-local $merr = &made_changes();
+my $merr = &made_changes();
 &$second_print(&text('setup_emade', "<tt>$merr</tt>")) if (defined($merr));
 &reset_domain_envs($dom);
 &virtualmin_api_log(\@OLDARGV, $dom, $dom->{'hashpass'} ? [ "pass" ] : [ ]);

--- a/modify-limits.pl
+++ b/modify-limits.pl
@@ -116,7 +116,7 @@ if (!$module_name) {
 # Parse command-line args
 @all_allow = (@opt_features, "virt", &list_feature_plugins());
 while(@ARGV > 0) {
-	local $a = shift(@ARGV);
+	my $a = shift(@ARGV);
 	if ($a eq "--domain") {
 		$domain = lc(shift(@ARGV));
 		}

--- a/modify-mail.pl
+++ b/modify-mail.pl
@@ -94,7 +94,7 @@ $config{'mail'} || &usage("Email is not enabled for Virtualmin");
 
 # Parse command-line args
 while(@ARGV > 0) {
-	local $a = shift(@ARGV);
+	my $a = shift(@ARGV);
 	if ($a eq "--domain") {
 		push(@dnames, shift(@ARGV));
 		}
@@ -315,7 +315,7 @@ foreach $d (@doms) {
 
 	# Enable or disable autoconfig
 	if (!$d->{'alias'} && &domain_has_website($d) && defined($autoconfig)) {
-		local $err;
+		my $err;
 		if ($autoconfig) {
 			&$first_print("Enabling mail client ".
 				      "auto-configuration for $d->{'dom'} ..");
@@ -337,8 +337,8 @@ foreach $d (@doms) {
 
 	# Enable or disable cloud mail filter
 	if (defined($cloud)) {
-		local $err;
-		local $oldprov = &get_domain_cloud_mail_provider($d);
+		my $err;
+		my $oldprov = &get_domain_cloud_mail_provider($d);
 		if ($prov) {
 			if (!$oldprov ||
 			    $prov->{'name'} ne $oldprov->{'name'} ||

--- a/modify-php-ini.pl
+++ b/modify-php-ini.pl
@@ -49,7 +49,7 @@ if (!$module_name) {
 
 # Parse command-line args
 while(@ARGV > 0) {
-	local $a = shift(@ARGV);
+	my $a = shift(@ARGV);
 	if ($a eq "--domain") {
 		push(@domains, shift(@ARGV));
 		}
@@ -155,16 +155,16 @@ foreach my $d (@doms) {
 	$mod_php = 0;
 	if ($d->{'web'} && &get_apache_mod_php_version()) {
 		&obtain_lock_web($d);
-		local @ports;
+		my @ports;
 		push(@ports, $d->{'web_port'}) if ($d->{'web'});
 		push(@ports, $d->{'web_sslport'}) if ($d->{'ssl'});
 		foreach my $port (@ports) {
-			local ($virt, $vconf, $conf) = &get_apache_virtual(
+			my ($virt, $vconf, $conf) = &get_apache_virtual(
 							$d->{'dom'}, $port);
 			next if (!$virt);
 
 			# Find currently set PHP variables
-			local @phpv = &apache::find_directive(
+			my @phpv = &apache::find_directive(
 					"php_value", $vconf);
 			for(my $i=0; $i<@ini_names; $i++) {
 				my $found = 0;

--- a/modify-plan.pl
+++ b/modify-plan.pl
@@ -35,7 +35,7 @@ if (!$module_name) {
 # Parse command-line args
 $newplan = { };
 while(@ARGV > 0) {
-	local $a = shift(@ARGV);
+	my $a = shift(@ARGV);
 	if ($a eq "--name") {
 		$planname = shift(@ARGV);
 		}
@@ -208,7 +208,7 @@ if ($applyplan) {
 	&set_all_null_print();
 	foreach my $d (&get_domain_by("plan", $plan->{'id'})) {
 		next if ($d->{'parent'});
-		local $oldd = { %$d };
+		my $oldd = { %$d };
 		&set_limits_from_plan($d, $plan);
 		&set_featurelimits_from_plan($d, $plan);
 		&set_capabilities_from_plan($d, $plan);

--- a/modify-proxy.pl
+++ b/modify-proxy.pl
@@ -38,7 +38,7 @@ if (!$module_name) {
 # Parse command-line args
 &require_mail();
 while(@ARGV > 0) {
-	local $a = shift(@ARGV);
+	my $a = shift(@ARGV);
 	if ($a eq "--domain") {
 		$domain = shift(@ARGV);
 		}

--- a/modify-scheduled-backup.pl
+++ b/modify-scheduled-backup.pl
@@ -34,7 +34,7 @@ if (!$module_name) {
 
 # Parse command-line args
 while(@ARGV > 0) {
-	local $a = shift(@ARGV);
+	my $a = shift(@ARGV);
 	if ($a eq "--id") {
 		$schedid = shift(@ARGV);
 		}

--- a/modify-spam.pl
+++ b/modify-spam.pl
@@ -77,7 +77,7 @@ $config{'spam'} || &usage("Spam filtering is not enabled for Virtualmin");
 $spamlevel = undef;
 $auto = { };
 while(@ARGV > 0) {
-	local $a = shift(@ARGV);
+	my $a = shift(@ARGV);
 	if ($a eq "--domain") {
 		push(@dnames, shift(@ARGV));
 		}

--- a/modify-template.pl
+++ b/modify-template.pl
@@ -39,7 +39,7 @@ if (!$module_name) {
 # Parse command-line args
 $owner = 1;
 while(@ARGV > 0) {
-	local $a = shift(@ARGV);
+	my $a = shift(@ARGV);
 	if ($a eq "--name") {
 		$tmplname = shift(@ARGV);
 		}

--- a/modify-user.pl
+++ b/modify-user.pl
@@ -103,7 +103,7 @@ if (!$module_name) {
 
 # Parse command-line args
 while(@ARGV > 0) {
-	local $a = shift(@ARGV);
+	my $a = shift(@ARGV);
 	if ($a eq "--domain") {
 		$domain = shift(@ARGV);
 		}

--- a/modify-users.pl
+++ b/modify-users.pl
@@ -44,7 +44,7 @@ if (!$module_name) {
 # Parse command-line args
 my $argvs = "@ARGV";
 while(@ARGV > 0) {
-	local $a = shift(@ARGV);
+	my $a = shift(@ARGV);
 	if ($a eq "--all-domains") {
 		$all_doms = 1;
 		}

--- a/modify-web.pl
+++ b/modify-web.pl
@@ -166,7 +166,7 @@ if (!$module_name) {
 # Parse command-line args
 $supports_ruby = defined(&supported_ruby_modes);
 while(@ARGV > 0) {
-	local $a = shift(@ARGV);
+	my $a = shift(@ARGV);
 	if ($a eq "--domain") {
 		push(@dnames, shift(@ARGV));
 		}
@@ -617,7 +617,7 @@ foreach $d (@doms) {
 			$rubymode eq "none" ? undef : $rubymode);
 		}
 
-	local $oldd = { %$d };
+	my $oldd = { %$d };
 	if (!$d->{'alias'} && defined($content)) {
 		# Just create index.html page with content
 		&$first_print($text{'setup_contenting'});
@@ -628,7 +628,7 @@ foreach $d (@doms) {
 
 	if (defined($webmail) && &domain_has_website($d)) {
 		# Enable or disable webmail redirects
-		local @oldwm = &get_webmail_redirect_directives($d);
+		my @oldwm = &get_webmail_redirect_directives($d);
 		if ($webmail && !@oldwm) {
 			&$first_print("Adding webmail and admin redirects ..");
 			&add_webmail_redirect_directives($d, undef, 1);
@@ -650,7 +650,7 @@ foreach $d (@doms) {
 
 	if (defined($matchall) && &domain_has_website($d)) {
 		# Enable or disable *.domain.com serveralias
-		local $oldmatchall = &get_domain_web_star($d);
+		my $oldmatchall = &get_domain_web_star($d);
 		if ($matchall && !$oldmatchall) {
 			&$first_print(
 			    "Adding all sub-domains to Apache config ..");
@@ -673,7 +673,7 @@ foreach $d (@doms) {
 
 	if (defined($includes) && &domain_has_website($d)) {
 		# Enable or disable server-side includes
-		local ($ok, $oldincludes) = &get_domain_web_ssi($d);
+		my ($ok, $oldincludes) = &get_domain_web_ssi($d);
 		if ($includes && $includes ne $oldincludes) {
 			&$first_print("Enabling server-side includes ..");
 			$err = &save_domain_web_ssi($d, $includes);

--- a/move-domain.pl
+++ b/move-domain.pl
@@ -46,7 +46,7 @@ if (!$module_name) {
 
 # Parse command-line args
 while(@ARGV > 0) {
-	local $a = shift(@ARGV);
+	my $a = shift(@ARGV);
 	if ($a eq "--domain") {
 		$domain = lc(shift(@ARGV));
 		}

--- a/newkey.cgi
+++ b/newkey.cgi
@@ -239,7 +239,7 @@ foreach $od (&get_domain_by("ssl_same", $d->{'id'})) {
 
 # Run the after command
 &set_domain_envs($d, "SSL_DOMAIN", undef, $oldd);
-local $merr = &made_changes();
+my $merr = &made_changes();
 &$second_print(&text('setup_emade', "<tt>$merr</tt>")) if (defined($merr));
 &reset_domain_envs($d);
 

--- a/notify-domains.pl
+++ b/notify-domains.pl
@@ -54,7 +54,7 @@ if (!$module_name) {
 
 # Parse command-line args
 while(@ARGV > 0) {
-	local $a = shift(@ARGV);
+	my $a = shift(@ARGV);
 	if ($a eq "--domain") {
 		push(@domains, shift(@ARGV));
 		}

--- a/php-lib.pl
+++ b/php-lib.pl
@@ -707,10 +707,10 @@ foreach my $ad (&get_domain_by("alias", $d->{'id'})) {
 # Set the IPCCommTimeout directive to follow the given PHP max execution time
 sub set_fcgid_max_execution_time
 {
-local ($d, $max, $mode, $port) = @_;
+my ($d, $max, $mode, $port) = @_;
 $mode ||= &get_domain_php_mode($d);
 return 0 if ($mode ne "fcgid");
-local $p = &domain_has_website($d);
+my $p = &domain_has_website($d);
 if ($p && $p ne 'web') {
 	return &plugin_call($p, "feature_set_fcgid_max_execution_time",
 			    $d, $max, $mode, $port);
@@ -718,20 +718,20 @@ if ($p && $p ne 'web') {
 elsif (!$p) {
 	return "Virtual server does not have a website";
 	}
-local @ports = ( $d->{'web_port'},
+my @ports = ( $d->{'web_port'},
 		 $d->{'ssl'} ? ( $d->{'web_sslport'} ) : ( ) );
 @ports = ( $port ) if ($port);	# Overridden to just do SSL or non-SSL
-local $conf = &apache::get_config();
-local $pfound = 0;
-local $changed = 0;
+my $conf = &apache::get_config();
+my $pfound = 0;
+my $changed = 0;
 foreach my $p (@ports) {
-        local ($virt, $vconf) = &get_apache_virtual($d->{'dom'}, $p);
+        my ($virt, $vconf) = &get_apache_virtual($d->{'dom'}, $p);
         next if (!$vconf);
 	$pfound++;
-	local @newdir = &apache::find_directive("FcgidIOTimeout", $vconf);
-	local $dirname = @newdir ? "FcgidIOTimeout" : "IPCCommTimeout";
-	local $oldvalue = &apache::find_directive($dirname, $vconf);
-	local $want = $max ? $max + 1 : $max_php_fcgid_timeout;
+	my @newdir = &apache::find_directive("FcgidIOTimeout", $vconf);
+	my $dirname = @newdir ? "FcgidIOTimeout" : "IPCCommTimeout";
+	my $oldvalue = &apache::find_directive($dirname, $vconf);
+	my $want = $max ? $max + 1 : $max_php_fcgid_timeout;
 	if ($oldvalue ne $want) {
 		&apache::save_directive($dirname, [ $want ],
 					$vconf, $conf);
@@ -749,15 +749,15 @@ if ($changed) {
 # Returns the current max FCGId execution time, or undef for unlimited
 sub get_fcgid_max_execution_time
 {
-local $p = &domain_has_website($d);
+my $p = &domain_has_website($d);
 if ($p && $p ne 'web') {
 	return &plugin_call($p, "feature_get_fcgid_max_execution_time", $d);
 	}
 elsif (!$p) {
 	return "Virtual server does not have a website";
 	}
-local ($virt, $vconf) = &get_apache_virtual($d->{'dom'}, $d->{'web_port'});
-local $v = &apache::find_directive("IPCCommTimeout", $vconf);
+my ($virt, $vconf) = &get_apache_virtual($d->{'dom'}, $d->{'web_port'});
+my $v = &apache::find_directive("IPCCommTimeout", $vconf);
 $v ||= &apache::find_directive("FcgidIOTimeout", $vconf);
 return $v == 9999 ? undef : $v ? $v-1 : 40;
 }
@@ -773,8 +773,8 @@ my @errs;
 foreach my $ini (&list_domain_php_inis($d)) {
 	eval {
 		local $main::error_must_die = 1;
-		local $f = $ini->[1];
-		local $conf = &phpini::get_config($f);
+		my $f = $ini->[1];
+		my $conf = &phpini::get_config($f);
 		&phpini::save_directive($conf, "max_execution_time", $max);
 		&flush_file_lines($f);
 		};
@@ -792,12 +792,12 @@ return @errs ? join(" ", @errs) : undef;
 # Returns the max execution time from a php.ini file
 sub get_php_max_execution_time
 {
-local ($d, $max) = @_;
+my ($d, $max) = @_;
 &foreign_require("phpini");
 foreach my $ini (&list_domain_php_inis($d)) {
-	local $f = $ini->[1];
-	local $conf = &phpini::get_config($f);
-	local $max = &phpini::find_value("max_execution_time", $conf);
+	my $f = $ini->[1];
+	my $conf = &phpini::get_config($f);
+	my $max = &phpini::find_value("max_execution_time", $conf);
 	return $max if ($max ne '');
 	}
 return undef;
@@ -807,7 +807,7 @@ return undef;
 # Returns 1 if this PHP mode needs CGI wrappers
 sub need_php_wrappers
 {
-local ($d, $mode) = @_;
+my ($d, $mode) = @_;
 $mode ||= &get_domain_php_mode($d);
 return $mode ne "mod_php" && $mode ne "fpm" && $mode ne "none";
 }
@@ -816,45 +816,45 @@ return $mode ne "mod_php" && $mode ne "fpm" && $mode ne "none";
 # Creates all phpN.cgi wrappers for some domain
 sub create_php_wrappers
 {
-local ($d, $mode) = @_;
+my ($d, $mode) = @_;
 $mode ||= &get_domain_php_mode($d);
-local $dest = $mode eq "fcgid" ? "$d->{'home'}/fcgi-bin" : &cgi_bin_dir($_[0]);
-local $tmpl = &get_template($d->{'template'});
+my $dest = $mode eq "fcgid" ? "$d->{'home'}/fcgi-bin" : &cgi_bin_dir($_[0]);
+my $tmpl = &get_template($d->{'template'});
 
 if (!-d $dest) {
 	# Need to create fcgi-bin
 	&make_dir_as_domain_user($d, $dest, 0755);
 	}
 
-local $suffix = $mode eq "fcgid" ? "fcgi" : "cgi";
-local $dirvar = $mode eq "fcgid" ? "PWD" : "DOCUMENT_ROOT";
+my $suffix = $mode eq "fcgid" ? "fcgi" : "cgi";
+my $dirvar = $mode eq "fcgid" ? "PWD" : "DOCUMENT_ROOT";
 
 # Make wrappers mutable
 &set_php_wrappers_writable($d, 1);
 
 # For each version of PHP, create a wrapper
-local $pub = &public_html_dir($d);
-local $children = &get_domain_php_children($d);
+my $pub = &public_html_dir($d);
+my $children = &get_domain_php_children($d);
 foreach my $v (&list_available_php_versions($d, $mode)) {
 	next if (!$v->[1]);	# No executable available?!
 	&open_tempfile_as_domain_user($d, PHP, ">$dest/php$v->[0].$suffix");
-	local $t = "php".$v->[0].$suffix;
+	my $t = "php".$v->[0].$suffix;
 	if ($tmpl->{$t} && $tmpl->{$t} ne 'none') {
 		# Use custom script from template
-		local $s = &substitute_domain_template($tmpl->{$t}, $d);
+		my $s = &substitute_domain_template($tmpl->{$t}, $d);
 		$s =~ s/\t/\n/g;
 		$s .= "\n" if ($s !~ /\n$/);
 		&print_tempfile(PHP, $s);
 		}
 	else {
 		# Automatically generate
-		local $shell = -r "/bin/bash" ? "/bin/bash" : "/bin/sh";
-		local $common = "#!$shell\n".
+		my $shell = -r "/bin/bash" ? "/bin/bash" : "/bin/sh";
+		my $common = "#!$shell\n".
 				"PHPRC=\$$dirvar/../etc/php$v->[0]\n".
 				"export PHPRC\n".
 				"umask 022\n";
 		if ($mode eq "fcgid") {
-			local $defchildren = $tmpl->{'web_phpchildren'};
+			my $defchildren = $tmpl->{'web_phpchildren'};
 			$defchildren = undef if ($defchildren eq "none");
 			if ($defchildren) {
 				$common .= "PHP_FCGI_CHILDREN=$defchildren\n";
@@ -901,7 +901,7 @@ foreach my $v (&list_available_php_versions($d, $mode)) {
 
 # Re-apply resource limits
 if (defined(&supports_resource_limits) && &supports_resource_limits()) {
-	local $pd = $d->{'parent'} ? &get_domain($d->{'parent'}) : $d;
+	my $pd = $d->{'parent'} ? &get_domain($d->{'parent'}) : $d;
 	&set_php_wrapper_ulimits($d, &get_domain_resource_limits($pd));
 	}
 
@@ -913,7 +913,7 @@ if (defined(&supports_resource_limits) && &supports_resource_limits()) {
 # If possible, make PHP wrapper scripts mutable or immutable
 sub set_php_wrappers_writable
 {
-local ($d, $writable, $subs) = @_;
+my ($d, $writable, $subs) = @_;
 if (&has_command("chattr")) {
 	foreach my $dir ("$d->{'home'}/fcgi-bin", &cgi_bin_dir($d)) {
 		foreach my $f (glob("$dir/php?.*cgi")) {
@@ -939,10 +939,10 @@ if (&has_command("chattr")) {
 # Add, update or remove ulimit lines to set RAM and process restrictions
 sub set_php_wrapper_ulimits
 {
-local ($d, $rv) = @_;
+my ($d, $rv) = @_;
 foreach my $dir ("$d->{'home'}/fcgi-bin", &cgi_bin_dir($d)) {
 	foreach my $f (glob("$dir/php?.*cgi")) {
-		local $lref = &read_file_lines_as_domain_user($d, $f);
+		my $lref = &read_file_lines_as_domain_user($d, $f);
 		foreach my $u ([ 'v', int($rv->{'mem'}/1024) ],
 			       [ 'u', $rv->{'procs'} ],
 			       [ 't', $rv->{'time'}*60 ]) {
@@ -954,7 +954,7 @@ foreach my $dir ("$d->{'home'}/fcgi-bin", &cgi_bin_dir($d)) {
 				}
 
 			# Find current line
-			local $lnum;
+			my $lnum;
 			for(my $i=0; $i<@$lref; $i++) {
 				if ($lref->[$i] =~ /^ulimit\s+\-(\S)\s+(\d+)/ &&
 				    $1 eq $u->[0]) {
@@ -977,7 +977,7 @@ foreach my $dir ("$d->{'home'}/fcgi-bin", &cgi_bin_dir($d)) {
 			}
 		# If using process limits, we can't exec PHP as there will
 		# be no chance for the limit to be applied :(
-		local $ll = scalar(@$lref) - 1;
+		my $ll = scalar(@$lref) - 1;
 		if ($lref->[$ll] =~ /php/) {
 			if ($rv->{'procs'} && $lref->[$ll] =~ /^exec\s+(.*)/) {
 				# Remove exec
@@ -1115,7 +1115,7 @@ foreach my $v (@all_possible_php_versions) {
 foreach my $path (split(/\t+/, $config{'php_paths'})) {
 	next if (!-x $path);
 	&clean_environment();
-	local $out = &backquote_command(quotemeta($path).
+	my $out = &backquote_command(quotemeta($path).
 		" -v 2>&1 </dev/null");
 	&reset_environment();
 	if ($out =~ /PHP\s+(\d+.\d+)/ && !$vercmds{$1}) {
@@ -1123,13 +1123,13 @@ foreach my $path (split(/\t+/, $config{'php_paths'})) {
 		}
 	}
 
-local $php = &has_command("php-cgi");
+my $php = &has_command("php-cgi");
 if ($php && scalar(keys %vercmds) != scalar(@all_possible_php_versions)) {
 	# What version is the php command? If it is a version we don't have
 	# a command for yet, use it.
 	if (!$php_command_version_cache) {
 		&clean_environment();
-		local $out = &backquote_command(quotemeta($php).
+		my $out = &backquote_command(quotemeta($php).
 			" -v 2>&1 </dev/null");
 		&reset_environment();
 		if ($out =~ /PHP\s+(\d+\.\d+)/) {
@@ -1240,7 +1240,7 @@ return $php_command_for_version_cache{$v,$cgimode};
 # version number, like 5.2.7
 sub get_php_version
 {
-local ($cmd, $d) = @_;
+my ($cmd, $d) = @_;
 if (exists($get_php_version_cache{$cmd})) {
 	return $get_php_version_cache{$cmd};
 	}
@@ -1248,7 +1248,7 @@ if ($cmd !~ /^\//) {
 	# A number was given .. find the matching command
 	my $shortcmd = $cmd;
 	$shortcmd =~ s/^(\d+\.\d+)\..*/$1/;  # Reduce version to 5.x
-	local ($phpn) = grep { $_->[0] == $cmd ||
+	my ($phpn) = grep { $_->[0] == $cmd ||
 			       $_->[0] == $shortcmd }
 			     &list_available_php_versions($d);
 	if (!$phpn && $cmd =~ /^5\./) {
@@ -1269,7 +1269,7 @@ if ($cmd !~ /^\//) {
 	$cmd = $phpn->[1] || &has_command("php$cmd") || &has_command("php");
 	}
 &clean_environment();
-local $out = &backquote_command(quotemeta($cmd)." -v 2>&1 </dev/null");
+my $out = &backquote_command(quotemeta($cmd)." -v 2>&1 </dev/null");
 &reset_environment();
 if ($out =~ /PHP\s+([0-9\.]+)/) {
 	$get_php_version_cache{$cmd} = $1;
@@ -1284,7 +1284,7 @@ return undef;
 sub can_domain_php_directories
 {
 my ($d, $mode) = @_;
-local $p = &domain_has_website($d);
+my $p = &domain_has_website($d);
 if ($p && $p ne 'web' &&
     &plugin_defined($p, "feature_can_domain_php_directories")) {
 	return &plugin_call($p, "feature_can_domain_php_directories",
@@ -1580,16 +1580,16 @@ return 0;
 # commands.
 sub list_domain_php_inis
 {
-local ($d, $mode) = @_;
-local @inis;
+my ($d, $mode) = @_;
+my @inis;
 foreach my $v (&list_available_php_versions($d, $mode)) {
-	local $ifile = "$d->{'home'}/etc/php$v->[0]/php.ini";
+	my $ifile = "$d->{'home'}/etc/php$v->[0]/php.ini";
 	if (-r $ifile) {
 		push(@inis, [ $v->[0], $ifile, $v->[1] ]);
 		}
 	}
 if (!@inis) {
-	local $ifile = "$d->{'home'}/etc/php.ini";
+	my $ifile = "$d->{'home'}/etc/php.ini";
 	if (-r $ifile) {
 		push(@inis, [ undef, $ifile, undef ]);
 		}
@@ -1602,8 +1602,8 @@ return @inis;
 # the home directory only
 sub find_domain_php_ini_files
 {
-local ($d) = @_;
-local @inis;
+my ($d) = @_;
+my @inis;
 foreach my $f (glob("$d->{'home'}/etc/php*/php.ini")) {
 	if ($f =~ /php([0-9\.]+)\/php.ini$/) {
 		push(@inis, [ $1, $f ]);
@@ -1616,9 +1616,9 @@ return @inis;
 # Returns the php.ini file path for this domain and a PHP version
 sub get_domain_php_ini
 {
-local ($d, $phpver, $dir) = @_;
-local @inis = &list_domain_php_inis($d);
-local ($ini) = grep { $_->[0] == $phpver } @inis;
+my ($d, $phpver, $dir) = @_;
+my @inis = &list_domain_php_inis($d);
+my ($ini) = grep { $_->[0] == $phpver } @inis;
 if (!$ini) {
 	($ini) = grep { !$_->[0]} @inis;
 	}
@@ -1639,10 +1639,10 @@ else {
 # Returns the full path to the global PHP config file
 sub get_global_php_ini
 {
-local ($ver, $mode) = @_;
-local $nodotv = $ver;
+my ($ver, $mode) = @_;
+my $nodotv = $ver;
 $nodotv =~ s/\.//g;
-local $shortv = $ver;
+my $shortv = $ver;
 $shortv =~ s/^(\d+\.\d+)\..*$/$1/g;
 foreach my $i ("/opt/rh/php$nodotv/root/etc/php.ini",
 	       "/opt/rh/php$nodotv/lib/php.ini",
@@ -1681,19 +1681,19 @@ return undef;
 # if not set.
 sub get_php_mysql_socket
 {
-local ($d) = @_;
+my ($d) = @_;
 return 'none' if (!&foreign_check("phpini"));
-local $mode = &get_domain_php_mode($d);
-local @vers = &list_available_php_versions($d, $mode);
+my $mode = &get_domain_php_mode($d);
+my @vers = &list_available_php_versions($d, $mode);
 return 'none' if (!@vers);
-local $tmpl = &get_template($d->{'template'});
-local $inifile = $tmpl->{'web_php_ini_'.$vers[0]->[0]};
+my $tmpl = &get_template($d->{'template'});
+my $inifile = $tmpl->{'web_php_ini_'.$vers[0]->[0]};
 if (!$inifile || $inifile eq "none" || !-r $inifile) {
 	$inifile = &get_global_php_ini($vers[0]->[0], $mode);
 	}
 &foreign_require("phpini");
-local $gconf = &phpini::get_config($inifile);
-local $sock = &phpini::find_value("mysql.default_socket", $gconf);
+my $gconf = &phpini::get_config($inifile);
+my $sock = &phpini::find_value("mysql.default_socket", $gconf);
 return $sock;
 }
 
@@ -1767,8 +1767,8 @@ my ($d, $modetype) = @_;
 # Update all of a domain's PHP wrapper scripts with the new number of children
 sub save_domain_php_children
 {
-local ($d, $children, $nowritable) = @_;
-local $p = &domain_has_website($d);
+my ($d, $children, $nowritable) = @_;
+my $p = &domain_has_website($d);
 if ($p && $p ne 'web') {
 	return &plugin_call($p, "feature_save_web_php_children", $d,
 			    $children, $nowritable);
@@ -1779,15 +1779,15 @@ elsif (!$p) {
 my $mode = &get_domain_php_mode($d);
 if ($mode eq "fcgid") {
 	# Update in FCGI wrapper scripts
-	local $count = 0;
+	my $count = 0;
 	&set_php_wrappers_writable($d, 1) if (!$nowritable);
 	foreach my $ver (&list_available_php_versions($d, "fcgi")) {
-		local $wrapper = "$d->{'home'}/fcgi-bin/php$ver->[0].fcgi";
+		my $wrapper = "$d->{'home'}/fcgi-bin/php$ver->[0].fcgi";
 		next if (!-r $wrapper);
 
 		# Find the current line
-		local $lref = &read_file_lines_as_domain_user($d, $wrapper);
-		local $idx;
+		my $lref = &read_file_lines_as_domain_user($d, $wrapper);
+		my $idx;
 		for(my $i=0; $i<@$lref; $i++) {
 			if ($lref->[$i] =~ /PHP_FCGI_CHILDREN\s*=\s*\d+/) {
 				$idx = $i;
@@ -1803,7 +1803,7 @@ if ($mode eq "fcgid") {
 			}
 		elsif ($children && !defined($idx)) {
 			# Add before export line
-			local $found = 0;
+			my $found = 0;
 			for(my $e=0; $e<@$lref; $e++) {
 				if ($lref->[$e] =~ /^export\s+PHP_FCGI_CHILDREN/) {
 					splice(@$lref, $e, 0,
@@ -1869,11 +1869,11 @@ else {
 # Returns an error message if the domain's PHP config is invalid
 sub check_php_configuration
 {
-local ($d, $ver, $cmd) = @_;
+my ($d, $ver, $cmd) = @_;
 $cmd ||= &has_command("php".$ver) || &has_command("php");
-local $mode = &get_domain_php_mode($d);
+my $mode = &get_domain_php_mode($d);
 if ($mode eq "mod_php") {
-	local $gini = &get_global_php_ini($ver, $mode);
+	my $gini = &get_global_php_ini($ver, $mode);
 	if ($gini) {
 		$gini =~ s/\/php.ini$//;
 		$ENV{'PHPRC'} = $gini;
@@ -1883,8 +1883,8 @@ else {
 	$ENV{'PHPRC'} = &get_domain_php_ini($d, $ver, 1);
 	}
 &clean_environment();
-local $out = &backquote_command(quotemeta($cmd)." -d error_log= -m 2>&1");
-local @errs;
+my $out = &backquote_command(quotemeta($cmd)." -d error_log= -m 2>&1");
+my @errs;
 foreach my $l (split(/\r?\n/, $out)) {
 	$l = &html_tags_to_text($l);
 	if ($l =~ /(PHP\s+)?Fatal\s+error:\s*(.*)/) {
@@ -1902,15 +1902,15 @@ return join(", ", @errs);
 # Returns a list of PHP modules available for some domain. Uses caching.
 sub list_php_modules
 {
-local ($d, $ver, $cmd) = @_;
-local $mode = &get_domain_php_mode($d);
+my ($d, $ver, $cmd) = @_;
+my $mode = &get_domain_php_mode($d);
 if (!defined($main::php_modules{$ver,$d->{'id'}})) {
 	$cmd ||= &has_command("php".$ver) || &has_command("php");
 	$main::php_modules{$ver} = [ ];
 	if ($mode eq "mod_php" || $mode eq "fpm") {
 		# Use global PHP config, since with mod_php we can't do
 		# per-domain configurations
-		local $gini = &get_global_php_ini($ver, $mode);
+		my $gini = &get_global_php_ini($ver, $mode);
 		if ($gini) {
 			$gini =~ s/\/php.ini$//;
 			$ENV{'PHPRC'} = $gini;
@@ -1945,8 +1945,8 @@ return @rv;
 # number of changes made.
 sub fix_php_ini_files
 {
-local ($d, $fixes) = @_;
-local ($mode, $rv);
+my ($d, $fixes) = @_;
+my ($mode, $rv);
 if (defined(&get_domain_php_mode) &&
     ($mode = &get_domain_php_mode($d)) &&
     $mode ne "mod_php" &&
@@ -1957,10 +1957,10 @@ if (defined(&get_domain_php_mode) &&
 	foreach my $i (&list_domain_php_inis($d)) {
 		&unflush_file_lines($i->[1]);	# In case cached
 		undef($phpini::get_config_cache{$i->[1]});
-		local $pconf = &phpini::get_config($i->[1]);
+		my $pconf = &phpini::get_config($i->[1]);
 		foreach my $f (@$fixes) {
-			local $ov = &phpini::find_value($f->[0], $pconf);
-			local $nv = $ov;
+			my $ov = &phpini::find_value($f->[0], $pconf);
+			my $nv = $ov;
 			if (!defined($f->[1])) {
 				# Always change
 				$nv = $f->[2];
@@ -2043,12 +2043,12 @@ return $rv;
 # If the extension_dir in a domain's php.ini file is invalid, try to fix it
 sub fix_php_extension_dir
 {
-local ($d) = @_;
+my ($d) = @_;
 return if (!&foreign_check("phpini"));
 &foreign_require("phpini");
 foreach my $i (&list_domain_php_inis($d)) {
-	local $pconf = &phpini::get_config($i->[1]);
-	local $ed = &phpini::find_value("extension_dir", $pconf);
+	my $pconf = &phpini::get_config($i->[1]);
+	my $ed = &phpini::find_value("extension_dir", $pconf);
 	if ($ed && !-d $ed) {
 		# Doesn't exist .. maybe can fix
 		my $newed = $ed;
@@ -2071,12 +2071,12 @@ foreach my $i (&list_domain_php_inis($d)) {
 # Get the PHP version used by the domain by default (for public_html)
 sub get_domain_php_version
 {
-local ($d, $mode) = @_;
+my ($d, $mode) = @_;
 $mode ||= &get_domain_php_mode($d);
 if ($mode ne "mod_php") {
-	local @dirs = &list_domain_php_directories($d);
-	local $phd = &public_html_dir($d);
-        local ($hdir) = grep { $_->{'dir'} eq $phd } @dirs;
+	my @dirs = &list_domain_php_directories($d);
+	my $phd = &public_html_dir($d);
+        my ($hdir) = grep { $_->{'dir'} eq $phd } @dirs;
         $hdir ||= $dirs[0];
 	return $hdir ? $hdir->{'version'} : undef;
 	}
@@ -2113,10 +2113,10 @@ return $phpver;
 # public_html directory
 sub create_php_ini_link
 {
-local ($d, $mode) = @_;
-local $ver = &get_domain_php_version($d, $mode);
+my ($d, $mode) = @_;
+my $ver = &get_domain_php_version($d, $mode);
 if ($ver) {
-	local $etc = "$d->{'home'}/etc";
+	my $etc = "$d->{'home'}/etc";
 	&unlink_file_as_domain_user($d, "$etc/php.ini");
 	&symlink_file_as_domain_user($d, "php".$ver."/php.ini", "$etc/php.ini");
 	}
@@ -2425,7 +2425,7 @@ return $rv;
 sub get_domain_php_fpm_port
 {
 my ($d) = @_;
-local $p = &domain_has_website($d);
+my $p = &domain_has_website($d);
 if ($p ne 'web') {
 	if (!&plugin_defined($p, "feature_get_domain_php_fpm_port")) {
 		return (-1, "Not supported by plugin $p");
@@ -2640,7 +2640,7 @@ else {
 	my $defmaxspare = &get_php_max_spare_servers($defchildren);
 	my $defminspare = &get_php_min_spare_servers($defchildren);
 	my $defstartservers = &get_php_start_servers($defchildren);
-	local $tmp = &create_server_tmp($d);
+	my $tmp = &create_server_tmp($d);
 	my $lref = &read_file_lines($file);
 	@$lref = ( "[$d->{'id'}]",
 		   "user = ".$d->{'user'},

--- a/plans-lib.pl
+++ b/plans-lib.pl
@@ -4,17 +4,17 @@
 # Returns a list of all plans, each of which is a hash ref
 sub list_plans
 {
-local ($noconvert) = @_;
+my ($noconvert) = @_;
 if (!-d $plans_dir && !$noconvert) {
 	# Somehow hasn't been run yet
 	&convert_plans();
 	}
 if (!@list_plans_cache) {
-	local @rv;
+	my @rv;
 	opendir(DIR, $plans_dir);
 	foreach my $id (readdir(DIR)) {
 		if ($id ne "." && $id ne "..") {
-			local $plan = &get_plan($id);
+			my $plan = &get_plan($id);
 			push(@rv, $plan) if ($plan && !$plan->{'deleted'});
 			}
 		}
@@ -28,7 +28,7 @@ return @list_plans_cache;
 # Returns a list of plans the current user can edit
 sub list_editable_plans
 {
-local $canmode = &can_edit_plans();
+my $canmode = &can_edit_plans();
 if ($canmode == 0) {
 	return ( );
 	}
@@ -44,8 +44,8 @@ else {
 # Returns a list of plans the current user can use
 sub list_available_plans
 {
-local $canmode = &can_edit_plans();
-local @plans = &list_plans();
+my $canmode = &can_edit_plans();
+my @plans = &list_plans();
 if (&master_admin()) {
 	# Master admin can use all
 	return @plans;
@@ -68,7 +68,7 @@ else {
 # Returns 1 if the current user can use a plan
 sub can_use_plan
 {
-local ($plan) = @_;
+my ($plan) = @_;
 if (&master_admin()) {
 	# Masters can use all plans
 	return 1;
@@ -90,9 +90,9 @@ else {
 # Returns the default plan for the current user - may be undef if none is set
 sub get_default_plan
 {
-local ($allowundef) = @_;
-local @plans = sort { $a->{'id'} <=> $b->{'id'} } &list_available_plans();
-local $defplan;
+my ($allowundef) = @_;
+my @plans = sort { $a->{'id'} <=> $b->{'id'} } &list_available_plans();
+my $defplan;
 if (&reseller_admin()) {
 	($defplan) = grep { $_->{'id'} eq $access{'defplan'} } @plans;
 	}
@@ -110,7 +110,7 @@ return $defplan;
 # sets a reseller-level option .. otherwise, the global default iset
 sub set_default_plan
 {
-local ($plan) = @_;
+my ($plan) = @_;
 if (&reseller_admin()) {
 	$access{'defplan'} = $plan ? $plan->{'id'} : undef;
 	&save_module_acl(\%access);
@@ -125,9 +125,9 @@ else {
 # Returns the hash ref for the plan with some ID
 sub get_plan
 {
-local ($id) = @_;
+my ($id) = @_;
 return undef if ($id !~ /^\d+$/);
-local %plan;
+my %plan;
 &read_file_cached("$plans_dir/$id", \%plan) || return undef;
 $plan{'id'} = $id;
 $plan{'file'} = "$plans_dir/$id";
@@ -138,8 +138,8 @@ return \%plan;
 # Updates or creates a plan on disk
 sub save_plan
 {
-local ($plan) = @_;
-local $newplan;
+my ($plan) = @_;
+my $newplan;
 if ($plan->{'id'} eq '') {
 	$plan->{'id'} = &domain_id();
 	$newplan = 1;
@@ -160,9 +160,9 @@ if (@list_plans_cache && $newplan) {
 # Deletes an existing plan.
 sub delete_plan
 {
-local ($plan) = @_;
+my ($plan) = @_;
 &lock_file($plan->{'file'});
-local @users = &get_domain_by("plan", $plan->{'id'});
+my @users = &get_domain_by("plan", $plan->{'id'});
 if (@users) {
 	# Just flag as deleted
 	$plan->{'deleted'} = 1;
@@ -187,10 +187,10 @@ sub convert_plans
 local $main::no_auto_plan = 1;	# So plans don't get set by complete_domain
 
 # For each template, create a plan
-local %planmap;
+my %planmap;
 foreach my $ltmpl (&list_templates()) {
-	local $tmpl = &get_template($ltmpl->{'id'});
-	local $got = &get_plan($tmpl->{'id'});
+	my $tmpl = &get_template($ltmpl->{'id'});
+	my $got = &get_plan($tmpl->{'id'});
 	next if ($got);				# Already converted
 	next if ($tmpl->{'id'} eq '1');		# Sub-servers don't have plans!
 
@@ -219,7 +219,7 @@ foreach my $ltmpl (&list_templates()) {
 # For each top-level domain, map its template to the created plan
 foreach my $d (grep { !$_->{'parent'} } &list_domains()) {
 	if ($d->{'plan'} eq '' || !&get_plan($d->{'plan'})) {
-		local $plan = $planmap{$d->{'template'}};
+		my $plan = $planmap{$d->{'template'}};
 		$d->{'plan'} = $plan ? $plan->{'id'} : '0';
 		&save_domain($d);
 		}
@@ -260,7 +260,7 @@ else {
 # Set initial owner limits on a domain from the given plan
 sub set_limits_from_plan
 {
-local ($d, $plan) = @_;
+my ($d, $plan) = @_;
 $d->{'quota'} = $plan->{'quota'};
 $d->{'uquota'} = $plan->{'uquota'};
 $d->{'bw_limit'} = $plan->{'bwlimit'};
@@ -287,8 +287,8 @@ $d->{'migrate'} = $plan->{'migrate'};
 # Set initial limits for a reseller based on relevant ones from a plan
 sub set_reseller_limits_from_plan
 {
-local ($resel, $plan) = @_;
-local %lmap = ( 'domslimit' => 'max_doms',
+my ($resel, $plan) = @_;
+my %lmap = ( 'domslimit' => 'max_doms',
 		'aliasdomslimit' => 'max_aliasdoms',
 		'realdomslimit' => 'max_realdoms',
 		'quota' => 'max_quota',
@@ -312,10 +312,10 @@ foreach my $m (keys %lmap) {
 # features or limits defined in the plan.
 sub set_featurelimits_from_plan
 {
-local ($d, $plan) = @_;
+my ($d, $plan) = @_;
 if ($plan->{'featurelimits'}) {
 	# From template
-	local %flimits = map { $_, 1 } split(/\s+/, $plan->{'featurelimits'});
+	my %flimits = map { $_, 1 } split(/\s+/, $plan->{'featurelimits'});
 	foreach my $f (@features, 'virt', &list_feature_plugins()) {
 		$d->{'limit_'.$f} = int($flimits{$f});
 		}
@@ -332,8 +332,8 @@ else {
 # Set limits on allowed features for a reseller from a plan
 sub set_reseller_featurelimits_from_plan
 {
-local ($resel, $plan) = @_;
-local %flimits = map { $_, 1 } split(/\s+/, $plan->{'featurelimits'});
+my ($resel, $plan) = @_;
+my %flimits = map { $_, 1 } split(/\s+/, $plan->{'featurelimits'});
 foreach my $f (@features, &list_feature_plugins()) {
 	$resel->{'acl'}->{'feature_'.$f} = int($flimits{$f});
 	}
@@ -344,9 +344,9 @@ foreach my $f (@features, &list_feature_plugins()) {
 # the given plan
 sub set_capabilities_from_plan
 {
-local ($d, $plan) = @_;
+my ($d, $plan) = @_;
 if ($plan->{'capabilities'}) {
-	local %caps = map { $_, 1 } split(/\s+/, $plan->{'capabilities'});
+	my %caps = map { $_, 1 } split(/\s+/, $plan->{'capabilities'});
 	foreach my $ed (@edit_limits) {
 		$d->{'edit_'.$ed} = $caps{$ed} ? 1 : 0;
 		}

--- a/postgrey-lib.pl
+++ b/postgrey-lib.pl
@@ -100,8 +100,8 @@ return 0;
 sub install_postgrey_package
 {
 &foreign_require("software");
-local $pkg = &get_postgrey_package();
-local @inst = &software::update_system_install($pkg);
+my $pkg = &get_postgrey_package();
+my @inst = &software::update_system_install($pkg);
 return scalar(@inst) || !&check_postgrey();
 }
 
@@ -167,10 +167,10 @@ return undef;
 # Returns the port on which postgrey listens
 sub get_postgrey_port
 {
-local $args = &get_postgrey_args();
+my $args = &get_postgrey_args();
 if ($args =~ /--inet=(\S+)/) {
 	# TCP port
-	local $opts = $1;
+	my $opts = $1;
 	if ($opts =~ /^(\S+):(\d+)$/) {
 		return $2;
 		}
@@ -272,15 +272,15 @@ if (&get_postgrey_type() eq 'milter') {
 
 # Enable at boot
 &foreign_require("init");
-local $init = &get_postgrey_init();
-local $port = &get_postgrey_port();
+my $init = &get_postgrey_init();
+my $port = &get_postgrey_port();
 &$first_print($text{'postgrey_init'});
 if (&init::action_status($init) != 2) {
 	if (!$port) {
 		# Pick a random port now
 		$port = &allocate_random_port(60000);
 		}
-	local $postgrey = &has_command("postgrey");
+	my $postgrey = &has_command("postgrey");
 	&init::enable_at_boot(
 		$init,
 		'Start the Postgrey greylisting server',
@@ -296,7 +296,7 @@ else {
 # Start process
 &$first_print($text{'postgrey_proc'});
 if (!&find_byname("postgrey")) {
-	local ($ok, $out) = &init::start_action($init);
+	my ($ok, $out) = &init::start_action($init);
 	if (!$ok) {
 		&$second_print(&text('postgrey_procfailed',
 				     "<tt>".&html_escape($out)."</tt>"));
@@ -313,14 +313,14 @@ $port = &get_postgrey_port();	# In case we got it from the running
 # Configure Postfix and restart
 &$first_print($text{'postgrey_postfix'});
 &require_mail();
-local $rr = &postfix::get_real_value("smtpd_recipient_restrictions");
+my $rr = &postfix::get_real_value("smtpd_recipient_restrictions");
 if ($rr =~ /check_policy_service\s+inet:\S+:\Q$port\E/ ||
     $rr =~ /check_policy_service\s+unix:\Q$port\E/) {
 	# Already OK
 	&$second_print($text{'postgrey_postfixalready'});
 	}
 else {
-	local $wantport = $port =~ /^\// ? "unix:$port"
+	my $wantport = $port =~ /^\// ? "unix:$port"
 					 : "inet:127.0.0.1:$port";
 	if ($rr =~ /(.*)check_policy_service\s+(inet|unix):[^, ]+(.*)/) {
 		# Wrong port?!
@@ -351,10 +351,10 @@ if (&get_postgrey_type() eq 'milter') {
 
 # Remove from Postfix configuration
 &$first_print($text{'postgrey_nopostfix'});
-local $port = &get_postgrey_port();
-local $init = &get_postgrey_init();
+my $port = &get_postgrey_port();
+my $init = &get_postgrey_init();
 &require_mail();
-local $rr = &postfix::get_real_value("smtpd_recipient_restrictions");
+my $rr = &postfix::get_real_value("smtpd_recipient_restrictions");
 if ($rr =~ /^(.*)\s*check_policy_service\s+inet:\S+:\Q$port\E(.*)/ ||
     $rr =~ /^(.*)\s*check_policy_service\s+unix:\Q$port\E(.*)/) {
 	$rr = $1.$2;
@@ -368,10 +368,10 @@ else {
 
 # Kill the process
 &foreign_require("init");
-local $init = &get_postgrey_init();
+my $init = &get_postgrey_init();
 &$first_print($text{'postgrey_noproc'});
 if (&find_byname("postgrey")) {
-	local ($ok, $out) = &init::stop_action($init);
+	my ($ok, $out) = &init::stop_action($init);
 	if (!$ok) {
 		&$second_print(&text('postgrey_noprocfailed',
 				     "<tt>".&html_escape($out)."</tt>"));
@@ -399,8 +399,8 @@ else {
 # Find a socket that isn't currently in use
 sub allocate_random_port
 {
-local ($port) = @_;
-local $proto = getprotobyname('tcp');
+my ($port) = @_;
+my $proto = getprotobyname('tcp');
 if (!socket(RANDOMSOCK, PF_INET, SOCK_STREAM, $proto)) {
 	&error("socket failed : $!");
 	}
@@ -1286,12 +1286,12 @@ else {
 sub get_postgrey_data_file
 {
 return undef if (&get_postgrey_type() eq 'milter');
-local ($type) = @_;
-local $args = &get_postgrey_args();
+my ($type) = @_;
+my $args = &get_postgrey_args();
 if ($args =~ /--whitelist-\Q$type\E=(\S+)/) {
 	return $1;
 	}
-local $out = &backquote_command("postgrey -h 2>&1");
+my $out = &backquote_command("postgrey -h 2>&1");
 if ($out =~ /--whitelist-\Q$type\E=.*default:\s+(\S+)/) {
 	return $1;
 	}
@@ -1302,7 +1302,7 @@ return undef;
 # Returns a list of Postgrey configuration entries of some type, as an array ref
 sub list_postgrey_data
 {
-local ($type) = @_;
+my ($type) = @_;
 if (&get_postgrey_type() eq 'milter') {
 	if (!$postgrey_data_cache{$type}) {
 		$postgrey_data_cache{$type} =
@@ -1310,11 +1310,12 @@ if (&get_postgrey_type() eq 'milter') {
 		}
 	return $postgrey_data_cache{$type};
 	}
-local $file = &get_postgrey_data_file($type);
+my $file = &get_postgrey_data_file($type);
 return undef if (!$file);
 if (!$postgrey_data_cache{$type}) {
-	local ($_, @rv, @cmts);
-	local $lnum = 0;
+	local $_;
+	my (@rv, @cmts);
+	my $lnum = 0;
 	&open_readfile(POSTGREY, $file);
 	while(<POSTGREY>) {
 		s/\r|\n//g;
@@ -1378,15 +1379,15 @@ return undef;
 # Add an entry to a Postgrey whitelist file, and in-memory cache
 sub create_postgrey_data
 {
-local ($type, $data) = @_;
+my ($type, $data) = @_;
 if (&get_postgrey_type() eq 'milter') {
 	&create_postgrey_milter_data($type, $data);
 	return;
 	}
-local $file = &get_postgrey_data_file($type);
+my $file = &get_postgrey_data_file($type);
 $file || &error("Failed to find file for $type");
-local @newlines = &postgrey_data_lines($data);
-local $lref = &read_file_lines($file);
+my @newlines = &postgrey_data_lines($data);
+my $lref = &read_file_lines($file);
 if ($postgrey_data_cache{$type}) {
 	# Add to cache and set lines and index
 	$data->{'line'} = scalar(@$lref);
@@ -1403,17 +1404,17 @@ push(@$lref, @newlines);
 # Modify an entry in a Postgrey whitelist file
 sub modify_postgrey_data
 {
-local ($type, $data) = @_;
+my ($type, $data) = @_;
 if (&get_postgrey_type() eq 'milter') {
 	my $old = &list_postgrey_data($type)->[$data->{'index'}];
 	&modify_postgrey_milter_data($type, $old, $data);
 	return;
 	}
-local $file = &get_postgrey_data_file($type);
+my $file = &get_postgrey_data_file($type);
 $file || &error("Failed to find file for $type");
-local @newlines = &postgrey_data_lines($data);
-local $oldlines = $data->{'eline'} - $data->{'line'} + 1;
-local $lref = &read_file_lines($file);
+my @newlines = &postgrey_data_lines($data);
+my $oldlines = $data->{'eline'} - $data->{'line'} + 1;
+my $lref = &read_file_lines($file);
 splice(@$lref, $data->{'line'}, $oldlines, @newlines);
 $data->{'eline'} = $data->{'line'} + scalar(@newlines) - 1;
 if ($postgrey_data_cache{$type} && scalar(@newlines) != $oldlines) {
@@ -1432,15 +1433,15 @@ if ($postgrey_data_cache{$type} && scalar(@newlines) != $oldlines) {
 # Remove an entry from a Postgrey whitelist file, and in-memory cache
 sub delete_postgrey_data
 {
-local ($type, $data) = @_;
+my ($type, $data) = @_;
 if (&get_postgrey_type() eq 'milter') {
 	&delete_postgrey_milter_data($type, $data);
 	return;
 	}
-local $file = &get_postgrey_data_file($type);
+my $file = &get_postgrey_data_file($type);
 $file || &error("Failed to find file for $type");
-local $lref = &read_file_lines($file);
-local $oldlines = $data->{'eline'} - $data->{'line'} + 1;
+my $lref = &read_file_lines($file);
+my $oldlines = $data->{'eline'} - $data->{'line'} + 1;
 splice(@$lref, $data->{'line'}, $oldlines);
 if ($postgrey_data_cache{$type}) {
 	# Remove from cache and shift other lines and indexes down
@@ -1460,8 +1461,8 @@ if ($postgrey_data_cache{$type}) {
 
 sub postgrey_data_lines
 {
-local ($data) = @_;
-local @rv;
+my ($data) = @_;
+my @rv;
 push(@rv, map { "# $_" } @{$data->{'cmts'}});
 push(@rv, $data->{'re'} ? "/".$data->{'value'}."/" : $data->{'value'});
 return @rv;
@@ -1477,10 +1478,10 @@ if (&get_postgrey_type() eq 'milter') {
 	my ($ok, $out) = &init::restart_action(&get_postgrey_init());
 	return $ok ? 1 : 0;
 	}
-local $args = &get_postgrey_args();
-local $pid;
+my $args = &get_postgrey_args();
+my $pid;
 if ($args =~ /--pidfile=(\S+)/) {
-	local $pidfile = $1;
+	my $pidfile = $1;
 	$pid = &check_pid_file($pidfile);
 	}
 ($pid) = &find_byname("postgrey") if (!$pid);
@@ -1517,4 +1518,3 @@ $main::got_lock_postgrey-- if ($main::got_lock_postgrey);
 }
 
 1;
-

--- a/postinstall.pl
+++ b/postinstall.pl
@@ -6,7 +6,7 @@ do 'virtual-server-lib.pl';
 sub module_install
 {
 &foreign_require("cron");
-local $need_restart;
+my $need_restart;
 &lock_file($module_config_file);
 
 # Update last post-install time
@@ -30,7 +30,7 @@ foreach my $script (@all_cron_commands) {
 	}
 
 # Convert all templates to plans, if needed
-local @oldplans = &list_plans(1);
+my @oldplans = &list_plans(1);
 if (!@oldplans) {
 	&convert_plans();
 	}
@@ -87,9 +87,9 @@ if (!$config{'defaultdomain_name'}) {
 	}
 
 # Make sure the remote.cgi page is accessible in non-session mode
-local %miniserv;
+my %miniserv;
 &get_miniserv_config(\%miniserv);
-local @sa = split(/\s+/, $miniserv{'sessiononly'});
+my @sa = split(/\s+/, $miniserv{'sessiononly'});
 if (&indexof("/$module_name/remote.cgi", @sa) < 0) {
 	# Need to add
 	push(@sa, "/$module_name/remote.cgi");
@@ -163,7 +163,7 @@ elsif ($config{'preload_mode'} eq '') {
 $need_restart = 1 if ($config{'preload_mode'});		# To apply .pl changes
 
 # Restart Webmin if needed
-local %miniserv;
+my %miniserv;
 &get_miniserv_config(\%miniserv);
 if (&check_pid_file($miniserv{'pidfile'}) && $need_restart) {
 	&restart_miniserv();
@@ -210,7 +210,7 @@ if ($virtualmin_pro && !$config{'done_fix_autoreplies'}) {
 	}
 
 # If installing for the first time, enable backup of all features by default
-local @doms = &list_domains();
+my @doms = &list_domains();
 if (!@doms && !defined($config{'backup_feature_all'})) {
 	$config{'backup_feature_all'} = 1;
 	&save_module_config();
@@ -223,9 +223,9 @@ if (!@doms && !defined($config{'backup_feature_all'})) {
 if (&foreign_installed("sshd") && !$config{'nodeniedssh'}) {
 	# Add to SSHd config
 	&foreign_require("sshd");
-	local $conf = &sshd::get_sshd_config();
-	local @denyg = &sshd::find_value("DenyGroups", $conf);
-	local $commas = $sshd::version{'type'} eq 'ssh' &&
+	my $conf = &sshd::get_sshd_config();
+	my @denyg = &sshd::find_value("DenyGroups", $conf);
+	my $commas = $sshd::version{'type'} eq 'ssh' &&
 			$sshd::version{'number'} >= 3.2;
 	if ($commas) {
 		@denyg = split(/,/, $denyg[0]);
@@ -241,10 +241,10 @@ if (&foreign_installed("sshd") && !$config{'nodeniedssh'}) {
 	# Create the actual group, if missing
 	&require_useradmin();
 	&obtain_lock_unix();
-	local @allgroups = &list_all_groups();
-	local ($group) = grep { $_->{'group'} eq $denied_ssh_group } @allgroups;
+	my @allgroups = &list_all_groups();
+	my ($group) = grep { $_->{'group'} eq $denied_ssh_group } @allgroups;
 	if (!$group) {
-		local (%gtaken, %ggtaken);
+		my (%gtaken, %ggtaken);
 		&build_group_taken(\%gtaken, \%ggtaken, \@allgroups);
 		$group = { 'group' => $denied_ssh_group,
 			   'members' => '',
@@ -267,7 +267,7 @@ if (&foreign_installed("sshd") && !$config{'nodeniedssh'}) {
 
 # Decide if sub-domains should be allowed, by checking if any exist
 if ($config{'allow_subdoms'} eq '') {
-	local @subdoms = grep { $_->{'subdom'} } &list_domains();
+	my @subdoms = grep { $_->{'subdom'} } &list_domains();
 	$config{'allow_subdoms'} = @subdoms ? 1 : 0;
 	&save_module_config();
 	}
@@ -358,7 +358,7 @@ if (!$cerr) {
 
 # Make all domains' .acl files non-world-readable
 foreach my $d (grep { !$_->{'parent'} && $_->{'webmin'} } &list_domains()) {
-	local @aclfiles = glob("$config_directory/*/$d->{'user'}.acl");
+	my @aclfiles = glob("$config_directory/*/$d->{'user'}.acl");
 	foreach my $f (@aclfiles) {
 		&set_ownership_permissions(undef, undef, 0600, $f);
 		}
@@ -369,7 +369,7 @@ foreach my $d (grep { !$_->{'parent'} && $_->{'webmin'} } &list_domains()) {
 # /etc/webmin/*/config files
 foreach my $m ("mysql", "postgresql", "ldap-client", "ldap-server",
 	       "ldap-useradmin", $module_name) {
-	local $mdir = "$config_directory/$m";
+	my $mdir = "$config_directory/$m";
 	if (-d $mdir) {
 		&set_ownership_permissions(undef, undef, 0711,
 					   $mdir, "$mdir/config");
@@ -469,9 +469,9 @@ if (!@doms && $config{'allow_symlinks'} ne '1') {
 	}
 
 # Print warning if PHP or symlink settings have not been checked
-local $warn;
+my $warn;
 if ($config{'allow_symlinks'} eq '') {
-	local @fixdoms = &fix_symlink_security(undef, 1);
+	my @fixdoms = &fix_symlink_security(undef, 1);
 	$warn++ if (@fixdoms);
 	}
 if ($warn) {
@@ -692,9 +692,9 @@ if ($gconfig{'os_type'} eq 'redhat-linux' &&
 &run_post_actions_silently();
 
 # Record the install time for this version
-local %itimes;
+my %itimes;
 &read_file($install_times_file, \%itimes);
-local $basever = &get_base_module_version();
+my $basever = &get_base_module_version();
 if (!$itimes{$basever}) {
 	$itimes{$basever} = time();
 	&write_file($install_times_file, \%itimes);

--- a/proftpd-lib.pl
+++ b/proftpd-lib.pl
@@ -30,9 +30,9 @@ my $conf = &proftpd::get_config();
 my $st = &proftpd::find_directive("ServerType", $conf);
 if (lc($st) ne "inetd") {
 	&$first_print($text{'setup_proftpdpid'});
-	local $proftpdlock = "$module_config_directory/proftpd-restart";
+	my $proftpdlock = "$module_config_directory/proftpd-restart";
 	&lock_file($proftpdlock);
-	local $err = &proftpd::apply_configuration();
+	my $err = &proftpd::apply_configuration();
 	&unlock_file($proftpdlock);
 	&$second_print($err ? &text('setup_proftpdfailed', $err)
 			    : $text{'setup_done'});
@@ -143,7 +143,7 @@ my $conf = &proftpd::get_config();
 $proftpd::conf = $conf;		# get_or_create is broken in Webmin 1.410
 my $gconf = &proftpd::get_or_create_global($conf);
 foreach my $dr (&proftpd::find_directive_struct("DefaultRoot", $gconf)) {
-	local $chroot = { 'dr' => $dr,
+	my $chroot = { 'dr' => $dr,
 			  'dir' => $dr->{'words'}->[0] };
 	if ($dr->{'words'}->[1] eq '') {
 		# Applies to all groups

--- a/quotas.pl
+++ b/quotas.pl
@@ -52,7 +52,7 @@ foreach $d (&list_domains()) {
 		}
 	foreach $u (@users) {
 		next if ($u->{'webowner'});
-		local $msg;
+		my $msg;
 
 		# Check if over home quota
 		if ($u->{'quota'}) {
@@ -113,19 +113,19 @@ if ($config{'quota_email'}) {
 # Converts a list of domain over-quota notifications into a message, and send it
 sub send_domain_quota_email
 {
-local ($msgs, $email) = @_;
+my ($msgs, $email) = @_;
 $email = $gconfig{'webmin_email_to'} if ($email eq '*');
 
-local $fmt = "%-20.20s %-15.15s %-15.15s %-20.20s\n";
-local $body = "$text{'quotawarn_body'}\n\n";
-local $body .= sprintf($fmt, $text{'quotawarn_server'},
+my $fmt = "%-20.20s %-15.15s %-15.15s %-20.20s\n";
+my $body = "$text{'quotawarn_body'}\n\n";
+my $body .= sprintf($fmt, $text{'quotawarn_server'},
 			     $text{'quotawarn_quota'},
 			     $text{'quotawarn_usage'},
 			     $text{'quotawarn_status'});
 $body .= sprintf($fmt, "-" x 20, "-" x 15, "-" x 15, "-" x 20);
-local $emaild = undef;
+my $emaild = undef;
 foreach my $m (@$msgs) {
-	local $msg = $m->[3] ? &text('quotawarn_reached', $m->[3])
+	my $msg = $m->[3] ? &text('quotawarn_reached', $m->[3])
 			     : $text{'quotawarn_over'};
 	$emaild ||= $m->[0];
 	$body .= sprintf($fmt, $m->[0]->{'dom'},
@@ -156,18 +156,18 @@ else {
 # Converts a list of user over-quota notifications into a message, and send it
 sub send_user_quota_email
 {
-local ($msgs, $email) = @_;
+my ($msgs, $email) = @_;
 
-local $fmt = "%-30.30s %-15.15s %-15.15s %-15.15s\n";
-local $body = "$text{'quotawarn_body2'}\n\n";
+my $fmt = "%-30.30s %-15.15s %-15.15s %-15.15s\n";
+my $body = "$text{'quotawarn_body2'}\n\n";
 $body .= sprintf($fmt, $text{'quotawarn_email'},
                        $text{'quotawarn_quota'},
                        $text{'quotawarn_usage'},
                        $text{'quotawarn_status'});
 $body .= sprintf($fmt, "-" x 35, "-" x 15, "-" x 15, "-" x 15);
-local $emaild = undef;
+my $emaild = undef;
 foreach my $m (@$msgs) {
-	local $msg = $m->[3] ? &text('quotawarn_reached', $m->[3])
+	my $msg = $m->[3] ? &text('quotawarn_reached', $m->[3])
                              : $text{'quotawarn_over'};
 	$emaild ||= $m->[0];
 	$body .= sprintf($fmt, $m->[5]->{'email'} ||
@@ -199,15 +199,15 @@ else {
 # Send email to one user who is close to or over quota
 sub send_single_user_quota_email
 {
-local ($msg) = @_;
+my ($msg) = @_;
 $email = $msg->[5]->{'email'} ||
 	  $msg->[5]->{'user'}.'@'.&get_system_hostname();
-local $tmpl = &get_quotas_message();
-local %hash = %{$msg->[5]};
+my $tmpl = &get_quotas_message();
+my %hash = %{$msg->[5]};
 $hash{'quota_limit'} = &nice_size($msg->[2]);
 $hash{'quota_used'} = &nice_size($msg->[1]);
 $hash{'quota_percent'} = $msg->[3] || '';
-local $body = &substitute_domain_template($tmpl, $msg->[0], \%hash);
+my $body = &substitute_domain_template($tmpl, $msg->[0], \%hash);
 
 # Send the email
 if ($debug_mode) {
@@ -230,14 +230,14 @@ else {
 # a message hash ref with the details.
 sub check_quota_threshold
 {
-local ($d, $usage, $limit, $user) = @_;
+my ($d, $usage, $limit, $user) = @_;
 if ($usage >= $limit) {
 	# Over!
 	return [ $d, $usage, $limit, undef, 100, $user ];
 	}
 elsif ($config{'quota_warn'}) {
 	# Check if passed some threshold
-	local @warn = sort { $b <=> $a } split(/\s+/, $config{'quota_warn'});
+	my @warn = sort { $b <=> $a } split(/\s+/, $config{'quota_warn'});
 	foreach my $w (@warn) {
 		if ($usage > $limit*$w/100) {
 			return [ $d, $usage, $limit,
@@ -252,7 +252,7 @@ return undef;
 # Returns 0 if the user or domain should not be notified, 1 if so
 sub check_quota_interval
 {
-local ($msg, $lastt, $lastw) = @_;
+my ($msg, $lastt, $lastw) = @_;
 if ($config{'quota_interval'}) {
 	# When as the last time we emailed at this level or
 	# higher?

--- a/recovery.cgi
+++ b/recovery.cgi
@@ -19,7 +19,7 @@ $user || &error("User does not exist!");
 if ($in{'confirm'}) {
 	# Generate a new password
 	if (!$user->{'plainpass'}) {
-		local $olduser = { %$user };
+		my $olduser = { %$user };
 		$user->{'passmode'} = 3;
 		$user->{'plainpass'} = &random_password();
 		$user->{'pass'} = &encrypt_user_password(

--- a/redirects-lib.pl
+++ b/redirects-lib.pl
@@ -358,7 +358,7 @@ if (($redirect->{'stripfile'} || $redirect->{'stripquery'}) &&
 	       "for this website type";
 	}
 &normalize_redirect_destination_slash($redirect);
-local $p = &domain_has_website($d);
+my $p = &domain_has_website($d);
 if ($p && $p ne 'web') {
         return &plugin_call($p, "feature_create_web_redirect", $d, $redirect);
         }
@@ -470,7 +470,7 @@ return "No Apache virtualhost found";
 sub delete_redirect
 {
 my ($d, $redirect) = @_;
-local $p = &domain_has_website($d);
+my $p = &domain_has_website($d);
 if ($p && $p ne 'web') {
         return &plugin_call($p, "feature_delete_web_redirect", $d, $redirect);
         }

--- a/rename-domain.pl
+++ b/rename-domain.pl
@@ -39,7 +39,7 @@ if (!$module_name) {
 
 # Parse command-line args
 while(@ARGV > 0) {
-	local $a = shift(@ARGV);
+	my $a = shift(@ARGV);
 	if ($a eq "--domain") {
 		$domain = lc(shift(@ARGV));
 		}

--- a/resend-email.pl
+++ b/resend-email.pl
@@ -29,7 +29,7 @@ if (!$module_name) {
 
 # Parse command-line args
 while(@ARGV > 0) {
-	local $a = shift(@ARGV);
+	my $a = shift(@ARGV);
 	if ($a eq "--domain") {
 		$domain = lc(shift(@ARGV));
 		}

--- a/reset-feature.pl
+++ b/reset-feature.pl
@@ -38,7 +38,7 @@ if (!$module_name) {
 
 # Parse command-line args
 while(@ARGV > 0) {
-	local $a = shift(@ARGV);
+	my $a = shift(@ARGV);
 	if ($a eq "--domain") {
 		push(@dnames, shift(@ARGV));
 		}
@@ -206,7 +206,7 @@ foreach $d (sort { ($b->{'alias'} ? 2 : $b->{'parent'} ? 1 : 0) <=>
 
 	# Run the after command
 	&set_domain_envs($d, "MODIFY_DOMAIN", undef, $oldd);
-	local $merr = &made_changes();
+	my $merr = &made_changes();
 	&$second_print(&text('setup_emade', "<tt>$merr</tt>"))
 		if (defined($merr));
 	&reset_domain_envs($d);

--- a/reset-pass.pl
+++ b/reset-pass.pl
@@ -45,7 +45,7 @@ if (!$module_name) {
 
 # Parse command-line args
 while(@ARGV > 0) {
-	local $a = shift(@ARGV);
+	my $a = shift(@ARGV);
 	if ($a eq "--domain") {
 		push(@dnames, shift(@ARGV));
 		}

--- a/restart-server.pl
+++ b/restart-server.pl
@@ -38,7 +38,7 @@ if (!$module_name) {
 
 # Parse command-line args
 while(@ARGV > 0) {
-	local $a = shift(@ARGV);
+	my $a = shift(@ARGV);
 	if ($a eq "--domain") {
 		$dname = shift(@ARGV);
 		}

--- a/restore-domain.pl
+++ b/restore-domain.pl
@@ -126,12 +126,12 @@ $reuid = 1;
 $reuser = 0;
 $ipinfo = { };
 while(@ARGV > 0) {
-	local $a = shift(@ARGV);
+	my $a = shift(@ARGV);
 	if ($a eq "--source") {
 		$src = shift(@ARGV);
 		}
 	elsif ($a eq "--feature") {
-		local $f = shift(@ARGV);
+		my $f = shift(@ARGV);
 		&is_enabled_backup_feature($f) ||
 			&usage("Feature $f is not enabled");
 		push(@rfeats, $f);
@@ -146,7 +146,7 @@ while(@ARGV > 0) {
 		$all_features = 1;
 		}
 	elsif ($a eq "--except-feature") {
-		local $f = shift(@ARGV);
+		my $f = shift(@ARGV);
 		$all_features || &usage("--except-feature must come after ".
 				        "--all-features");
 		@rfeats = grep { $_ ne $f } @rfeats;
@@ -357,7 +357,7 @@ if ($all_doms) {
 	@rdoms = keys %$cont;
 	}
 foreach $dname (@rdoms) {
-	local $dinfo = &get_domain_by("dom", $dname);
+	my $dinfo = &get_domain_by("dom", $dname);
 	if ($dinfo && (!$dinfo->{'id'} || !$dinfo->{'dom'} || !$dinfo->{'user'})) {
 		# File is actually empty!
 		$dinfo = undef;

--- a/restore.cgi
+++ b/restore.cgi
@@ -113,7 +113,7 @@ if (&can_backup_virtualmin()) {
 
 # Parse option inputs
 foreach $f (@do_features) {
-	local $ofunc = "parse_restore_$f";
+	my $ofunc = "parse_restore_$f";
 	if (defined(&$ofunc)) {
 		$options{$f} = &$ofunc(\%in);
 		}
@@ -178,7 +178,7 @@ if ($in{'confirm'}) {
 			$gotvbs = 1;
 			next;
 			}
-		local $dinfo = &get_domain_by("dom", $d);
+		my $dinfo = &get_domain_by("dom", $d);
 		if ($dinfo && (!$dinfo->{'id'} || !$dinfo->{'dom'})) {
 			# File is actually empty!
 			$dinfo = undef;
@@ -258,8 +258,8 @@ if (!$in{'confirm'}) {
 	$anymissing = 0;
 	foreach $d (sort { $a cmp $b } keys %$cont) {
 		next if ($d eq "virtualmin");
-		local $dinfo = &get_domain_by("dom", $d);
-		local $can = $crmode == 1 ||
+		my $dinfo = &get_domain_by("dom", $d);
+		my $can = $crmode == 1 ||
 			     $dinfo && &can_edit_domain($dinfo);
 		if ($in{'log'} && !$can) {
 			# When restoring from a logged backup, don't even show

--- a/restore_form.cgi
+++ b/restore_form.cgi
@@ -117,10 +117,10 @@ foreach $f (&get_available_backup_features(!$safe_backup)) {
 		$text{'backup_feature_'.$f} || $text{'feature_'.$f},
 		$sched->{'feature_'.$f},
 		"onClick='form.feature_all[1].checked = true'");
-	local $ofunc = "show_restore_$f";
-	local %opts = map { split(/=/, $_) }
+	my $ofunc = "show_restore_$f";
+	my %opts = map { split(/=/, $_) }
 			split(/,/, $sched->{'opts_'.$f});
-	local $ohtml;
+	my $ohtml;
 	if (defined(&$ofunc) && ($ohtml = &$ofunc(\%opts)) && $ohtml) {
 		$ftable .= "<table><tr><td>\n";
 		$ftable .= ("&nbsp;" x 5);

--- a/rs-lib.pl
+++ b/rs-lib.pl
@@ -250,7 +250,7 @@ sub rs_http_call
 {
 my ($url, $method, $headers, $dstfile, $srcfile, $offset, $length, $tries) = @_;
 $tries ||= $rs_upload_tries;
-local @rv;
+my @rv;
 
 for(my $i=0; $i<$tries; $i++) {
 	@rv = &rs_http_single_call($url, $method, $headers, $dstfile, $srcfile,

--- a/run-api-command.pl
+++ b/run-api-command.pl
@@ -63,7 +63,7 @@ if (!$module_name) {
 $owner = 1;
 @allplans = &list_plans();
 while(@ARGV > 0) {
-	local $a = shift(@ARGV);
+	my $a = shift(@ARGV);
 	if ($a eq "--domain") {
 		push(@domains, shift(@ARGV));
 		}

--- a/s3-lib.pl
+++ b/s3-lib.pl
@@ -965,7 +965,7 @@ foreach my $sched (&list_scheduled_backups()) {
 # access key, secret key and endpoint. Duplicate access keys are not repeated.
 sub list_all_s3_accounts
 {
-local @rv;
+my @rv;
 if (&can_cloud_providers()) {
 	foreach my $s3 (&list_s3_accounts()) {
 		push(@rv, [ $s3->{'access'}, $s3->{'secret'},
@@ -973,9 +973,9 @@ if (&can_cloud_providers()) {
 		}
 	}
 foreach my $sched (grep { &can_backup_sched($_) } &list_scheduled_backups()) {
-	local @dests = &get_scheduled_backup_dests($sched);
+	my @dests = &get_scheduled_backup_dests($sched);
 	foreach my $dest (@dests) {
-		local ($mode, $user, $pass, $server, $path, $port) =
+		my ($mode, $user, $pass, $server, $path, $port) =
 			&parse_backup_url($dest);
 		if ($mode == 3) {
 			my $s3 = &get_s3_account($user);
@@ -989,7 +989,7 @@ foreach my $sched (grep { &can_backup_sched($_) } &list_scheduled_backups()) {
 			}
 		}
 	}
-local %done;
+my %done;
 return grep { !$done{$_->[0]}++ } @rv;
 }
 

--- a/save_dbname.cgi
+++ b/save_dbname.cgi
@@ -56,7 +56,7 @@ foreach $f (@database_features) {
 
 # Run the after command
 &set_domain_envs($d, "DBNAME_DOMAIN", undef, $oldd);
-local $merr = &made_changes();
+my $merr = &made_changes();
 &$second_print(&text('setup_emade', "<tt>$merr</tt>")) if (defined($merr));
 &reset_domain_envs($d);
 

--- a/save_dbpass.cgi
+++ b/save_dbpass.cgi
@@ -40,7 +40,7 @@ foreach $f (@database_features) {
 
 # Run the after command
 &set_domain_envs($d, "DBPASS_DOMAIN", undef, $oldd);
-local $merr = &made_changes();
+my $merr = &made_changes();
 &$second_print(&text('setup_emade', "<tt>$merr</tt>")) if (defined($merr));
 &reset_domain_envs($d);
 

--- a/save_defaults.cgi
+++ b/save_defaults.cgi
@@ -43,7 +43,7 @@ else {
 
 # Save databases
 foreach $db (split(/\r?\n/, $in{'dbs'})) {
-	local ($type, $name) = split(/_/, $db, 2);
+	my ($type, $name) = split(/_/, $db, 2);
 	push(@dbs, { 'type' => $type, 'name' => $name });
 	}
 $user->{'dbs'} = \@dbs;

--- a/save_domain.cgi
+++ b/save_domain.cgi
@@ -58,7 +58,7 @@ if (defined($in{'prefix'})) {
 
 # Check if the password was changed, and if so is it valid
 if (!$d->{'parent'} && !$in{'passwd_def'}) {
-	local $fakeuser = { 'user' => $d->{'user'},
+	my $fakeuser = { 'user' => $d->{'user'},
 			    'plainpass' => $in{'passwd'} };
 	$err = &check_password_restrictions($fakeuser, $d->{'webmin'});
 	&error($err) if ($err);
@@ -146,7 +146,7 @@ $newdom{'dir'} = $in{'mail'} ? 1 : 0 if ($d->{'alias'} && $config{'dir'} == 3);
 # he is sure
 if (!$in{'confirm'} && !$d->{'disabled'}) {
 	# Collect features and plugins being disabled
-	local (@alosing, @losing, @plosing);
+	my (@alosing, @losing, @plosing);
 	foreach $f (@dom_features) {
 		if ($config{$f} && $d->{$f} && !$newdom{$f}) {
 			push(@alosing, $f);
@@ -164,7 +164,7 @@ if (!$in{'confirm'} && !$d->{'disabled'}) {
 		}
 
 	# Check if any alias domains use a feature being disabled
-	local @ausers;
+	my @ausers;
 	foreach my $ad (&get_domain_by("alias", $d->{'id'})) {
 		foreach $f (@alosing) {
 			if ($ad->{$f}) {
@@ -419,7 +419,7 @@ if ($d->{'template'} ne $oldd->{'template'}) {
 # Run the after command
 &run_post_actions();
 &set_domain_envs($d, "MODIFY_DOMAIN", undef, $oldd);
-local $merr = &made_changes();
+my $merr = &made_changes();
 &$second_print(&text('setup_emade', "<tt>$merr</tt>")) if (defined($merr));
 &reset_domain_envs($d);
 &webmin_log("modify", "domain", $d->{'dom'}, $d);

--- a/save_linkcats.cgi
+++ b/save_linkcats.cgi
@@ -21,7 +21,7 @@ for($i=0; defined($in{"desc_$i"}); $i++) {
 
 sub desc_to_category_id
 {
-local ($desc) = @_;
+my ($desc) = @_;
 $desc =~ s/\s+/_/g;
 $desc = lc($desc);
 return $desc;

--- a/save_newip.cgi
+++ b/save_newip.cgi
@@ -332,7 +332,7 @@ elsif ($d->{'virt6'} && $oldd->{'virt6'}) {
 
 # Update features and plugins
 foreach $f (@features) {
-	local $mfunc = "modify_$f";
+	my $mfunc = "modify_$f";
 	if ($config{$f} && $d->{$f}) {
 		&try_function($f, $mfunc, $d, $oldd);
 		}
@@ -378,7 +378,7 @@ foreach $sd (@doms) {
 		}
 
 	foreach $f (@features) {
-		local $mfunc = "modify_$f";
+		my $mfunc = "modify_$f";
 		if ($config{$f} && $sd->{$f}) {
 			&try_function($f, $mfunc, $sd, $oldsd);
 			}
@@ -402,7 +402,7 @@ foreach $sd (@doms) {
 # Run the after command
 &run_post_actions();
 &set_domain_envs($d, "MODIFY_DOMAIN", undef, $oldd);
-local $merr = &made_changes();
+my $merr = &made_changes();
 &$second_print(&text('setup_emade', "<tt>$merr</tt>")) if (defined($merr));
 &reset_domain_envs($d);
 &webmin_log("newip", "domain", $d->{'dom'}, $d);

--- a/save_newips.cgi
+++ b/save_newips.cgi
@@ -90,7 +90,7 @@ foreach $d (@doms) {
 	&error(&text('save_emaking', "<tt>$merr</tt>")) if (defined($merr));
 
 	foreach $f (@features) {
-		local $mfunc = "modify_$f";
+		my $mfunc = "modify_$f";
 		if ($config{$f} && $d->{$f}) {
 			&try_function($f, $mfunc, $d, $oldd);
 			}
@@ -108,7 +108,7 @@ foreach $d (@doms) {
 
 	# Run the after command
 	&set_domain_envs($d, "MODIFY_DOMAIN", undef, \%oldd);
-	local $merr = &made_changes();
+	my $merr = &made_changes();
 	&$second_print(&text('setup_emade', "<tt>$merr</tt>"))
 		if (defined($merr));
 	&reset_domain_envs($d);

--- a/save_newshells.cgi
+++ b/save_newshells.cgi
@@ -18,7 +18,7 @@ else {
 		next if (!$in{"shell_$i"});
 		-r $in{"shell_$i"} || &error(&text('newshells_eshell', $i+1));
 		$in{"desc_$i"} =~ /\S/ || &error(&text('newshells_edesc',$i+1));
-		local %shell = ( 'shell' => $in{"shell_$i"},
+		my %shell = ( 'shell' => $in{"shell_$i"},
 				 'desc' => $in{"desc_$i"},
 				 'owner' => $in{"owner_$i"},
 				 'mailbox' => $in{"mailbox_$i"},

--- a/save_newsv.cgi
+++ b/save_newsv.cgi
@@ -59,7 +59,7 @@ if ($config{'spam'}) {
 	}
 if ($config{'virus'} && !$config{'provision_virus_host'}) {
 	if ($in{'scanner'} == 2) {
-		local ($cmd, @args) = &split_quoted_string($in{'scanprog'});
+		my ($cmd, @args) = &split_quoted_string($in{'scanprog'});
 		&has_command($cmd) || &error($text{'spam_escanner'});
 		$fullcmd = $in{'scanprog'};
 		}

--- a/save_pass.cgi
+++ b/save_pass.cgi
@@ -23,7 +23,7 @@ $in{'new1'} eq $in{'new2'} || error($text{'pass_enew2'});
 
 # Check password quality for virtual servers
 if ($d) {
-	local $fakeuser = { 'user' => $d->{'user'},
+	my $fakeuser = { 'user' => $d->{'user'},
 			    'plainpass' => $in{'new1'} };
 	$err = &check_password_restrictions($fakeuser, $d->{'webmin'});
 	&error($err) if ($err);
@@ -54,7 +54,7 @@ if ($d) {
 
 	# Call all save functions
 	foreach $f (@features) {
-		local $mfunc = "modify_$f";
+		my $mfunc = "modify_$f";
 		if ($config{$f} && $d->{$f}) {
 			&try_function($f, $mfunc, $d, $oldd);
 			}
@@ -73,7 +73,7 @@ if ($d) {
 	# Run the after command
 	&run_post_actions();
 	&set_domain_envs($d, "MODIFY_DOMAIN", undef, \%oldd);
-	local $merr = &made_changes();
+	my $merr = &made_changes();
 	&$second_print(&text('setup_emade', "<tt>$merr</tt>"))
 		if (defined($merr));
 	&reset_domain_envs($d);

--- a/save_phpmode.cgi
+++ b/save_phpmode.cgi
@@ -258,7 +258,7 @@ if (!$anything) {
 
 # Run the after command
 &set_domain_envs($d, "MODIFY_DOMAIN", undef, $oldd);
-local $merr = &made_changes();
+my $merr = &made_changes();
 &$second_print(&text('setup_emade', "<tt>$merr</tt>")) if (defined($merr));
 &reset_domain_envs($d);
 

--- a/save_plan.cgi
+++ b/save_plan.cgi
@@ -141,7 +141,7 @@ else {
 		&set_all_null_print();
 		foreach my $d (&get_domain_by("plan", $plan->{'id'})) {
 			next if ($d->{'parent'});
-			local $oldd = { %$d };
+			my $oldd = { %$d };
 			&set_limits_from_plan($d, $plan);
 			&set_featurelimits_from_plan($d, $plan);
 			&set_capabilities_from_plan($d, $plan);

--- a/save_plugconfig.cgi
+++ b/save_plugconfig.cgi
@@ -17,7 +17,7 @@ $mdir = defined(&module_root_directory) ? &module_root_directory($m)
 if (-r "$mdir/config_info.pl") {
 	# Module has a custom config editor
 	&foreign_require($m, "config_info.pl");
-	local $fn = "${m}::config_form";
+	my $fn = "${m}::config_form";
 	if (defined(&$fn)) {
 		$func++;
 		&foreign_call($m, "config_save", \%pconfig);

--- a/save_spf.cgi
+++ b/save_spf.cgi
@@ -26,7 +26,7 @@ if (!$in{'readonly'}) {
 		$spf ||= &default_domain_spf($d);
 		$defspf = &default_domain_spf($d);
 		foreach $t ('a', 'mx', 'ip4', 'ip6', 'include') {
-			local @v = split(/\s+/, $in{'extra_'.$t});
+			my @v = split(/\s+/, $in{'extra_'.$t});
 			foreach my $v (@v) {
 				if ($a eq 'a' || $t eq 'mx' || $t eq 'include'){
 					# Must be a valid hostname

--- a/save_user.cgi
+++ b/save_user.cgi
@@ -124,8 +124,8 @@ elsif ($in{'delete'}) {
 		print &ui_hidden("delete", 1);
 
 		# Count up home directory size
-		local ($mailsz) = &mail_file_size($user);
-		local ($msg, $homesz);
+		my ($mailsz) = &mail_file_size($user);
+		my ($msg, $homesz);
 		if ($user->{'nocreatehome'} || !$user->{'home'}) {
 			$msg = 'user_rusurew';
 			}
@@ -142,7 +142,7 @@ elsif ($in{'delete'}) {
 		# Check for home directory clash
 		if (!$user->{'nocreatehome'} && $user->{'home'} &&
 		    !$user->{'webowner'}) {
-			local @hclash = grep {
+			my @hclash = grep {
 				(&same_file($_->{'home'}, $user->{'home'}) ||
 				 &is_under_directory($user->{'home'},
 						     $_->{'home'})) &&
@@ -242,9 +242,9 @@ else {
 			}
 
 		# Save list of allowed databases
-		local ($db, @dbs);
+		my ($db, @dbs);
 		foreach $db (split(/\r?\n/, $in{'dbs'})) {
-			local ($type, $name) = split(/_/, $db, 2);
+			my ($type, $name) = split(/_/, $db, 2);
 			push(@dbs, { 'type' => $type,
 				     'name' => $name });
 			}
@@ -274,9 +274,9 @@ else {
 		if ($e eq $eu."\@".$d->{'dom'}) {
 			&error(&text('user_eextra5', $e));
 			}
-		local ($eu, $ed) = ($1, $2);
+		my ($eu, $ed) = ($1, $2);
 		$ed = &parse_domain_name($ed);
-		local $edom = &get_domain_by("dom", $ed);
+		my $edom = &get_domain_by("dom", $ed);
 		$edom && $edom->{'mail'} || &error(&text('user_eextra2', $ed));
 		&can_edit_domain($edom) || $oldextra{$e} ||
 			&error(&text('user_eextra3', $ed));
@@ -700,7 +700,7 @@ else {
 
 			# Set mail file location
 			if ($user->{'qmail'}) {
-				local $store = &substitute_virtualmin_template(
+				my $store = &substitute_virtualmin_template(
 					$config{'ldap_mailstore'}, $user);
 				$user->{'mailstore'} = $store;
 				}

--- a/script_form.cgi
+++ b/script_form.cgi
@@ -45,7 +45,7 @@ $ver =~ /^\S+$/ || &error($text{'scripts_eversion'});
 # Check that the domain has a PHP version
 $ok = 1;
 if (&indexof("php", @{$script->{'uses'}}) >= 0) {
-	@gotvers = grep { local $v = $_; local $_;
+	@gotvers = grep { my $v = $_; local $_;
 			  &check_php_version($d, $v) }
 			&expand_php_versions($d, [5]);
 	@gotvers = sort { &get_php_version($b, $d) <=>

--- a/script_install.cgi
+++ b/script_install.cgi
@@ -246,7 +246,7 @@ else {
 
 # Run post commands
 &set_domain_envs($d, "SCRIPT_DOMAIN", undef, \%envs);
-local $merr = &made_changes();
+my $merr = &made_changes();
 &$second_print(&text('setup_emade', "<tt>$merr</tt>")) if (defined($merr));
 &reset_domain_envs($d);
 

--- a/scripts-lib.pl
+++ b/scripts-lib.pl
@@ -299,10 +299,10 @@ return @rv;
 # Records the installation of a script for a domains
 sub add_domain_script
 {
-local ($d, $name, $version, $opts, $desc, $url, $user, $pass, $partial) = @_;
+my ($d, $name, $version, $opts, $desc, $url, $user, $pass, $partial) = @_;
 $main::add_domain_script_count++;
 $partial =~ s/[\r\n]+/ /mg if ($partial);
-local %info = ( 'id' => time().$$.$main::add_domain_script_count,
+my %info = ( 'id' => time().$$.$main::add_domain_script_count,
 		'name' => $name,
 		'version' => $version,
 		'desc' => $desc,
@@ -310,7 +310,7 @@ local %info = ( 'id' => time().$$.$main::add_domain_script_count,
 		'user' => $user,
 		'pass' => $pass,
 		'partial' => $partial );
-local $o;
+my $o;
 foreach $o (keys %$opts) {
 	$info{'opts_'.$o} = $opts->{$o};
 	}
@@ -329,14 +329,14 @@ return \%info;
 # Updates a script object for a domain on disk
 sub save_domain_script
 {
-local ($d, $sinfo) = @_;
-local %info;
+my ($d, $sinfo) = @_;
+my %info;
 foreach my $k (keys %$sinfo) {
 	if ($k eq 'id' || $k eq 'file') {
 		next;	# No need to save
 		}
 	elsif ($k eq 'opts') {
-		local $opts = $sinfo->{'opts'};
+		my $opts = $sinfo->{'opts'};
 		foreach my $o (keys %$opts) {
 			$info{'opts_'.$o} = $opts->{$o};
 			}
@@ -358,7 +358,7 @@ foreach my $f (@fs) {
 # Records the un-install of a script for a domain
 sub remove_domain_script
 {
-local ($d, $info) = @_;
+my ($d, $info) = @_;
 &unlink_file($info->{'file'});
 &load_plugin_libraries();
 my @fs = grep { &plugin_defined($_, "feature_remove_domain_script") } @plugins;
@@ -376,10 +376,10 @@ sub find_database_table
 {
 my $myd = ref($_[0]) ? shift(@_) : $d;
 my ($dbtype, $dbname, $table) = @_;
-local $cfunc = "check_".$dbtype."_database_clash";
+my $cfunc = "check_".$dbtype."_database_clash";
 if (&$cfunc(undef, $dbname)) {
-	local $lfunc = "list_".$dbtype."_tables";
-	local @tables = &$lfunc($myd, $dbname);
+	my $lfunc = "list_".$dbtype."_tables";
+	my @tables = &$lfunc($myd, $dbname);
 	foreach my $t (@tables) {
 		if ($t =~ /^$table$/i) {
 			return $t;
@@ -394,11 +394,11 @@ return undef;
 # available file.
 sub save_scripts_available
 {
-local ($scripts) = @_;
+my ($scripts) = @_;
 &lock_file($scripts_unavail_file);
 &read_file_cached($scripts_unavail_file, \%unavail);
 foreach my $script (@$scripts) {
-	local $n = $script->{'name'};
+	my $n = $script->{'name'};
 	delete($unavail{$n."_minversion"});
 	if (!$script->{'avail_only'}) {
 		$unavail{$n} = 1;
@@ -420,12 +420,12 @@ foreach my $script (@$scripts) {
 # on success, or an error message on failure. Also prints out download progress.
 sub fetch_script_files
 {
-local ($script, $d, $ver, $opts, $sinfo, $gotfiles, $nocallback) = @_;
-local %serial;
+my ($script, $d, $ver, $opts, $sinfo, $gotfiles, $nocallback) = @_;
+my %serial;
 &read_env_file($virtualmin_license_file, \%serial);
 
-local $cb = $nocallback ? undef : \&progress_callback;
-local @files = &{$script->{'files_func'}}($d, $ver, $opts, $sinfo);
+my $cb = $nocallback ? undef : \&progress_callback;
+my @files = &{$script->{'files_func'}}($d, $ver, $opts, $sinfo);
 foreach my $f (@files) {
 	next if ($f->{'nodownload'});
 	if (-r "$script->{'dir'}/$f->{'file'}") {
@@ -439,12 +439,12 @@ foreach my $f (@files) {
 	else {
 		# Need to fetch it .. build list of possible URLs, from script
 		# and from Virtualmin
-		local @urls;
+		my @urls;
 		my $temp = &transname($f->{'file'});
-		local $newurl = &convert_osdn_url($f->{'url'});
+		my $newurl = &convert_osdn_url($f->{'url'});
 		push(@urls, [ $newurl || $f->{'url'}, $f->{'nocache'},
 			      $f->{'user'}, $f->{'pass'} ]);
-		local $vurl = "http://$script_download_host:$script_download_port$script_download_dir$f->{'file'}";
+		my $vurl = "http://$script_download_host:$script_download_port$script_download_dir$f->{'file'}";
 		if ($f->{'virtualmin'}) {
 			# Use Virtualmin site first, for scripts that don't
 			# have a version-specific name
@@ -474,12 +474,12 @@ foreach my $f (@files) {
 			}
 
 		# Try each URL
-		local $firsterror;
+		my $firsterror;
 		foreach my $urlcache (@urls) {
 			my ($url, $nocache, $user, $pass) = @$urlcache;
-			local $error;
+			my $error;
 			$progress_callback_url = $url;
-			local %headers;
+			my %headers;
 			if ($f->{'referer'}) {
 				$headers{'Referer'} = $f->{'referer'};
 				}
@@ -512,8 +512,8 @@ foreach my $f (@files) {
 
 			# Make sure the downloaded file is in some archive
 			# format, or is Perl or PHP.
-			local $fmt = &compression_format($temp);
-			local $cont;
+			my $fmt = &compression_format($temp);
+			my $cont;
 			if (!$fmt && $temp =~ /\.(pl|php|phar)$/i) {
 				$cont = &read_file_contents($temp);
 				}
@@ -528,7 +528,7 @@ foreach my $f (@files) {
 
 			# Check that it is a valid compressed file
 			if ($fmt) {
-				local $e = &extract_compressed_file($temp);
+				my $e = &extract_compressed_file($temp);
 				if ($e) {
 					$firsterror ||=
 					  &text('scripts_edownload3', $url, $e);
@@ -561,12 +561,12 @@ return undef;
 # domain. Can also include an option for a new database
 sub ui_database_select
 {
-local ($name, $value, $dbs, $d, $newsuffix) = @_;
-local ($newdbname, $newdbtype);
+my ($name, $value, $dbs, $d, $newsuffix) = @_;
+my ($newdbname, $newdbtype);
 if ($newsuffix) {
 	# Work out a name for the new DB (if one is allowed)
-	local $tmpl = &get_template($d->{'template'});
-	local ($dleft, $dreason, $dmax) = &count_feature("dbs");
+	my $tmpl = &get_template($d->{'template'});
+	my ($dleft, $dreason, $dmax) = &count_feature("dbs");
 	if ($dleft != 0 && &can_edit_databases()) {
 		# Choose a name ether based on the allowed prefix, or the
 		# default DB name
@@ -577,7 +577,7 @@ if ($newsuffix) {
 				&vui_edit_link_icon("edit_domain.cgi?dom=$d->{'id'}"));
 			}
 		if ($tmpl->{'mysql_suffix'} ne "none") {
-			local $prefix = &substitute_domain_template(
+			my $prefix = &substitute_domain_template(
 						$tmpl->{'mysql_suffix'}, $d);
 			$prefix =~ s/-/_/g;
 			$prefix =~ s/\./_/g;
@@ -595,7 +595,7 @@ if ($newsuffix) {
 
 		# Check if an existing DB with the same name already exists,
 		# and if so add a suffix for the new DB
-		local $count = 1;
+		my $count = 1;
 		while(1) {
 			my ($already) = grep { $_->{'type'} eq $newdbtype &&
 				       $_->{'name'} eq $newdbname } @$dbs;
@@ -621,10 +621,10 @@ return &ui_select($name, $value,
 sub create_script_database
 {
 my ($d, $dbspec, $opts) = @_;
-local ($dbtype, $dbname) = split(/_/, $dbspec, 2);
+my ($dbtype, $dbname) = split(/_/, $dbspec, 2);
 
 # Check limits (again)
-local ($dleft, $dreason, $dmax) = &count_feature("dbs");
+my ($dleft, $dreason, $dmax) = &count_feature("dbs");
 if ($dleft == 0) {
 	return "You are not allowed to create any more databases";
 	}
@@ -662,9 +662,9 @@ return undef;
 # on failure, or undef on success.
 sub cleanup_script_database
 {
-local ($d, $dbspec, $tables) = @_;
-local ($dbtype, $dbname) = split(/_/, $dbspec, 2);
-local $droperr;
+my ($d, $dbspec, $tables) = @_;
+my ($dbtype, $dbname) = split(/_/, $dbspec, 2);
+my $droperr;
 eval {
 	local $main::error_must_die = 1;
 	if ($dbtype eq "mysql") {
@@ -724,19 +724,19 @@ return $@ || $droperr;
 # Deletes the database that was created for some script, if it is empty
 sub delete_script_database
 {
-local ($d, $dbspec) = @_;
-local ($dbtype, $dbname) = split(/_/, $dbspec, 2);
+my ($d, $dbspec) = @_;
+my ($dbtype, $dbname) = split(/_/, $dbspec, 2);
 
-local $cfunc = "check_".$dbtype."_database_clash";
+my $cfunc = "check_".$dbtype."_database_clash";
 if (!&$cfunc($d, $dbname)) {
 	return "Database $dbname does not exist";
 	}
 
-local $lfunc = "list_".$dbtype."_tables";
-local @tables = &$lfunc($d, $dbname);
+my $lfunc = "list_".$dbtype."_tables";
+my @tables = &$lfunc($d, $dbname);
 if (!@tables) {
 	&push_all_print();
-	local $dfunc = "delete_".$dbtype."_database";
+	my $dfunc = "delete_".$dbtype."_database";
 	&$dfunc($d, $dbname);
 	&save_domain($d);
 	&refresh_webmin_user($d);
@@ -987,21 +987,21 @@ foreach my $script (@domain_scripts) {
 # missing.
 sub check_pear_module
 {
-local ($mod, $ver, $d) = @_;
-local ($mod, $modver) = split(/\-/, $mod);
+my ($mod, $ver, $d) = @_;
+my ($mod, $modver) = split(/\-/, $mod);
 return -1 if (!&foreign_check("php-pear"));
 &foreign_require("php-pear");
-local @cmds = &php_pear::get_pear_commands();
+my @cmds = &php_pear::get_pear_commands();
 return -1 if (!@cmds);
 if ($ver) {
 	# Check if we have Pear for this PHP version
-	local ($vercmd) = grep { $_->[1] == $ver } @cmds;
+	my ($vercmd) = grep { $_->[1] == $ver } @cmds;
 	return -1 if (!$vercmd);
 	}
 if (!scalar(@php_pear_modules)) {
 	@php_pear_modules = &php_pear::list_installed_pear_modules();
 	}
-local ($got) = grep { $_->{'name'} eq $mod &&
+my ($got) = grep { $_->{'name'} eq $mod &&
 		      (!$ver || $_->{'pear'} == $ver) } @php_pear_modules;
 return $got ? 1 : 0;
 }
@@ -1010,7 +1010,7 @@ return $got ? 1 : 0;
 # Normalizes PHP extension names from package/script naming to php -m style.
 sub normalize_php_module_name
 {
-local ($mod) = @_;
+my ($mod) = @_;
 $mod = "" if (!defined($mod));
 $mod = lc($mod);
 $mod =~ s/^pecl-//;
@@ -1026,20 +1026,20 @@ return $mod;
 # is missing
 sub check_php_module
 {
-local ($mod, $ver, $d) = @_;
-local @vers = &list_available_php_versions($d);
-local $verinfo;
+my ($mod, $ver, $d) = @_;
+my @vers = &list_available_php_versions($d);
+my $verinfo;
 if ($ver) {
 	($verinfo) = grep { $_->[0] == $ver } @vers;
 	}
 $verinfo ||= $vers[0];
 return -1 if (!$verinfo);
-local $cmd = $verinfo->[1];
+my $cmd = $verinfo->[1];
 &has_command($cmd) || return -1;
-local $want = &normalize_php_module_name($mod);
-local @mods = map { &normalize_php_module_name($_) }
+my $want = &normalize_php_module_name($mod);
+my @mods = map { &normalize_php_module_name($_) }
 	&list_php_modules($d, $verinfo->[0], $verinfo->[1]);
-local %mods = map { $_, 1 } @mods;
+my %mods = map { $_, 1 } @mods;
 return 1 if ($mods{$want});
 return 0;
 }
@@ -1048,10 +1048,10 @@ return 0;
 # Checks if some Perl module exists
 sub check_perl_module
 {
-local ($mod, $d) = @_;
+my ($mod, $d) = @_;
 return 0 if ($mod !~ /^[A-Za-z_][A-Za-z0-9_:]*$/);
-local $perl = &get_perl_path();
-local $out = &backquote_command(quotemeta($perl)." -e ".
+my $perl = &get_perl_path();
+my $out = &backquote_command(quotemeta($perl)." -e ".
 				quotemeta("use $mod")." 2>&1");
 return $? ? 0 : 1;
 }
@@ -1060,9 +1060,9 @@ return $? ? 0 : 1;
 # Checks if some Python module exists
 sub check_python_module
 {
-local ($mod, $d, $pyver) = @_;
+my ($mod, $d, $pyver) = @_;
 my $python = &get_python_path($pyver);
-local $out = &backquote_command("echo import ".quotemeta($mod).
+my $out = &backquote_command("echo import ".quotemeta($mod).
 				" | $python 2>&1");
 return $? ? 0 : 1;
 }
@@ -1072,7 +1072,7 @@ return $? ? 0 : 1;
 # Otherwise returns undef and an error message.
 sub setup_python_version
 {
-local ($d, $script, $scriptver, $path) = @_;
+my ($d, $script, $scriptver, $path) = @_;
 my $minfunc = $script->{'python_fullver_func'};
 my $maxfunc = $script->{'python_maxver_func'};
 return (undef, undef) if (!defined(&$minfunc));
@@ -1100,8 +1100,8 @@ return ($gotver, undef);
 # is given, any is allowed.
 sub check_php_version
 {
-local ($d, $ver) = @_;
-local @avail = map { $_->[0] } &list_available_php_versions($d);
+my ($d, $ver) = @_;
+my @avail = map { $_->[0] } &list_available_php_versions($d);
 return $ver ? &indexof($ver, @avail) >= 0
 	    : scalar(@avail);
 }
@@ -1111,12 +1111,12 @@ return $ver ? &indexof($ver, @avail) >= 0
 # if available
 sub expand_php_versions
 {
-local ($d, $vers) = @_;
-local @rv = @$vers;
+my ($d, $vers) = @_;
+my @rv = @$vers;
 if (&indexof(5, @rv) >= 0) {
 	# If the script indicates that it supports PHP 5 but we have separate
 	# 5.3+ versions detected, allow them too
-	local @fiveplus = grep { $_ > 5 } map { $_->[0] }
+	my @fiveplus = grep { $_ > 5 } map { $_->[0] }
 			       &list_available_php_versions($d);
 	push(@rv, @fiveplus);
 	}
@@ -1129,7 +1129,7 @@ return sort { $b <=> $a } &unique(@rv);
 # version, or undef and an error message.
 sub setup_php_version
 {
-local ($d, $script, $scriptver, $path) = @_;
+my ($d, $script, $scriptver, $path) = @_;
 
 # Figure out which PHP versions the script supports
 my @vers;
@@ -1165,13 +1165,13 @@ if (!@vers) {
 	}
 
 # Find the best matching directory with a PHP version set
-local $dirpath = &public_html_dir($d);
+my $dirpath = &public_html_dir($d);
 my $candirs = &can_domain_php_directories($d);
 if ($candirs && $path ne '/') {
 	$dirpath .= $path;
 	}
-local @dirs = &list_domain_php_directories($d);
-local $bestdir;
+my @dirs = &list_domain_php_directories($d);
+my $bestdir;
 foreach my $dir (sort { length($a->{'dir'}) cmp length($b->{'dir'}) } @dirs) {
 	if (&is_under_directory($dir->{'dir'}, $dirpath) ||
 	    $dir->{'dir'} eq $dirpath) {
@@ -1201,7 +1201,7 @@ if (!$candirs) {
 my ($setver) = sort { &compare_versions($a, $b) } @vers;
 $setver = $vmap{$setver} || $setver;
 $setver || return (undef, "No versions found!");
-local $err = &save_domain_php_directory($d, $dirpath, $setver);
+my $err = &save_domain_php_directory($d, $dirpath, $setver);
 if ($err) {
 	return (undef, &text('scripts_ephpverchange', $dirpath, $vers[0]));
 	}
@@ -1214,7 +1214,7 @@ else {
 # Removes the custom PHP version setting for some script
 sub clear_php_version
 {
-local ($d, $sinfo) = @_;
+my ($d, $sinfo) = @_;
 if ($sinfo->{'opts'}->{'dir'} &&
     $sinfo->{'opts'}->{'dir'} ne &public_html_dir($d)) {
 	&delete_domain_php_directory($d, $sinfo->{'opts'}->{'dir'});
@@ -1226,11 +1226,11 @@ if ($sinfo->{'opts'}->{'dir'} &&
 # of the install is written to STDOUT. Returns 1 if successful, 0 if not.
 sub setup_php_modules
 {
-local ($d, $script, $ver, $phpver, $opts, $installed) = @_;
-local $modfunc = $script->{'php_mods_func'};
-local $optmodfunc = $script->{'php_opt_mods_func'};
+my ($d, $script, $ver, $phpver, $opts, $installed) = @_;
+my $modfunc = $script->{'php_mods_func'};
+my $optmodfunc = $script->{'php_opt_mods_func'};
 return 1 if (!defined(&$modfunc) && !defined(&$optmodfunc));
-local (@mods, @optmods);
+my (@mods, @optmods);
 if (defined(&$modfunc)) {
 	push(@mods, &$modfunc($d, $ver, $phpver, $opts));
 	}
@@ -1241,7 +1241,7 @@ if (defined(&$optmodfunc)) {
 
 my $installing;
 foreach my $m (@mods) {
-	local $opt = &indexof($m, @optmods) >= 0 ? 1 : 0;
+	my $opt = &indexof($m, @optmods) >= 0 ? 1 : 0;
 	if ($phpver >= 7 && $m eq "mysql") {
 		# PHP actual package name is mysqlnd on all systems
 		$m = "mysqlnd";
@@ -1259,8 +1259,8 @@ foreach my $m (@mods) {
 
 	# Find the php.ini file
 	&foreign_require("phpini");
-	local $mode = &get_domain_php_mode($d);
-	local $inifile = $mode eq "mod_php" || $mode eq "fpm" ?
+	my $mode = &get_domain_php_mode($d);
+	my $inifile = $mode eq "mod_php" || $mode eq "fpm" ?
 			&get_global_php_ini($phpver, $mode) :
 			&get_domain_php_ini($d, $phpver);
 	if (!$inifile) {
@@ -1285,11 +1285,11 @@ foreach my $m (@mods) {
 		}
 
 	# Check if the package is already installed
-	local $iok = 0;
-	local @poss;
-	local @allphps = map{ $_->[0] } list_available_php_versions($d);
-	local $phpvercurr = $phpver;
-	local $nodotphpvercurr = $phpvercurr;
+	my $iok = 0;
+	my @poss;
+	my @allphps = map{ $_->[0] } list_available_php_versions($d);
+	my $phpvercurr = $phpver;
+	my $nodotphpvercurr = $phpvercurr;
 	$nodotphpvercurr =~ s/\.//;
 	foreach my $phpverall (@allphps) {
 		my $fullphpver = &get_php_version($phpverall, $d);
@@ -1356,12 +1356,12 @@ foreach my $m (@mods) {
 			my ($out, $rs) = &capture_function_output(
 				\&software::update_system_install, $pkg);
 			$iok = 1 if (scalar(@$rs));
-			local $newpkg = $pkg;
+			my $newpkg = $pkg;
 			if ($software::update_system eq "csw") {
 				# Real package name is different
 				$newpkg = "CSWphp".$phpver.$m;
 				}
-			local @pinfo2 = &software::package_info($newpkg);
+			my @pinfo2 = &software::package_info($newpkg);
 			if (@pinfo2 && $pinfo2[0] eq $newpkg) {
 				# Yep, it worked
 				$iok = 1;
@@ -1390,14 +1390,14 @@ foreach my $m (@mods) {
 	else {
 		# On success configure the domain's php.ini to load it,
 		# if needed
-		local $pconf = &phpini::get_config($inifile);
-		local @allexts = grep { $_->{'name'} eq 'extension' } @$pconf;
-		local @exts = grep { $_->{'enabled'} } @allexts;
-		local ($got) = grep { $_->{'value'} eq "${mphp}.so" ||
+		my $pconf = &phpini::get_config($inifile);
+		my @allexts = grep { $_->{'name'} eq 'extension' } @$pconf;
+		my @exts = grep { $_->{'enabled'} } @allexts;
+		my ($got) = grep { $_->{'value'} eq "${mphp}.so" ||
 		                      $_->{'value'} eq $mphp } @exts;
 		if (!$got && &check_php_module($mphp, $phpver, $d) != 1) {
 			# Needs to be enabled
-			local $lref = &read_file_lines($inifile);
+			my $lref = &read_file_lines($inifile);
 			if (@exts) {
 				# After current extensions
 				splice(@$lref, $exts[$#exts]->{'line'}+1, 0,
@@ -1428,7 +1428,7 @@ foreach my $m (@mods) {
 
 	# If we are running via mod_php or fcgid, an Apache reload is needed
 	if ($mode eq "mod_php" || $mode eq "fcgid") {
-		local $p = &domain_has_website($d);
+		my $p = &domain_has_website($d);
 		if ($p eq "web") {
 			&register_post_action(\&restart_apache);
 			}
@@ -1454,10 +1454,10 @@ return 1;
 # of the install is written to STDOUT. Returns 1 if successful, 0 if not.
 sub setup_pear_modules
 {
-local ($d, $script, $ver, $phpver) = @_;
-local $modfunc = $script->{'pear_mods_func'};
+my ($d, $script, $ver, $phpver) = @_;
+my $modfunc = $script->{'pear_mods_func'};
 return 1 if (!defined(&$modfunc));
-local @mods = &$modfunc($d, $opts);
+my @mods = &$modfunc($d, $opts);
 return 1 if (!@mods);
 
 # Make sure we have the pear module
@@ -1470,8 +1470,8 @@ if (!&foreign_check("php-pear")) {
 
 # And that we have Pear for this PHP version
 &foreign_require("php-pear");
-local @cmds = &php_pear::get_pear_commands();
-local ($vercmd) = grep { $_->[1] == $phpver } @cmds;
+my @cmds = &php_pear::get_pear_commands();
+my ($vercmd) = grep { $_->[1] == $phpver } @cmds;
 if (!$vercmd) {
 	# No pear .. cannot do anything
 	&$first_print(&text('scripts_nopearcmd',
@@ -1481,12 +1481,12 @@ if (!$vercmd) {
 
 foreach my $m (@mods) {
 	next if (&check_pear_module($m, $phpver, $d) == 1);
-	local ($mname, $mver) = split(/\-/, $m);
+	my ($mname, $mver) = split(/\-/, $m);
 
 	# Install if needed
 	&$first_print(&text('scripts_needpear', "<tt>$mname</tt>"));
 	&foreign_require("php-pear");
-	local $err = &php_pear::install_pear_module($m, $phpver);
+	my $err = &php_pear::install_pear_module($m, $phpver);
 	if ($err) {
 		print $err;
 		&$second_print($text{'scripts_esoftwaremod'});
@@ -1512,9 +1512,9 @@ return 1;
 # At the moment, auto-install of modules is done only from APT or YUM.
 sub setup_perl_modules
 {
-local ($d, $script, $ver, $opts) = @_;
-local $modfunc = $script->{'perl_mods_func'};
-local $optmodfunc = $script->{'perl_opt_mods_func'};
+my ($d, $script, $ver, $opts) = @_;
+my $modfunc = $script->{'perl_mods_func'};
+my $optmodfunc = $script->{'perl_opt_mods_func'};
 return 1 if (!defined(&$modfunc) && !defined(&$optmodfunc));
 if (defined(&$modfunc)) {
 	push(@mods, &$modfunc($d, $ver, $opts));
@@ -1525,7 +1525,7 @@ if (defined(&$optmodfunc)) {
 	}
 
 # Check if the software module is installed and can do update
-local $canpkgs = 0;
+my $canpkgs = 0;
 if (&foreign_installed("software")) {
 	&foreign_require("software");
 	if (defined(&software::update_system_install)) {
@@ -1535,12 +1535,12 @@ if (&foreign_installed("software")) {
 
 foreach my $m (@mods) {
 	next if (&check_perl_module($m, $d) == 1);
-	local $opt = &indexof($m, @optmods) >= 0 ? 1 : 0;
-	local $pkg;
-	local $done = 0;
+	my $opt = &indexof($m, @optmods) >= 0 ? 1 : 0;
+	my $pkg;
+	my $done = 0;
 	if ($canpkgs) {
 		# Work out the package name
-		local $mp = $m;
+		my $mp = $m;
 		if ($software::config{'package_system'} eq 'rpm') {
 			# We can use RPM's tracking of perl dependencies
 			# to install the exact module.
@@ -1614,10 +1614,10 @@ return 1;
 # At the moment, auto-install of modules is done only from APT or YUM.
 sub setup_python_modules
 {
-local ($d, $script, $ver, $opts) = @_;
-local $modfunc = $script->{'python_mods_func'};
-local $optmodfunc = $script->{'python_opt_mods_func'};
-local (@mods, @optmods);
+my ($d, $script, $ver, $opts) = @_;
+my $modfunc = $script->{'python_mods_func'};
+my $optmodfunc = $script->{'python_opt_mods_func'};
+my (@mods, @optmods);
 if (defined(&$modfunc)) {
 	push(@mods, &$modfunc($d, $ver, $opts));
 	}
@@ -1628,7 +1628,7 @@ if (defined(&$optmodfunc)) {
 return 1 if (!@mods);
 
 # Check if the software module is installed and can do update
-local $canpkgs = 0;
+my $canpkgs = 0;
 if (&foreign_installed("software")) {
 	&foreign_require("software");
 	if (defined(&software::update_system_install)) {
@@ -1639,7 +1639,7 @@ my $python = &get_python_path($opts->{'pyver'});
 my $pyver = &get_python_version($python);
 foreach my $m (@mods) {
 	next if (&check_python_module($m, $d, $pyver) == 1);
-	local $opt = &indexof($m, @optmods) >= 0 ? 1 : 0;
+	my $opt = &indexof($m, @optmods) >= 0 ? 1 : 0;
 	&$first_print(&text($opt ? 'scripts_optpythonmod'
 				 : 'scripts_needpythonmod', "<tt>$m</tt>"));
 	if (!$canpkgs) {
@@ -1649,9 +1649,9 @@ foreach my $m (@mods) {
 		}
 
 	# Work out the package name
-	local @pkgs;
-	local $done = 0;
-	local $mp = $m;
+	my @pkgs;
+	my $done = 0;
+	my $mp = $m;
 	if ($software::config{'package_system'} eq 'debian') {
 		# For APT, the package name is python- followed
 		# by the lower-case module name, except for the svn module
@@ -1729,13 +1729,13 @@ foreach my $m (@mods) {
 		}
 
 	# Install the RPM, Debian or CSW package. If any work, then we are done
-	local $anyok;
+	my $anyok;
 	foreach my $pkg (@pkgs) {
 		&$first_print(&text('scripts_softwaremod', "<tt>$pkg</tt>"));
 		&$indent_print();
 		&software::update_system_install($pkg);
 		&$outdent_print();
-		local @pinfo = &software::package_info($pkg);
+		my @pinfo = &software::package_info($pkg);
 		if (@pinfo && $pinfo[0] eq $pkg) {
 			# Yep, it worked
 			&$second_print($text{'setup_done'});
@@ -1756,11 +1756,11 @@ return 1;
 # modifies 'path'. Returns an error message if the path is not valid
 sub validate_script_path
 {
-local ($opts, $script, $d) = @_;
+my ($opts, $script, $d) = @_;
 if (&indexof("horde", @{$script->{'uses'}}) >= 0) {
 	# Under Horde directory
-	local @scripts = &list_domain_scripts($d);
-	local ($horde) = grep { $_->{'name'} eq 'horde' } @scripts;
+	my @scripts = &list_domain_scripts($d);
+	my ($horde) = grep { $_->{'name'} eq 'horde' } @scripts;
 	$horde || return "Script uses Horde, but it is not installed";
 	$opts->{'path'} eq '/' && return "A path of / is not valid for Horde scripts";
 	$opts->{'db'} = $horde->{'opts'}->{'db'};
@@ -1769,13 +1769,13 @@ if (&indexof("horde", @{$script->{'uses'}}) >= 0) {
 	}
 elsif ($opts->{'path'} =~ /^\/cgi-bin/) {
 	# Under cgi directory
-	local $hdir = &cgi_bin_dir($d);
+	my $hdir = &cgi_bin_dir($d);
 	$opts->{'dir'} = $opts->{'path'} eq "/" ?
 				$hdir : $hdir.$opts->{'path'};
 	}
 else {
 	# Under HTML directory
-	local $hdir = &public_html_dir($d);
+	my $hdir = &public_html_dir($d);
 	$opts->{'dir'} = $opts->{'path'} eq "/" ?
 				$hdir : $hdir.$opts->{'path'};
 	}
@@ -1787,8 +1787,8 @@ return undef;
 # The path always ends with a /
 sub script_path_url
 {
-local ($d, $opts) = @_;
-local $pp = $opts->{'path'} eq '/' ? '' : $opts->{'path'};
+my ($d, $opts) = @_;
+my $pp = $opts->{'path'} eq '/' ? '' : $opts->{'path'};
 if ($pp !~ /\.(cgi|pl|php)$/i) {
 	$pp .= "/";
 	}
@@ -1799,21 +1799,21 @@ return &get_domain_url($d, 1).$pp;
 # Outputs HTML for editing script installer template options
 sub show_template_scripts
 {
-local ($tmpl) = @_;
-local $scripts = &list_template_scripts($tmpl);
-local $empty = { 'db' => '${DB}' };
-local @list = $scripts eq "none" ? ( $empty ) : ( @$scripts, $empty );
+my ($tmpl) = @_;
+my $scripts = &list_template_scripts($tmpl);
+my $empty = { 'db' => '${DB}' };
+my @list = $scripts eq "none" ? ( $empty ) : ( @$scripts, $empty );
 
 # Build field list and disablers
-local @sfields = map { ("name_".$_, "path_".$_,
+my @sfields = map { ("name_".$_, "path_".$_,
 			"version_".$_, "version_".$_."_def",
 			"db_def_".$_, "db_".$_, "dbtype_".$_) }
 		     (0..scalar(@list)-1);
-local $dis1 = &js_disable_inputs(\@sfields, [ ]);
-local $dis2 = &js_disable_inputs([ ], \@sfields);
+my $dis1 = &js_disable_inputs(\@sfields, [ ]);
+my $dis2 = &js_disable_inputs([ ], \@sfields);
 
 # None/default/listed selector
-local $stable = $text{'tscripts_what'}."\n";
+my $stable = $text{'tscripts_what'}."\n";
 $stable .= &ui_radio("def",
 	$scripts eq "none" ? 2 :
 	  @$scripts ? 0 :
@@ -1823,23 +1823,23 @@ $stable .= &ui_radio("def",
 	  [ 0, $text{'tscripts_below'}, "onClick='$dis2'" ] ]),"<p>\n";
 
 # Find scripts
-local @opts = ( );
+my @opts = ( );
 foreach $sname (&list_available_scripts()) {
 	$script = &get_script($sname);
 	push(@opts, [ $sname, $script->{'desc'} ]);
 	}
 @opts = sort { lc($a->[1]) cmp lc($b->[1]) } @opts;
-local @dbopts = ( );
+my @dbopts = ( );
 push(@dbopts, [ "mysql", $text{'databases_mysql'} ]) if ($config{'mysql'});
 push(@dbopts, [ "postgres", $text{'databases_postgres'} ]) if ($config{'postgres'});
 
 # Show table of scripts
-local $i = 0;
-local @table;
+my $i = 0;
+my @table;
 foreach $script (@list) {
 	$db_def = $script->{'db'} eq '${DB}' ? 1 :
                         $script->{'db'} ? 2 : 0;
-	local ($name, $ver) = split(/\s+/, $script->{'name'});
+	my ($name, $ver) = split(/\s+/, $script->{'name'});
 	push(@table, [
 		&ui_select("name_$i", $name,
 			   [ [ undef, "&nbsp;" ], @opts ]),
@@ -1881,9 +1881,9 @@ print &ui_table_row(undef, $stable, 2);
 # Updates script installer template options from %in
 sub parse_template_scripts
 {
-local ($tmpl) = @_;
+my ($tmpl) = @_;
 
-local $scripts;
+my $scripts;
 if ($in{'def'} == 2) {
 	# None explicitly chosen
 	$scripts = "none";
@@ -1897,12 +1897,12 @@ else {
 	$scripts = [ ];
 	for($i=0; defined($name = $in{"name_$i"}); $i++) {
 		next if (!$name);
-		local $ver = $in{"version_${i}_def"} ? "latest"
+		my $ver = $in{"version_${i}_def"} ? "latest"
 						     : $in{"version_${i}"};
 		$ver =~ /^\S+$/ || &error(&text('tscripts_eversion', $i+1));
-		local $script = { 'id' => $i,
+		my $script = { 'id' => $i,
 			    	  'name' => $name." ".$ver };
-		local $path = $in{"path_$i"};
+		my $path = $in{"path_$i"};
 		$path =~ /^\/\S*$/ || &error(&text('tscripts_epath', $i+1));
 		$script->{'path'} = $path;
 		$script->{'dbtype'} = $in{"dbtype_$i"};
@@ -1929,28 +1929,28 @@ else {
 # (like cpg([0-9\.]+).zip), returns a list of version numbers found, newest 1st
 sub osdn_package_versions
 {
-local ($project, @res) = @_;
-local $subdir;
+my ($project, @res) = @_;
+my $subdir;
 if ($project =~ /^([^\/]+)(\/\S+)$/) {
 	$project = $1;
 	$subdir = $2;
 	}
-local ($alldata, $err);
+my ($alldata, $err);
 &http_download($osdn_website_host, $osdn_website_port,
 	       "/projects/$project/files".$subdir,
 	       \$alldata, \$err, undef, 0, undef, undef, undef, 0, 1);
 return ( ) if ($err);
 
 # Search for sub-directories
-local @data = ( $alldata );
-local $data = $alldata;
-local %donepath;
+my @data = ( $alldata );
+my $data = $alldata;
+my %donepath;
 while($data =~ /href="(\/projects\/$project\/files\Q$subdir\E\/[^: ]+)"(.*)/is) {
 	$data = $2;
-	local $spath = $1;
+	my $spath = $1;
 	next if ($donepath{$spath}++ || $spath =~ /\/stats\/timeline/ ||
 		 $spath =~ /\.\.$/ || $spath =~ /\/download$/);
-	local ($sdata, $err);
+	my ($sdata, $err);
 	&http_download($osdn_website_host, $osdn_website_port, $spath,
 		       \$sdata, \$err, undef, 0, undef, undef, undef, 0, 1);
 	push(@data, $sdata) if (!$err);
@@ -1958,10 +1958,10 @@ while($data =~ /href="(\/projects\/$project\/files\Q$subdir\E\/[^: ]+)"(.*)/is) 
 	}
 
 # Check them all for files
-local @vers;
+my @vers;
 foreach my $alldata (@data) {
 	foreach my $re (@res) {
-		local $data = $alldata;
+		my $data = $alldata;
 		while($data =~ /$re(.*)/is) {
 			push(@vers, $1);
 			$data = $2;
@@ -1976,8 +1976,8 @@ return @vers;
 # Returns 1 if the current user can install some version of a script
 sub can_script_version
 {
-local ($script, $ver) = @_;
-local ($allowmaster, $allowvers) = &get_script_master_permissions();
+my ($script, $ver) = @_;
+my ($allowmaster, $allowvers) = &get_script_master_permissions();
 if (&master_admin() && $allowvers) {
 	# No limits for master admin
 	return 1;
@@ -2012,7 +2012,7 @@ my $host = &get_domain_http_hostname($d);
 my $usessl = &domain_has_ssl($d);
 my $port = $usessl ? $d->{'web_sslport'} : $d->{'web_port'};
 
-local $oldproxy = $gconfig{'http_proxy'};	# Proxies mess up connection
+my $oldproxy = $gconfig{'http_proxy'};	# Proxies mess up connection
 $gconfig{'http_proxy'} = '';			# to the IP explicitly
 $main::download_timed_out = undef;
 local $SIG{ALRM} = \&download_timeout;
@@ -2092,7 +2092,7 @@ my @headers;
 push(@headers, [ "Host", $host ]);
 push(@headers, [ "User-agent", "Webmin" ]);
 if ($user) {
-	local $auth = &encode_base64("$user:$pass");
+	my $auth = &encode_base64("$user:$pass");
 	$auth =~ tr/\r\n//d;
 	push(@headers, [ "Authorization", "Basic $auth" ]);
 	}
@@ -2109,7 +2109,7 @@ if (!$gotcookie) {
 $main::download_timed_out = undef;
 local $SIG{ALRM} = \&download_timeout;
 alarm($timeout || 60);
-local $h = &make_http_connection($ip, $port, $ssl, "GET", $page, \@headers,
+my $h = &make_http_connection($ip, $port, $ssl, "GET", $page, \@headers,
 			 undef, { 'host' => $host, 'nocheckhost' => 1 });
 alarm(0);
 $h = $main::download_timed_out if ($main::download_timed_out);
@@ -2592,11 +2592,11 @@ if ($callnow) {
 # Remove the cron job that runs some PHP command
 sub delete_script_php_cron
 {
-local ($d, $cmd) = @_;
+my ($d, $cmd) = @_;
 return 0 if (!&foreign_check("cron"));
 &foreign_require("cron");
-local @jobs = &cron::list_cron_jobs();
-local ($job) = grep { $_->{'user'} eq $d->{'user'} &&
+my @jobs = &cron::list_cron_jobs();
+my ($job) = grep { $_->{'user'} eq $d->{'user'} &&
 		      $_->{'command'} =~ /-f\s+\Q$cmd\E/ } @jobs;
 return 0 if (!$job);
 &cron::delete_cron_job($job);
@@ -3400,22 +3400,22 @@ return 0;
 # SymLinksifOwnerMatch
 sub fix_script_htaccess_files
 {
-local ($d, $dir, $findonly, $filename) = @_;
+my ($d, $dir, $findonly, $filename) = @_;
 $filename ||= ".htaccess";
-local $out = &run_as_domain_user($d, "find ".quotemeta($dir).
+my $out = &run_as_domain_user($d, "find ".quotemeta($dir).
 				     " -type f -name ".quotemeta($filename).
 				     " 2>/dev/null");
-local @fixed;
+my @fixed;
 foreach my $file (split(/\r?\n/, $out)) {
 	next if (!-r $file);
 	eval {
 		local $main::error_must_die = 1;
 		&lock_file($file) if (!$findonly);
-		local $lref = $findonly ?
+		my $lref = $findonly ?
 			&read_file_lines($file) :
 			&read_file_lines_as_domain_user($d, $file);
-		local $fixed = 0;
-		local $allowed = &get_allowed_options_list();
+		my $fixed = 0;
+		my $allowed = &get_allowed_options_list();
 		$allowed =~ s/^Options=//;
 		$allowed =~ s/,/ /g;
 		foreach my $l (@$lref) {

--- a/scripts/classicpress.pl
+++ b/scripts/classicpress.pl
@@ -153,7 +153,7 @@ else {
 # Returns an error message if a required option is missing or invalid
 sub script_classicpress_check
 {
-local ($d, $ver, $opts, $upgrade) = @_;
+my ($d, $ver, $opts, $upgrade) = @_;
 $opts->{'dir'} =~ /^\// || return "Missing or invalid install directory";
 $opts->{'db'} || return "Missing database";
 if (-r "$opts->{'dir'}/wp-login.php") {
@@ -191,7 +191,7 @@ return ("unzip");
 # message, or 0 and an error
 sub script_classicpress_install
 {
-local ($d, $version, $opts, $files, $upgrade, $domuser, $dompass) = @_;
+my ($d, $version, $opts, $files, $upgrade, $domuser, $dompass) = @_;
 my ($out, $ex);
 if ($opts->{'newdb'} && !$upgrade) {
 	my $err = create_script_database($d, $opts->{'db'});

--- a/scripts/phpmyadmin.pl
+++ b/scripts/phpmyadmin.pl
@@ -30,7 +30,7 @@ return $vers[0];
 
 sub script_phpmyadmin_version_desc
 {
-local ($ver) = @_;
+my ($ver) = @_;
 return &compare_versions($ver, "6") >= 0 ? "$ver (devel)" :
        &compare_versions($ver, "5") >= 0 ? "$ver" : "$ver (LTS)";
 }
@@ -42,7 +42,7 @@ return 13;		# compare_versions is not compare_version_numbers
 
 sub script_phpmyadmin_can_upgrade
 {
-local ($sinfo, $newver) = @_;
+my ($sinfo, $newver) = @_;
 if (&compare_versions($newver, 6) >= 0 &&
     &compare_versions($sinfo->{'version'}, 5) <= 0) {
 	# Cannot upgrade 5 -> 6 devel
@@ -113,9 +113,9 @@ return $txt;
 # Returns HTML for table rows for options for installing PHP-NUKE
 sub script_phpmyadmin_params
 {
-local ($d, $ver, $upgrade) = @_;
-local $rv;
-local $hdir = &public_html_dir($d, 1);
+my ($d, $ver, $upgrade) = @_;
+my $rv;
+my $hdir = &public_html_dir($d, 1);
 if ($upgrade) {
 	# Options are fixed when upgrading
 	my $httpdauth_enabled =
@@ -145,11 +145,11 @@ if ($upgrade) {
 					? $text{'yes'}
 					: $text{'no'});
 			}
-		local @dbnames = split(/\s+/, $upgrade->{'opts'}->{'db'});
+		my @dbnames = split(/\s+/, $upgrade->{'opts'}->{'db'});
 		$rv .= &ui_table_row("Databases to manage",
 			join(" ", @dbnames) || "<i>All databases</i>");
 		}
-	local $dir = $upgrade->{'opts'}->{'dir'};
+	my $dir = $upgrade->{'opts'}->{'dir'};
 	$dir =~ s/^$d->{'home'}\///;
 	$rv .= &ui_table_row("Install directory", $dir);
 	}
@@ -264,7 +264,7 @@ EOF
 			&ui_radio("auto", 0, [ [ 1, "Yes" ],
 					[ 0, "No" ] ]));
 		}
-	local @dbs = &domain_databases($d, [ "mysql" ]);
+	my @dbs = &domain_databases($d, [ "mysql" ]);
 	$rv .= &ui_table_row("Database to manage",
 		     &ui_radio("db_def", 1, [ [ 1, "All databases" ],
 					      [ 0, "Only selected .." ] ]).
@@ -287,16 +287,16 @@ return $rv;
 # Returns either a hash ref of parsed options, or an error string
 sub script_phpmyadmin_parse
 {
-local ($d, $ver, $in, $upgrade) = @_;
+my ($d, $ver, $in, $upgrade) = @_;
 if ($upgrade) {
 	# Options are always the same
 	return $upgrade->{'opts'};
 	}
 else {
-	local $hdir = &public_html_dir($d, 0);
+	my $hdir = &public_html_dir($d, 0);
 	$in->{'dir_def'} || $in->{'dir'} =~ /\S/ && $in->{'dir'} !~ /\.\./ ||
 		return "Missing or invalid installation directory";
-	local $dir = $in->{'dir_def'} ? $hdir : "$hdir/$in->{'dir'}";
+	my $dir = $in->{'dir_def'} ? $hdir : "$hdir/$in->{'dir'}";
 	if (!$in->{'db_def'} && !$in->{'db'}) {
 		return "No MySQL database to manage selected";
 		}
@@ -321,9 +321,9 @@ else {
 # Returns .htaccess and .htpasswd paths for phpMyAdmin auth
 sub script_phpmyadmin_httpdauth_paths
 {
-local ($d, $opts) = @_;
-local $htaccess = ".htaccess";
-local $htpasswd = ".htpasswd";
+my ($d, $opts) = @_;
+my $htaccess = ".htaccess";
+my $htpasswd = ".htpasswd";
 if (&foreign_check("htaccess-htpasswd")) {
 	&foreign_require("htaccess-htpasswd");
 	$htaccess = $htaccess_htpasswd::config{'htaccess'} || $htaccess;
@@ -336,8 +336,8 @@ return ("$opts->{'dir'}/$htaccess", "$opts->{'dir'}/$htpasswd", $htpasswd);
 # Returns 1 if HTTP Basic auth files currently exist for this install
 sub script_phpmyadmin_httpdauth_is_enabled
 {
-local ($d, $opts) = @_;
-local ($htaccess_path, $htpasswd_path) =
+my ($d, $opts) = @_;
+my ($htaccess_path, $htpasswd_path) =
 	&script_phpmyadmin_httpdauth_paths($d, $opts);
 return (-r $htaccess_path && -r $htpasswd_path) ? 1 : 0;
 }
@@ -346,12 +346,12 @@ return (-r $htaccess_path && -r $htpasswd_path) ? 1 : 0;
 # Returns username and encrypted password for basic auth
 sub script_phpmyadmin_httpdauth_user_pass
 {
-local ($d) = @_;
-local $huser = $d->{'user'};
-local $hpass = $d->{'enc_pass'} || $d->{'md5_enc_pass'} ||
+my ($d) = @_;
+my $huser = $d->{'user'};
+my $hpass = $d->{'enc_pass'} || $d->{'md5_enc_pass'} ||
 	       $d->{'crypt_enc_pass'};
 if ((!$huser || !$hpass) && $d->{'parent'}) {
-	local $pd = &get_domain($d->{'parent'});
+	my $pd = &get_domain($d->{'parent'});
 	$huser ||= $pd->{'user'};
 	$hpass ||= $pd->{'enc_pass'} || $pd->{'md5_enc_pass'} ||
 		   $pd->{'crypt_enc_pass'};
@@ -363,8 +363,8 @@ return ($huser, $hpass);
 # Removes protected-dir metadata for phpMyAdmin basic auth
 sub script_phpmyadmin_httpdauth_cleanup
 {
-local ($d, $opts) = @_;
-local ($htaccess_path, $htpasswd_path) =
+my ($d, $opts) = @_;
+my ($htaccess_path, $htpasswd_path) =
 	&script_phpmyadmin_httpdauth_paths($d, $opts);
 
 # Remove protected directory in webserver plugins
@@ -381,7 +381,7 @@ foreach my $p (&list_feature_plugins()) {
 if (&foreign_check("htaccess-htpasswd")) {
 	&foreign_require("htaccess-htpasswd");
 	&lock_file($htaccess_htpasswd::directories_file);
-	local @pdirs = &htaccess_htpasswd::list_directories();
+	my @pdirs = &htaccess_htpasswd::list_directories();
 	@pdirs = grep { ref($_) ? $_->[0] ne $opts->{'dir'}
 				: $_ ne $opts->{'dir'} } @pdirs;
 	&htaccess_htpasswd::save_directories(\@pdirs);
@@ -393,7 +393,7 @@ if (&foreign_check("htaccess-htpasswd")) {
 # Returns an error message if a required option is missing or invalid
 sub script_phpmyadmin_check
 {
-local ($d, $ver, $opts, $upgrade) = @_;
+my ($d, $ver, $opts, $upgrade) = @_;
 $opts->{'dir'} =~ /^\// || return "Missing or invalid install directory";
 if (-r "$opts->{'dir'}/config.inc.php") {
 	return "phpMyAdmin appears to be already installed in the selected directory";
@@ -411,7 +411,7 @@ if ($opts->{'global_def'} && defined &list_all_global_def_scripts_cached) {
 		: undef;
 	}
 if ($opts->{'httpdauth'}) {
-	local ($huser, $hpass) = &script_phpmyadmin_httpdauth_user_pass($d);
+	my ($huser, $hpass) = &script_phpmyadmin_httpdauth_user_pass($d);
 	$huser || return "Cannot enable HTTP Basic authentication because ".
 			 "this domain has no owner username";
 	$hpass || return "Cannot enable HTTP Basic authentication because ".
@@ -442,7 +442,7 @@ $url = "https://files.phpmyadmin.net/phpMyAdmin/$origver/phpMyAdmin-$ver.zip";
 if (&compare_versions($ver, 6) >= 0) {
 	$url = "https://files.phpmyadmin.net/snapshots/phpMyAdmin-$ver.zip";
 	}
-local @files = ( { 'name' => "source",
+my @files = ( { 'name' => "source",
 	   'file' => "phpMyAdmin-$ver.zip",
 	   'url' => $url } );
 return @files;
@@ -458,12 +458,12 @@ return ("unzip");
 # message, or 0 and an error
 sub script_phpmyadmin_install
 {
-local ($d, $ver, $opts, $files, $upgrade) = @_;
-local ($out, $ex);
-local @dbs = map { s/^mysql_//; $_ } split(/\s+/, $opts->{'db'});
-local $dbuser;
-local $dbpass;
-local $dbhost = 'localhost';
+my ($d, $ver, $opts, $files, $upgrade) = @_;
+my ($out, $ex);
+my @dbs = map { s/^mysql_//; $_ } split(/\s+/, $opts->{'db'});
+my $dbuser;
+my $dbpass;
+my $dbhost = 'localhost';
 if ($d->{'mysql'}) {
 	$dbuser = &mysql_user($d);
 	$dbpass = &mysql_pass($d);
@@ -481,13 +481,13 @@ if ($opts->{'global_def'} && defined &invalidate_global_def_scripts_cache) {
 	}
 
 # Extract tar file to temp dir and copy to target
-local $temp = &transname();
-local $err = &extract_script_archive($files->{'source'}, $temp, $d,
+my $temp = &transname();
+my $err = &extract_script_archive($files->{'source'}, $temp, $d,
                                      $opts->{'dir'}, "phpMyAdmin*");
 $err && return (0, "Failed to extract source : $err");
-local $cfile = "$opts->{'dir'}/config.inc.php";
+my $cfile = "$opts->{'dir'}/config.inc.php";
 if (!-r $cfile) {
-	local $cdef = "$opts->{'dir'}/config.default.php";
+	my $cdef = "$opts->{'dir'}/config.default.php";
 	$cdef = "$opts->{'dir'}/libraries/config.default.php" if (!-r $cdef);
 	$cdef = "$opts->{'dir'}/config.sample.inc.php" if (!-r $cdef);
 	&run_as_domain_user($d, "cp ".quotemeta($cdef)." ".quotemeta($cfile));
@@ -495,11 +495,11 @@ if (!-r $cfile) {
 -r $cfile || return (0, "Failed to copy config file");
 
 # Update the config file
-local $lref = &read_file_lines_as_domain_user($d, $cfile);
-local $l;
-local $url = &script_path_url($d, $opts);
-local $dbs = join(" ", @dbs);
-local $dbsarray = @dbs ? "Array(".join(", ", map { "'$_'" } @dbs).")" : "''";
+my $lref = &read_file_lines_as_domain_user($d, $cfile);
+my $l;
+my $url = &script_path_url($d, $opts);
+my $dbs = join(" ", @dbs);
+my $dbsarray = @dbs ? "Array(".join(", ", map { "'$_'" } @dbs).")" : "''";
 foreach $l (@$lref) {
 	# These are for phpMyAdmin 2.6+
 	if ($opts->{'emptypass'}) {
@@ -561,13 +561,13 @@ foreach $l (@$lref) {
 
 	# These are for version 2.7
 	if ($l =~ /^\$cfgServers\[\$i\]\['blowfish_secret'\]/) {
-		local $rand = &random_password(32);
+		my $rand = &random_password(32);
 		$l = "\$cfgServers[\$i]['blowfish_secret'] = '$rand';";
 		}
 
 	# These are for version 2.8.1
 	if ($l =~ /^\$cfg\['blowfish_secret'\]/) {
-		local $rand = &random_password(32);
+		my $rand = &random_password(32);
 		$l = "\$cfg['blowfish_secret'] = '$rand';";
 		}
 
@@ -619,7 +619,7 @@ if ($opts->{'httpdauth'} && !$upgrade) {
 	if (&foreign_check("htaccess-htpasswd")) {
 		&foreign_require("htaccess-htpasswd");
 		&lock_file($htaccess_htpasswd::directories_file);
-		local @pdirs = &htaccess_htpasswd::list_directories();
+		my @pdirs = &htaccess_htpasswd::list_directories();
 		if (!grep { $_->[0] eq $opts->{'dir'} &&
 			    $_->[1] eq $htpasswd_path } @pdirs) {
 			push(@pdirs, [ $opts->{'dir'}, $htpasswd_path ]);
@@ -635,7 +635,7 @@ if ($opts->{'global_def'} && defined &invalidate_global_def_scripts_cache) {
 	}
 
 # Return a URL for the user
-local $rp = $opts->{'dir'};
+my $rp = $opts->{'dir'};
 $rp =~ s/^$d->{'home'}\///;
 return (1, "phpMyAdmin installation complete. It can be accessed at <a target=_blank href='$url'>$url</a>.", "Under $rp", $url, $dbuser, $dbpass);
 }
@@ -645,7 +645,7 @@ return (1, "phpMyAdmin installation complete. It can be accessed at <a target=_b
 # Returns 1 on success and a message, or 0 on failure and an error
 sub script_phpmyadmin_uninstall
 {
-local ($d, $version, $opts) = @_;
+my ($d, $version, $opts) = @_;
 
 # Invalidate global scripts default cache
 if ($opts->{'global_def'} && defined &invalidate_global_def_scripts_cache) {
@@ -653,7 +653,7 @@ if ($opts->{'global_def'} && defined &invalidate_global_def_scripts_cache) {
 	}
 
 # Remove the contents of the target directory
-local $derr = &delete_script_install_directory($d, $opts);
+my $derr = &delete_script_install_directory($d, $opts);
 return (0, $derr) if ($derr);
 
 # Cleanup basic auth metadata
@@ -668,7 +668,7 @@ return (1, "phpMyAdmin directory deleted.");
 # Returns a URL and regular expression or callback func to get the version
 sub script_phpmyadmin_latest
 {
-local ($ver) = @_;
+my ($ver) = @_;
 if (&compare_versions($ver, "6") > 0) {
 	return ( "http://www.phpmyadmin.net/home_page/downloads.php",
 		 "phpMyAdmin-(6\\.[0-9\\.]+)\\+snapshot-all-languages\\.zip" );

--- a/scripts/phppgadmin.pl
+++ b/scripts/phppgadmin.pl
@@ -50,7 +50,7 @@ return ("pgsql");
 # Must have at least one existing DB
 sub script_phppgadmin_depends
 {
-local ($d, $ver) = @_;
+my ($d, $ver) = @_;
 &has_domain_databases($d, [ "postgres" ], 1) ||
 	return ("phpPgAdmin requires a PostgreSQL database");
 return ( );
@@ -65,19 +65,19 @@ return 7.2;
 # Returns HTML for table rows for options for installing PHP-NUKE
 sub script_phppgadmin_params
 {
-local ($d, $ver, $upgrade) = @_;
-local $rv;
-local $hdir = &public_html_dir($d, 1);
+my ($d, $ver, $upgrade) = @_;
+my $rv;
+my $hdir = &public_html_dir($d, 1);
 if ($upgrade) {
 	# Options are fixed when upgrading
 	$rv .= &ui_table_row("Default database", $upgrade->{'opts'}->{'db'});
-	local $dir = $upgrade->{'opts'}->{'dir'};
+	my $dir = $upgrade->{'opts'}->{'dir'};
 	$dir =~ s/^$d->{'home'}\///;
 	$rv .= &ui_table_row("Install directory", $dir);
 	}
 else {
 	# Show editable install options
-	local @dbs = &domain_databases($d, [ "postgres" ]);
+	my @dbs = &domain_databases($d, [ "postgres" ]);
 	$rv .= &ui_table_row("Default database to manage",
 		     &ui_select("db", undef,
 			[ [ "template1", "&lt;PostgreSQL default&gt;" ],
@@ -92,16 +92,16 @@ return $rv;
 # Returns either a hash ref of parsed options, or an error string
 sub script_phppgadmin_parse
 {
-local ($d, $ver, $in, $upgrade) = @_;
+my ($d, $ver, $in, $upgrade) = @_;
 if ($upgrade) {
 	# Options are always the same
 	return $upgrade->{'opts'};
 	}
 else {
-	local $hdir = &public_html_dir($d, 0);
+	my $hdir = &public_html_dir($d, 0);
 	$in{'dir_def'} || $in{'dir'} =~ /\S/ && $in{'dir'} !~ /\.\./ ||
 		return "Missing or invalid installation directory";
-	local $dir = $in{'dir_def'} ? $hdir : "$hdir/$in{'dir'}";
+	my $dir = $in{'dir_def'} ? $hdir : "$hdir/$in{'dir'}";
 	return { 'db' => $in{'db'},
 		 'dir' => $dir,
 		 'path' => $in{'dir_def'} ? "/" : "/$in{'dir'}", };
@@ -112,7 +112,7 @@ else {
 # Returns an error message if a required option is missing or invalid
 sub script_phppgadmin_check
 {
-local ($d, $ver, $opts, $upgrade) = @_;
+my ($d, $ver, $opts, $upgrade) = @_;
 $opts->{'dir'} =~ /^\// || return "Missing or invalid install directory";
 #$opts->{'db'} || return "Missing database";
 $opts->{'db'} ||= "template1";
@@ -127,10 +127,10 @@ return undef;
 # containing a name, filename and URL
 sub script_phppgadmin_files
 {
-local ($d, $ver, $opts, $upgrade) = @_;
-local $uver = $ver;
+my ($d, $ver, $opts, $upgrade) = @_;
+my $uver = $ver;
 $uver =~ s/\./-/g;
-local @files = ( { 'name' => "source",
+my @files = ( { 'name' => "source",
 	   'file' => "phpPgAdmin-$ver.tar.gz",
 	   'url' => "https://github.com/phppgadmin/phppgadmin/archive/REL_$uver.tar.gz" 
 	} );
@@ -147,28 +147,28 @@ return ("tar", "gunzip");
 # message, or 0 and an error
 sub script_phppgadmin_install
 {
-local ($d, $version, $opts, $files, $upgrade) = @_;
-local ($out, $ex);
-local @dbs = split(/\s+/, $opts->{'db'});
-local $dbuser = &postgres_user($d);
-local $dbpass = &postgres_pass($d, 1);
-local $dbhost = &get_database_host("postgres", $d);
+my ($d, $version, $opts, $files, $upgrade) = @_;
+my ($out, $ex);
+my @dbs = split(/\s+/, $opts->{'db'});
+my $dbuser = &postgres_user($d);
+my $dbpass = &postgres_pass($d, 1);
+my $dbhost = &get_database_host("postgres", $d);
 
 # Extract tar file to temp dir and copy to target
-local $temp = &transname();
-local $err = &extract_script_archive($files->{'source'}, $temp, $d,
+my $temp = &transname();
+my $err = &extract_script_archive($files->{'source'}, $temp, $d,
                                      $opts->{'dir'}, "phppgadmin-*");
 $err && return (0, "Failed to extract source : $err");
-local $cfileorig = "$opts->{'dir'}/conf/config.inc.php-dist";
-local $cfile = "$opts->{'dir'}/conf/config.inc.php";
+my $cfileorig = "$opts->{'dir'}/conf/config.inc.php-dist";
+my $cfile = "$opts->{'dir'}/conf/config.inc.php";
 
 # Copy and update the config file
 if (!-r $cfile) {
 	&run_as_domain_user($d, "cp ".quotemeta($cfileorig)." ".
 				      quotemeta($cfile));
 	}
-local $lref = &read_file_lines_as_domain_user($d, $cfile);
-local $l;
+my $lref = &read_file_lines_as_domain_user($d, $cfile);
+my $l;
 foreach $l (@$lref) {
 	if ($l =~ /^\s*\$conf\['servers'\]\[0\]\['defaultdb'\]/) {
 		$l = "\$conf['servers'][0]['defaultdb'] = '$opts->{'db'}';";
@@ -185,8 +185,8 @@ foreach $l (@$lref) {
 &flush_file_lines_as_domain_user($d, $cfile);
 
 # Return a URL for the user
-local $url = &script_path_url($d, $opts);
-local $rp = $opts->{'dir'};
+my $url = &script_path_url($d, $opts);
+my $rp = $opts->{'dir'};
 $rp =~ s/^$d->{'home'}\///;
 return (1, "phpPgAdmin installation complete. It can be accessed at <a target=_blank href='$url'>$url</a>.", "Under $rp", $url, $dbuser, $dbpass);
 }
@@ -196,10 +196,10 @@ return (1, "phpPgAdmin installation complete. It can be accessed at <a target=_b
 # Returns 1 on success and a message, or 0 on failure and an error
 sub script_phppgadmin_uninstall
 {
-local ($d, $version, $opts) = @_;
+my ($d, $version, $opts) = @_;
 
 # Remove the contents of the target directory
-local $derr = &delete_script_install_directory($d, $opts);
+my $derr = &delete_script_install_directory($d, $opts);
 return (0, $derr) if ($derr);
 
 return (1, "phpPgAdmin directory deleted.");
@@ -209,7 +209,7 @@ return (1, "phpPgAdmin directory deleted.");
 # Returns a URL and regular expression or callback func to get the version
 sub script_phppgadmin_latest
 {
-local ($ver) = @_;
+my ($ver) = @_;
 return ( "https://github.com/phppgadmin/phppgadmin/tags",
 	 sub { my ($d, $v) = @_;
 	       $d =~ /REL_([0-9\.\-]+)/ || return ();

--- a/scripts/roundcube.pl
+++ b/scripts/roundcube.pl
@@ -22,7 +22,7 @@ return ( "1.7.1", "1.6.16" );
 
 sub script_roundcube_version_desc
 {
-local ($ver) = @_;
+my ($ver) = @_;
 return &compare_versions($ver, "1.6") >= 0 ? $ver : "$ver (LTS)";
 }
 
@@ -38,9 +38,9 @@ return 1;
 
 sub script_roundcube_php_modules
 {
-local ($d, $ver, $phpver, $opts) = @_;
-local ($dbtype, $dbname) = split(/_/, $opts->{'db'}, 2);
-local @modules = ( "xml", "zip", "dom", "iconv", "mbstring", "intl" );
+my ($d, $ver, $phpver, $opts) = @_;
+my ($dbtype, $dbname) = split(/_/, $opts->{'db'}, 2);
+my @modules = ( "xml", "zip", "dom", "iconv", "mbstring", "intl" );
 push(@modules, $dbtype eq "mysql" ? "mysql" : "pgsql");
 return @modules;
 }
@@ -76,7 +76,7 @@ return 6;	# Fix root public_html alias
 
 sub script_roundcube_php_fullver
 {
-local ($d, $ver, $sinfo, $phpver) = @_;
+my ($d, $ver, $sinfo, $phpver) = @_;
 my $phpver = &compare_versions($ver, "1.7") >= 0 ? "8.1" :
 	     &compare_versions($ver, "1.6") >= 0 ? "7.3" : 5.6;
 return $phpver;
@@ -103,20 +103,20 @@ return $r->{'path'} eq $opts->{'path'} &&
 # Returns HTML for table rows for options for installing PHP-NUKE
 sub script_roundcube_params
 {
-local ($d, $ver, $upgrade) = @_;
-local $rv;
-local $hdir = &public_html_dir($d, 1);
+my ($d, $ver, $upgrade) = @_;
+my $rv;
+my $hdir = &public_html_dir($d, 1);
 if ($upgrade) {
 	# Options are fixed when upgrading
-	local ($dbtype, $dbname) = split(/_/, $upgrade->{'opts'}->{'db'}, 2);
+	my ($dbtype, $dbname) = split(/_/, $upgrade->{'opts'}->{'db'}, 2);
 	$rv .= &ui_table_row("Database for RoundCube preferences", $dbname);
-	local $dir = $upgrade->{'opts'}->{'dir'};
+	my $dir = $upgrade->{'opts'}->{'dir'};
 	$dir =~ s/^$d->{'home'}\///;
 	$rv .= &ui_table_row("Install directory", $dir);
 	}
 else {
 	# Show editable install options
-	local @dbs = &domain_databases($d, [ "mysql", "postgres" ]);
+	my @dbs = &domain_databases($d, [ "mysql", "postgres" ]);
 	$rv .= &ui_table_row("Database for RoundCube preferences",
 		     &ui_database_select("db", undef, \@dbs, $d, "roundcube"));
 	$rv .= &ui_table_row("Install sub-directory under <tt>$hdir</tt>",
@@ -129,17 +129,17 @@ return $rv;
 # Returns either a hash ref of parsed options, or an error string
 sub script_roundcube_parse
 {
-local ($d, $ver, $in, $upgrade) = @_;
+my ($d, $ver, $in, $upgrade) = @_;
 if ($upgrade) {
 	# Options are always the same
 	return $upgrade->{'opts'};
 	}
 else {
-	local $hdir = &public_html_dir($d, 0);
+	my $hdir = &public_html_dir($d, 0);
 	$in{'dir_def'} || $in{'dir'} =~ /\S/ && $in{'dir'} !~ /\.\./ ||
 		return "Missing or invalid installation directory";
-	local $dir = $in{'dir_def'} ? $hdir : "$hdir/$in{'dir'}";
-	local ($newdb) = ($in->{'db'} =~ s/^\*//);
+	my $dir = $in{'dir_def'} ? $hdir : "$hdir/$in{'dir'}";
+	my ($newdb) = ($in->{'db'} =~ s/^\*//);
 	return { 'db' => $in->{'db'},
 		 'newdb' => $newdb,
 		 'dir' => $dir,
@@ -151,14 +151,14 @@ else {
 # Returns an error message if a required option is missing or invalid
 sub script_roundcube_check
 {
-local ($d, $ver, $opts, $upgrade) = @_;
+my ($d, $ver, $opts, $upgrade) = @_;
 $opts->{'dir'} =~ /^\// || return "Missing or invalid install directory";
 $opts->{'db'} || return "Missing database";
 if (-r "$opts->{'dir'}/config/db.inc.php") {
 	return "RoundCube appears to be already installed in the selected directory";
 	}
-local ($dbtype, $dbname) = split(/_/, $opts->{'db'}, 2);
-local $clash = &find_database_table($dbtype, $dbname, "system|filestore|contacts|users");
+my ($dbtype, $dbname) = split(/_/, $opts->{'db'}, 2);
+my $clash = &find_database_table($dbtype, $dbname, "system|filestore|contacts|users");
 $clash && return "RoundCube appears to be already using the selected database (table $clash)";
 return undef;
 }
@@ -168,8 +168,8 @@ return undef;
 # containing a name, filename and URL
 sub script_roundcube_files
 {
-local ($d, $ver, $opts, $upgrade) = @_;
-local @files = ( { 'name' => "source",
+my ($d, $ver, $opts, $upgrade) = @_;
+my @files = ( { 'name' => "source",
 	           'file' => "roundcube-$ver.tar.gz",
 	           'url' => $ver >= 1.1 ?
 			"https://github.com/roundcube/roundcubemail/releases/download/${ver}/roundcubemail-${ver}-complete.tar.gz" :
@@ -190,38 +190,38 @@ return ("tar", "gunzip");
 # message, or 0 and an error
 sub script_roundcube_install
 {
-local ($d, $version, $opts, $files, $upgrade) = @_;
-local ($out, $ex);
+my ($d, $version, $opts, $files, $upgrade) = @_;
+my ($out, $ex);
 
 # Create and get DB
 if ($opts->{'newdb'} && !$upgrade) {
-	local $err = &create_script_database($d, $opts->{'db'});
+	my $err = &create_script_database($d, $opts->{'db'});
 	return (0, "Database creation failed : $err") if ($err);
 	}
-local ($dbtype, $dbname) = split(/_/, $opts->{'db'}, 2);
-local $dbuser = $dbtype eq "mysql" ? &mysql_user($d) : &postgres_user($d);
-local $dbpass = $dbtype eq "mysql" ? &mysql_pass($d) : &postgres_pass($d, 1);
-local $dbphptype = $dbtype eq "mysql" ? "mysql" : "psql";
-local $dbhost = &get_database_host($dbtype, $d);
-local $dberr = &check_script_db_connection(
+my ($dbtype, $dbname) = split(/_/, $opts->{'db'}, 2);
+my $dbuser = $dbtype eq "mysql" ? &mysql_user($d) : &postgres_user($d);
+my $dbpass = $dbtype eq "mysql" ? &mysql_pass($d) : &postgres_pass($d, 1);
+my $dbphptype = $dbtype eq "mysql" ? "mysql" : "psql";
+my $dbhost = &get_database_host($dbtype, $d);
+my $dberr = &check_script_db_connection(
 	$d, $dbtype, $dbname, $dbuser, $dbpass);
 return (0, "Database connection failed : $dberr") if ($dberr);
 
 # Extract tar file to temp dir and copy to target
-local $temp = &transname();
-local $verdir = $ver;
+my $temp = &transname();
+my $verdir = $ver;
 $verdir =~ s/-complete$//;
-local $err = &extract_script_archive($files->{'source'}, $temp, $d,
+my $err = &extract_script_archive($files->{'source'}, $temp, $d,
                                      $opts->{'dir'}, "roundcubemail-$verdir");
 $err && return (0, "Failed to extract source : $err");
 
 if (!$upgrade) {
 	# Fix up the DB config file
-	local $dbcfileorig = "$opts->{'dir'}/config/db.inc.php.dist";
-	local $dbcfile = "$opts->{'dir'}/config/db.inc.php";
+	my $dbcfileorig = "$opts->{'dir'}/config/db.inc.php.dist";
+	my $dbcfile = "$opts->{'dir'}/config/db.inc.php";
 	if (-r $dbcfileorig) {
 		&copy_source_dest_as_domain_user($d, $dbcfileorig, $dbcfile);
-		local $lref = &read_file_lines_as_domain_user($d, $dbcfile);
+		my $lref = &read_file_lines_as_domain_user($d, $dbcfile);
 		foreach my $l (@$lref) {
 			if ($l =~ /^\$rcmail_config\['db_dsnw'\]\s+=/) {
 				$l = "\$rcmail_config['db_dsnw'] = 'mysql://$dbuser:".
@@ -236,11 +236,11 @@ if (!$upgrade) {
 		}
 
 	# Figure out folder names
-	local %fmap;
+	my %fmap;
 	$fmap{'drafts'} = $config{'drafts_folder'} || 'drafts';
 	$fmap{'sent'} = $config{'sent_folder'} || 'sent';
 	$fmap{'trash'} = $config{'trash_folder'} || 'sent';
-	local ($sdmode, $sdpath) = &get_domain_spam_delivery($d);
+	my ($sdmode, $sdpath) = &get_domain_spam_delivery($d);
 	if (($sdmode == 6 || $sdmode == 4) && $sdpath) {
 		$fmap{'junk'} = $sdpath;
 		}
@@ -249,14 +249,14 @@ if (!$upgrade) {
 		}
 
 	# Fix up the main config file
-	local $mcfileorig = "$opts->{'dir'}/config/main.inc.php.dist";
-	local $mcfile = "$opts->{'dir'}/config/main.inc.php";
+	my $mcfileorig = "$opts->{'dir'}/config/main.inc.php.dist";
+	my $mcfile = "$opts->{'dir'}/config/main.inc.php";
 	if (!-r $mcfileorig) {
 		$mcfileorig = "$opts->{'dir'}/config/config.inc.php.sample";
 		$mcfile = "$opts->{'dir'}/config/config.inc.php";
 		}
 	&copy_source_dest_as_domain_user($d, $mcfileorig, $mcfile);
-	local $lref = &read_file_lines_as_domain_user($d, $mcfile);
+	my $lref = &read_file_lines_as_domain_user($d, $mcfile);
 	foreach my $l (@$lref) {
 		if ($l =~ /^\$(rcmail_config|config)\['enable_caching'\]\s+=/) {
 			$l = "\$${1}['enable_caching'] = FALSE;";
@@ -295,14 +295,14 @@ if (!$upgrade) {
 
 	# Run SQL setup script
 	&require_mysql();
-	local $sqlfile;
+	my $sqlfile;
 	if ($dbtype eq "mysql") {
 		$sqlfile = "$opts->{'dir'}/SQL/mysql.initial.sql";
 		}
 	else {
 		$sqlfile = "$opts->{'dir'}/SQL/postgres.initial.sql";
 		}
-	local ($ex, $out) = &mysql::execute_sql_file($dbname, $sqlfile,
+	my ($ex, $out) = &mysql::execute_sql_file($dbname, $sqlfile,
 					       	     $dbuser, $dbpass);
 	$ex && return (-1, "Failed to run database setup script : ".
 			   "<tt>$out</tt>.");
@@ -335,8 +335,8 @@ if (&compare_versions($ver, "1.7") >= 0) {
 	}
 
 # Return a URL for the user
-local $url = &script_path_url($d, $opts);
-local $rp = $opts->{'dir'};
+my $url = &script_path_url($d, $opts);
+my $rp = $opts->{'dir'};
 $rp =~ s/^$d->{'home'}\///;
 my $installtype = $upgrade ? 'upgrade' : 'installation';
 return (1, "RoundCube $installtype complete. It can be accessed at <a target=_blank href='$url'>$url</a>.", "Under $rp using $dbphptype database $dbname", $url);
@@ -372,7 +372,7 @@ return $db_conn_desc;
 # Returns 1 on success and a message, or 0 on failure and an error
 sub script_roundcube_uninstall
 {
-local ($d, $version, $opts) = @_;
+my ($d, $version, $opts) = @_;
 
 # Remove roundcube tables from the database
 &cleanup_script_database($d, $opts->{'db'}, "(.*)");
@@ -393,7 +393,7 @@ if (&compare_versions($version, "1.7") >= 0) {
 	}
 
 # Remove the contents of the target directory
-local $derr = &delete_script_install_directory($d, $opts);
+my $derr = &delete_script_install_directory($d, $opts);
 return (0, $derr) if ($derr);
 
 return (1, "RoundCube directory and tables deleted.");
@@ -403,7 +403,7 @@ return (1, "RoundCube directory and tables deleted.");
 # Returns a URL and regular expression or callback func to get the version
 sub script_roundcube_latest
 {
-local ($ver) = @_;
+my ($ver) = @_;
 return ( "http://roundcube.net/download/",
          $ver >= 1.7 ? "roundcubemail-([0-9\\.]+)-complete.tar.gz" :
          $ver >= 1.6 ? "roundcubemail-(1\\.6\\.[0-9\\.]+)-complete.tar.gz" :

--- a/scripts/squirrelmail.pl
+++ b/scripts/squirrelmail.pl
@@ -28,7 +28,7 @@ return 2;	# Remove set_user_data
 
 sub script_squirrelmail_version_desc
 {
-local ($ver) = @_;
+my ($ver) = @_;
 return $ver < 1.5 ? "$ver (Stable)" : "$ver (Development)";
 }
 
@@ -59,7 +59,7 @@ return 1;
 
 sub script_squirrelmail_pear_modules
 {
-local ($d, $opts) = @_;
+my ($d, $opts) = @_;
 return $opts->{'db'} ? ( "DB" ) : ( );
 }
 
@@ -67,22 +67,22 @@ return $opts->{'db'} ? ( "DB" ) : ( );
 # Returns HTML for table rows for options for installing PHP-NUKE
 sub script_squirrelmail_params
 {
-local ($d, $ver, $upgrade) = @_;
-local $rv;
-local $hdir = &public_html_dir($d, 1);
+my ($d, $ver, $upgrade) = @_;
+my $rv;
+my $hdir = &public_html_dir($d, 1);
 if ($upgrade) {
 	# Options are fixed when upgrading
-	local ($dbtype, $dbname) = split(/_/, $upgrade->{'opts'}->{'db'}, 2);
+	my ($dbtype, $dbname) = split(/_/, $upgrade->{'opts'}->{'db'}, 2);
 	if ($dbtype) {
 		$rv .= &ui_table_row("Database for SquirrelMail preferences", $dbname);
 		}
-	local $dir = $upgrade->{'opts'}->{'dir'};
+	my $dir = $upgrade->{'opts'}->{'dir'};
 	$dir =~ s/^$d->{'home'}\///;
 	$rv .= &ui_table_row("Install directory", $dir);
 	}
 else {
 	# Show editable install options
-	local @dbs = &domain_databases($d, [ "mysql" ]);
+	my @dbs = &domain_databases($d, [ "mysql" ]);
 	if (@dbs) {
 		$rv .= &ui_table_row("Database for SquirrelMail preferences",
 		     &ui_radio("db_def", 1, [ [ 1, "None" ],
@@ -102,16 +102,16 @@ return $rv;
 # Returns either a hash ref of parsed options, or an error string
 sub script_squirrelmail_parse
 {
-local ($d, $ver, $in, $upgrade) = @_;
+my ($d, $ver, $in, $upgrade) = @_;
 if ($upgrade) {
 	# Options are always the same
 	return $upgrade->{'opts'};
 	}
 else {
-	local $hdir = &public_html_dir($d, 0);
+	my $hdir = &public_html_dir($d, 0);
 	$in{'dir_def'} || $in{'dir'} =~ /\S/ && $in{'dir'} !~ /\.\./ ||
 		return "Missing or invalid installation directory";
-	local $dir = $in{'dir_def'} ? $hdir : "$hdir/$in{'dir'}";
+	my $dir = $in{'dir_def'} ? $hdir : "$hdir/$in{'dir'}";
 	return { 'db' => $in{'db_def'} ? undef : $in->{'db'},
 		 'dir' => $dir,
 		 'path' => $in{'dir_def'} ? "/" : "/$in{'dir'}", };
@@ -122,14 +122,14 @@ else {
 # Returns an error message if a required option is missing or invalid
 sub script_squirrelmail_check
 {
-local ($d, $ver, $opts, $upgrade) = @_;
+my ($d, $ver, $opts, $upgrade) = @_;
 $opts->{'dir'} =~ /^\// || return "Missing or invalid install directory";
 if (-r "$opts->{'dir'}/config/config.php") {
 	return "SquirrelMail appears to be already installed in the selected directory";
 	}
 if ($opts->{'db'}) {
-	local ($dbtype, $dbname) = split(/_/, $opts->{'db'}, 2);
-	local $clash = &find_database_table($dbtype, $dbname, "userprefs|address|global_abook");
+	my ($dbtype, $dbname) = split(/_/, $opts->{'db'}, 2);
+	my $clash = &find_database_table($dbtype, $dbname, "userprefs|address|global_abook");
 	$clash && return "SquirrelMail appears to be already using the selected database (table $clash)";
 	}
 return undef;
@@ -140,8 +140,8 @@ return undef;
 # containing a name, filename and URL
 sub script_squirrelmail_files
 {
-local ($d, $ver, $opts, $upgrade) = @_;
-local @files = ( { 'name' => "source",
+my ($d, $ver, $opts, $upgrade) = @_;
+my @files = ( { 'name' => "source",
 	   'file' => "squirrelmail-$ver.tar.gz",
 	   'nocheck' => 1,
 	   'url' => "http://prdownloads.sourceforge.net/squirrelmail/squirrelmail-webmail-$ver.tar.gz" },
@@ -163,15 +163,15 @@ return ("tar", "gunzip");
 # message, or 0 and an error
 sub script_squirrelmail_install
 {
-local ($d, $version, $opts, $files, $upgrade) = @_;
-local ($out, $ex);
-local ($dbtype, $dbname) = split(/_/, $opts->{'db'}, 2);
-local $dbuser = $dbtype eq "mysql" ? &mysql_user($d) : &postgres_user($d);
-local $dbpass = $dbtype eq "mysql" ? &mysql_pass($d) : &postgres_pass($d, 1);
-local $dbphptype = $dbtype eq "mysql" ? "mysql" : "psql";
-local $dbhost = &get_database_host($dbtype, $d);
+my ($d, $version, $opts, $files, $upgrade) = @_;
+my ($out, $ex);
+my ($dbtype, $dbname) = split(/_/, $opts->{'db'}, 2);
+my $dbuser = $dbtype eq "mysql" ? &mysql_user($d) : &postgres_user($d);
+my $dbpass = $dbtype eq "mysql" ? &mysql_pass($d) : &postgres_pass($d, 1);
+my $dbphptype = $dbtype eq "mysql" ? "mysql" : "psql";
+my $dbhost = &get_database_host($dbtype, $d);
 if ($dbtype) {
-	local $dberr = &check_script_db_connection(
+	my $dberr = &check_script_db_connection(
 		$d, $dbtype, $dbname, $dbuser, $dbpass);
 	return (0, "Database connection failed : $dberr") if ($dberr);
 	}
@@ -182,25 +182,25 @@ if ($upgrade) {
 	}
 
 # Extract tar file to temp dir and copy to target
-local $temp = &transname();
-local $err = &extract_script_archive($files->{'source'}, $temp, $d,
+my $temp = &transname();
+my $err = &extract_script_archive($files->{'source'}, $temp, $d,
 			     $opts->{'dir'}, "squirrelmail-webmail-$ver");
 $err && return (0, "Failed to extract source : $err");
-local $cprog = "$opts->{'dir'}/config/conf.pl";
+my $cprog = "$opts->{'dir'}/config/conf.pl";
 
 # Extract locales
-local $temp2 = &transname();
-local $err2 = &extract_script_archive($files->{'locales'}, $temp2, $d,
+my $temp2 = &transname();
+my $err2 = &extract_script_archive($files->{'locales'}, $temp2, $d,
 			     $opts->{'dir'}."/locale", "locale");
 $err2 && return (0, "Failed to extract locales : $err2");
 
 if (!$upgrade) {
 	# Run the config program
 	&foreign_require("proc", "proc-lib.pl");
-	local $confcmd = &command_as_user($d->{'user'}, 0,
+	my $confcmd = &command_as_user($d->{'user'}, 0,
 					  "$opts->{'dir'}/config/conf.pl");
 	&clean_environment();
-	local ($fh, $fpid) = &proc::pty_process_exec($confcmd);
+	my ($fh, $fpid) = &proc::pty_process_exec($confcmd);
 	&reset_environment();
 	if (&wait_for($fh, "SquirrelMail", "different one") == 1) {
 		&sysprint($fh, "n\n");
@@ -208,7 +208,7 @@ if (!$upgrade) {
 	foreach my $cmd ([ ">>", "D" ], [ ">>", "courier" ],
 			 [ "any key|enter", "" ], [ ">>", "S" ],
 			 [ "enter", "" ], [ "Q", "Exiting" ]) {
-		local $rv = &wait_for($fh, $cmd->[0]);
+		my $rv = &wait_for($fh, $cmd->[0]);
 		return (0, "Configuration program failed : $wait_for_input")
 			if ($rv < 0);
 		&sysprint($fh, "$cmd->[1]\n");
@@ -219,7 +219,7 @@ if (!$upgrade) {
 	kill('KILL', $fpid);
 	if (&foreign_check("proc")) {
 		&foreign_require("proc", "proc-lib.pl");
-		local @cprocs = grep { $_->{'user'} eq $d->{'user'} &&
+		my @cprocs = grep { $_->{'user'} eq $d->{'user'} &&
 				       $_->{'args'} =~ /conf\.pl/ }
 				     &proc::list_processes();
 		foreach my $cproc (@cprocs) {
@@ -227,20 +227,20 @@ if (!$upgrade) {
 			}
 		}
 
-	local $cfile = "$opts->{'dir'}/config/config.php";
+	my $cfile = "$opts->{'dir'}/config/config.php";
 	-r $cfile || return (-1, "Failed to create config file");
 
 	# Create data directories
-	local $data_dir = "$opts->{'dir'}/data";
+	my $data_dir = "$opts->{'dir'}/data";
 	&make_dir_as_domain_user($d, $data_dir, 0700) if (!-d $data_dir);
 	&make_file_php_writable($d, $data_dir, 1, 1);
-	local $attachment_dir = "$opts->{'dir'}/attach";
+	my $attachment_dir = "$opts->{'dir'}/attach";
 	&make_dir_as_domain_user($d, $attachment_dir, 0700) if (!-d $attachment_dir);
 	&make_file_php_writable($d, $attachment_dir, 1, 1);
 
 	# Update the config file
-	local $lref = &read_file_lines_as_domain_user($d, $cfile);
-	local $dburl = "$dbphptype://$dbuser:".&php_quotemeta($dbpass, 1).
+	my $lref = &read_file_lines_as_domain_user($d, $cfile);
+	my $dburl = "$dbphptype://$dbuser:".&php_quotemeta($dbpass, 1).
 		       "\@$dbhost/$dbname";
 	foreach $l (@$lref) {
 		if ($l =~ /^\$domain\s*=\s*/) {
@@ -306,8 +306,8 @@ if (!$upgrade) {
 	}
 
 # Return a URL for the user
-local $url = &script_path_url($d, $opts);
-local $rp = $opts->{'dir'};
+my $url = &script_path_url($d, $opts);
+my $rp = $opts->{'dir'};
 $rp =~ s/^$d->{'home'}\///;
 return (1, "SquirrelMail installation complete. It can be accessed at <a target=_blank href='$url'>$url</a>.", $dbname ? "Under $rp using $dbphptype database $dbname" : "Under $rp", $url);
 }
@@ -317,14 +317,14 @@ return (1, "SquirrelMail installation complete. It can be accessed at <a target=
 # Returns 1 on success and a message, or 0 on failure and an error
 sub script_squirrelmail_uninstall
 {
-local ($d, $version, $opts) = @_;
+my ($d, $version, $opts) = @_;
 
 # Remove squirrelmail tables from the database
 &cleanup_script_database($d, $opts->{'db'},
 			 [ "address", "global_abook", "userprefs" ]);
 
 # Remove the contents of the target directory
-local $derr = &delete_script_install_directory($d, $opts);
+my $derr = &delete_script_install_directory($d, $opts);
 return (0, $derr) if ($derr);
 
 return (1, $dbname ? "SquirrelMail directory and tables deleted."
@@ -336,8 +336,8 @@ return (1, $dbname ? "SquirrelMail directory and tables deleted."
 # a newer one. Otherwise returns undef.
 sub script_squirrelmail_check_latest
 {
-local ($ver) = @_;
-local @vers = &osdn_package_versions("squirrelmail", "squirrelmail-webmail-([a-z0-9\\.]+)\\.tar\\.gz");
+my ($ver) = @_;
+my @vers = &osdn_package_versions("squirrelmail", "squirrelmail-webmail-([a-z0-9\\.]+)\\.tar\\.gz");
 @vers = grep { !/RC/ } @vers;
 if (&compare_versions($ver, 1.5) > 0) {
 	@vers = grep { &compare_versions($_, 1.5) > 0 } @vers;

--- a/scripts/tikiwiki.pl
+++ b/scripts/tikiwiki.pl
@@ -38,7 +38,7 @@ return "Wiki";
 
 sub script_tikiwiki_php_vers
 {
-local ($d, $ver) = @_;
+my ($d, $ver) = @_;
 if (&compare_versions($ver, "27") >= 0) {
 	return 8.1;
 	}
@@ -59,7 +59,7 @@ return ("mysql");
 # Returns the PHP version to use for this script, or undef if it is not supported
 sub script_tikiwiki_php_fullver
 {
-local ($d, $ver, $sinfo) = @_;
+my ($d, $ver, $sinfo) = @_;
 return &compare_versions($ver, 17) <= 0 ? undef :
        &compare_versions($ver, 22) <= 0 ? "7.2" :
        &compare_versions($ver, 25) <= 0 ? "7.4" : "8.1";
@@ -79,20 +79,20 @@ return ( [ 'memory_limit', '128M', '+' ] );
 # Returns HTML for table rows for options for installing TikiWiki
 sub script_tikiwiki_params
 {
-local ($d, $ver, $upgrade) = @_;
-local $rv;
-local $hdir = &public_html_dir($d, 1);
+my ($d, $ver, $upgrade) = @_;
+my $rv;
+my $hdir = &public_html_dir($d, 1);
 if ($upgrade) {
 	# Options are fixed when upgrading
-	local ($dbtype, $dbname) = split(/_/, $upgrade->{'opts'}->{'db'}, 2);
+	my ($dbtype, $dbname) = split(/_/, $upgrade->{'opts'}->{'db'}, 2);
 	$rv .= &ui_table_row("Database for TikiWiki tables", $dbname);
-	local $dir = $upgrade->{'opts'}->{'dir'};
+	my $dir = $upgrade->{'opts'}->{'dir'};
 	$dir =~ s/^$d->{'home'}\///;
 	$rv .= &ui_table_row("Install directory", $dir);
 	}
 else {
 	# Show editable install options
-	local @dbs = &domain_databases($d, [ "mysql" ]);
+	my @dbs = &domain_databases($d, [ "mysql" ]);
 	$rv .= &ui_table_row("Database for TikiWiki tables",
 		     &ui_database_select("db", undef, \@dbs, $d, "tikiwiki"));
 	$rv .= &ui_table_row("Install sub-directory under <tt>$hdir</tt>",
@@ -107,17 +107,17 @@ return $rv;
 # Returns either a hash ref of parsed options, or an error string
 sub script_tikiwiki_parse
 {
-local ($d, $ver, $in, $upgrade) = @_;
+my ($d, $ver, $in, $upgrade) = @_;
 if ($upgrade) {
 	# Options are always the same
 	return $upgrade->{'opts'};
 	}
 else {
-	local $hdir = &public_html_dir($d, 0);
+	my $hdir = &public_html_dir($d, 0);
 	$in{'dir_def'} || $in{'dir'} =~ /\S/ && $in{'dir'} !~ /\.\./ ||
 		return "Missing or invalid installation directory";
-	local $dir = $in{'dir_def'} ? $hdir : "$hdir/$in{'dir'}";
-	local ($newdb) = ($in->{'db'} =~ s/^\*//);
+	my $dir = $in{'dir_def'} ? $hdir : "$hdir/$in{'dir'}";
+	my ($newdb) = ($in->{'db'} =~ s/^\*//);
 	my $password = &virtual_server::random_password(8);
 	return { 'db' => $in->{'db'},
 		 'newdb' => $newdb,
@@ -132,13 +132,13 @@ else {
 # Returns an error message if a required option is missing or invalid
 sub script_tikiwiki_check
 {
-local ($d, $ver, $opts, $upgrade) = @_;
+my ($d, $ver, $opts, $upgrade) = @_;
 $opts->{'dir'} =~ /^\// || return "Missing or invalid install directory";
 if (-r "$opts->{'dir'}/tiki-install.php") {
 	return "TikiWiki appears to be already installed in the selected directory";
 	}
-local ($dbtype, $dbname) = split(/_/, $opts->{'db'}, 2);
-local $clash = &find_database_table($dbtype, $dbname, "tiki_.*");
+my ($dbtype, $dbname) = split(/_/, $opts->{'db'}, 2);
+my $clash = &find_database_table($dbtype, $dbname, "tiki_.*");
 $clash && return "TikiWiki appears to be already using the selected database (table $clash)";
 return undef;
 }
@@ -148,8 +148,8 @@ return undef;
 # containing a name, filename and URL
 sub script_tikiwiki_files
 {
-local ($d, $ver, $opts, $upgrade) = @_;
-local @files = ( { 'name' => "source",
+my ($d, $ver, $opts, $upgrade) = @_;
+my @files = ( { 'name' => "source",
 	   'file' => "tikiwiki-$ver.zip",
 	   'url' => "http://osdn.dl.sourceforge.net/sourceforge/tikiwiki/tiki-$ver.zip" } );
 return @files;
@@ -165,26 +165,26 @@ return ("unzip");
 # message, or 0 and an error
 sub script_tikiwiki_install
 {
-local ($d, $version, $opts, $files, $upgrade) = @_;
-local ($out, $ex);
+my ($d, $version, $opts, $files, $upgrade) = @_;
+my ($out, $ex);
 if ($opts->{'newdb'} && !$upgrade) {
-	local $dbopts = { 'charset' => 'utf8' };
-        local $err = &create_script_database($d, $opts->{'db'}, $dbopts);
+	my $dbopts = { 'charset' => 'utf8' };
+        my $err = &create_script_database($d, $opts->{'db'}, $dbopts);
         return (0, "Database creation failed : $err") if ($err);
         }
-local ($dbtype, $dbname) = split(/_/, $opts->{'db'}, 2);
-local $dbuser = &mysql_user($d);
-local $dbpass = &mysql_pass($d);
-local $dbhost = &get_database_host($dbtype, $d);
-local $dberr = &check_script_db_connection($d, $dbtype, $dbname, $dbuser, $dbpass);
+my ($dbtype, $dbname) = split(/_/, $opts->{'db'}, 2);
+my $dbuser = &mysql_user($d);
+my $dbpass = &mysql_pass($d);
+my $dbhost = &get_database_host($dbtype, $d);
+my $dberr = &check_script_db_connection($d, $dbtype, $dbname, $dbuser, $dbpass);
 return (0, "Database connection failed : $dberr") if ($dberr);
 
 # Extract tar file to temp dir and copy to target
-local $temp = &transname();
-local $err = &extract_script_archive($files->{'source'}, $temp, $d,
+my $temp = &transname();
+my $err = &extract_script_archive($files->{'source'}, $temp, $d,
                                      $opts->{'dir'}, "tiki-$ver");
 $err && return (0, "Failed to extract source : $err");
-local $cfile = "$opts->{'dir'}/db/local.php";
+my $cfile = "$opts->{'dir'}/db/local.php";
 my $post_install  = $opts->{'install'} == 'y';
 if (!$upgrade) {
 	# Create the config file
@@ -220,9 +220,9 @@ if (! $post_install && !$upgrade) {
 	$password = "";
 }
 
-local $url = &script_path_url($d, $opts);
-local $adminurl = $url.($post_install ? "" : "tiki-install.php");
-local $rp = $opts->{'dir'};
+my $url = &script_path_url($d, $opts);
+my $adminurl = $url.($post_install ? "" : "tiki-install.php");
+my $rp = $opts->{'dir'};
 $rp =~ s/^$d->{'home'}\///;
 if ($upgrade) {
 	return (1, "Initial TikiWiki upgrade complete. Go to <a target=_blank href='$adminurl'>$adminurl</a> to complete the upgrade process.", "Under $rp using $dbtype database $dbname", $url, "admin", "$password");
@@ -237,14 +237,14 @@ else {
 # Returns 1 on success and a message, or 0 on failure and an error
 sub script_tikiwiki_uninstall
 {
-local ($d, $version, $opts) = @_;
+my ($d, $version, $opts) = @_;
 
 # Remove phpbb tables from the database
 &cleanup_script_database($d, $opts->{'db'},
 			 "(tiki_|galaxia_|messu_|sessions|users_|metrics_)");
 
 # Remove the contents of the target directory
-local $derr = &delete_script_install_directory($d, $opts);
+my $derr = &delete_script_install_directory($d, $opts);
 return (0, $derr) if ($derr);
 
 # Take out the DB
@@ -287,8 +287,8 @@ return $db_conn_desc;
 # a newer one. Otherwise returns undef.
 sub script_tikiwiki_check_latest
 {
-local ($ver) = @_;
-local @vers;
+my ($ver) = @_;
+my @vers;
 if ($ver >= 29) {
 	@vers = &osdn_package_versions("tikiwiki/Tiki_29.x_Bellatrix",
 				       "tiki-(29\.[0-9\\.]+)\\.zip");
@@ -334,7 +334,7 @@ return 'http://tiki.org/';
 # setup instance configuration after an fresh installation or an upgrade.
 sub tikiwiki_postinstallation
 {
-local ($d, $upgrade, $opts) = @_;
+my ($d, $upgrade, $opts) = @_;
 my $dom_php_bin = &get_php_cli_command($opts->{'phpver'}) || &has_command("php");
 $dom_php_bin || return (0, "Could not find PHP CLI command");
 my $cmd_prefix = "$dom_php_bin $opts->{'dir'}/console.php";

--- a/scripts/whmcs.pl
+++ b/scripts/whmcs.pl
@@ -55,7 +55,7 @@ return ( 5 );
 
 sub script_whmcs_php_fullver
 {
-local ($d, $ver, $sinfo) = @_;
+my ($d, $ver, $sinfo) = @_;
 return &compare_versions($ver, 8) >= 0 ? 7.2 : 5.6;
 }
 
@@ -79,14 +79,14 @@ return ("mysql");
 # Returns HTML for table rows for options for installing WHMCS
 sub script_whmcs_params
 {
-local ($d, $ver, $upgrade) = @_;
-local $rv;
-local $hdir = &public_html_dir($d, 1);
+my ($d, $ver, $upgrade) = @_;
+my $rv;
+my $hdir = &public_html_dir($d, 1);
 if ($upgrade) {
 	# Options are fixed when upgrading
-	local ($dbtype, $dbname) = split(/_/, $upgrade->{'opts'}->{'db'}, 2);
+	my ($dbtype, $dbname) = split(/_/, $upgrade->{'opts'}->{'db'}, 2);
 	$rv .= &ui_table_row("Database for WHMCS tables", $dbname);
-	local $dir = $upgrade->{'opts'}->{'dir'};
+	my $dir = $upgrade->{'opts'}->{'dir'};
 	$dir =~ s/^$d->{'home'}\///;
 	$rv .= &ui_table_row("Install directory", $dir);
 	$rv .= &ui_table_row("WHMCS licence key",
@@ -94,7 +94,7 @@ if ($upgrade) {
 	}
 else {
 	# Show editable install options
-	local @dbs = &domain_databases($d, [ "mysql", "postgres" ]);
+	my @dbs = &domain_databases($d, [ "mysql", "postgres" ]);
 	$rv .= &ui_table_row("Database for WHMCS tables",
 		     &ui_database_select("db", undef, \@dbs, $d, "whmcs"));
 	$rv .= &ui_table_row("Install sub-directory under <tt>$hdir</tt>",
@@ -111,17 +111,17 @@ return $rv;
 # Returns either a hash ref of parsed options, or an error string
 sub script_whmcs_parse
 {
-local ($d, $ver, $in, $upgrade) = @_;
+my ($d, $ver, $in, $upgrade) = @_;
 if ($upgrade) {
 	# Options are always the same
 	return $upgrade->{'opts'};
 	}
 else {
-	local $hdir = &public_html_dir($d, 0);
+	my $hdir = &public_html_dir($d, 0);
 	$in{'dir_def'} || $in{'dir'} =~ /\S/ && $in{'dir'} !~ /\.\./ ||
 		return "Missing or invalid installation directory";
-	local $dir = $in{'dir_def'} ? $hdir : "$hdir/$in{'dir'}";
-	local ($newdb) = ($in->{'db'} =~ s/^\*//);
+	my $dir = $in{'dir_def'} ? $hdir : "$hdir/$in{'dir'}";
+	my ($newdb) = ($in->{'db'} =~ s/^\*//);
 	$in{'licensekey'} =~ s/^\s*//;
 	$in{'licensekey'} =~ s/\s*$//;
 	$in{'licensekey'} =~ /^\S+$/ ||
@@ -139,15 +139,15 @@ else {
 # Returns an error message if a required option is missing or invalid
 sub script_whmcs_check
 {
-local ($d, $ver, $opts, $upgrade) = @_;
+my ($d, $ver, $opts, $upgrade) = @_;
 $opts->{'licensekey'} || return "Missing licensekey option - licenses can be purchased at http://www.whmcs.com/members/aff.php?aff=4115";
 $opts->{'dir'} =~ /^\// || return "Missing or invalid install directory";
 $opts->{'db'} || return "Missing database";
 if (-r "$opts->{'dir'}/configuration.php") {
 	return "WHMCS appears to be already installed in the selected directory";
 	}
-local ($dbtype, $dbname) = split(/_/, $opts->{'db'}, 2);
-local $clash = &find_database_table($dbtype, $dbname, "tbl");
+my ($dbtype, $dbname) = split(/_/, $opts->{'db'}, 2);
+my $clash = &find_database_table($dbtype, $dbname, "tbl");
 $clash && return "WHMCS appears to be already using the selected database (table $clash)";
 
 # Check for PHP mode
@@ -155,15 +155,15 @@ $clash && return "WHMCS appears to be already using the selected database (table
 	return "WHMCS cannot be installed when PHP is being run via mod_php";
 
 # Check if ioncube loader can be found
-local $io = &script_whmcs_get_ioncube_type();
+my $io = &script_whmcs_get_ioncube_type();
 $io || return "No ionCube loader for your operating system and CPU ".
 	      "architecture could be found";
 
 # Validate the licence
-local $params = "key=".&urlize($whmcs_api_key).
+my $params = "key=".&urlize($whmcs_api_key).
 	        "&licensekey=".&urlize($opts->{'licensekey'});
 
-local ($out, $err);
+my ($out, $err);
 &http_download($whmcs_api_host, $whmcs_api_port, $whmcs_api_prefix."?".$params,
 	       \$out, \$err, undef, $whmcs_api_ssl, undef, undef, undef, 0, 1);
 if ($err) {
@@ -196,14 +196,14 @@ return undef;
 # containing a name, filename and URL
 sub script_whmcs_files
 {
-local ($d, $ver, $opts, $upgrade) = @_;
-local $shortver = $ver;
+my ($d, $ver, $opts, $upgrade) = @_;
+my $shortver = $ver;
 $shortver =~ s/\.//g;
-local @files = ( {
+my @files = ( {
     'name' => "source",
     'file' => "whmcs_v${shortver}.zip",
     'url' => "https://scripts.virtualmin.com/whmcs_v${shortver}.zip" } );
-local $io = &script_whmcs_get_ioncube_type();
+my $io = &script_whmcs_get_ioncube_type();
 push(@files, {
     'name' => "ioncube",
     'file' => "ioncube_loaders.zip",
@@ -213,8 +213,8 @@ return @files;
 
 sub script_whmcs_get_ioncube_type
 {
-local $io;
-local $arch = &backquote_command("uname -m");
+my $io;
+my $arch = &backquote_command("uname -m");
 if ($gconfig{'os_type'} eq 'solaris' && $arch =~ /sparc/) {
 	$io = "sun_sparc";
 	}
@@ -259,66 +259,66 @@ return ("unzip");
 # message, or 0 and an error
 sub script_whmcs_install
 {
-local ($d, $version, $opts, $files, $upgrade, $domuser, $dompass) = @_;
+my ($d, $version, $opts, $files, $upgrade, $domuser, $dompass) = @_;
 
 # Get DB details
-local ($out, $ex);
+my ($out, $ex);
 if ($opts->{'newdb'} && !$upgrade) {
-	local $err = &create_script_database($d, $opts->{'db'});
+	my $err = &create_script_database($d, $opts->{'db'});
 	return (0, "Database creation failed : $err") if ($err);
 	}
-local ($dbtype, $dbname) = split(/_/, $opts->{'db'}, 2);
-local $dbuser = $dbtype eq "mysql" ? &mysql_user($d) : &postgres_user($d);
-local $dbpass = $dbtype eq "mysql" ? &mysql_pass($d) : &postgres_pass($d, 1);
-local $dbphptype = $dbtype eq "mysql" ? "mysql" : "psql";
-local $dbhost = &get_database_host($dbtype, $d);
-local $dberr = &check_script_db_connection(
+my ($dbtype, $dbname) = split(/_/, $opts->{'db'}, 2);
+my $dbuser = $dbtype eq "mysql" ? &mysql_user($d) : &postgres_user($d);
+my $dbpass = $dbtype eq "mysql" ? &mysql_pass($d) : &postgres_pass($d, 1);
+my $dbphptype = $dbtype eq "mysql" ? "mysql" : "psql";
+my $dbhost = &get_database_host($dbtype, $d);
+my $dberr = &check_script_db_connection(
 	$d, $dbtype, $dbname, $dbuser, $dbpass);
 return (0, "Database connection failed : $dberr") if ($dberr);
 
 # Extract ioncube loader
-local $iotemp = &transname();
-local $err = &extract_script_archive($files->{'ioncube'}, $iotemp, $d);
+my $iotemp = &transname();
+my $err = &extract_script_archive($files->{'ioncube'}, $iotemp, $d);
 $err && return (0, "Failed to extract ionCube files : $err");
-local $io = &script_whmcs_get_ioncube_type();
-local $phpver = &get_php_version($opts->{'phpver'});
+my $io = &script_whmcs_get_ioncube_type();
+my $phpver = &get_php_version($opts->{'phpver'});
 $phpver =~ s/^(\d+\.\d+)\..*$/$1/;
-local ($sofile) = glob("$iotemp/ioncube/ioncube_loader_*_$phpver.so");
+my ($sofile) = glob("$iotemp/ioncube/ioncube_loader_*_$phpver.so");
 $sofile ||
 	return (0, "No ionCube loader for PHP version $phpver found in file");
 
 # Extract tar file to temp dir and copy to target
-local $temp = &transname();
-local $cfile = "$opts->{'dir'}/configuration.php";
-local $cfilesrc = "$opts->{'dir'}/configuration.php.new";
-local $err = &extract_script_archive($files->{'source'}, $temp, $d,
+my $temp = &transname();
+my $cfile = "$opts->{'dir'}/configuration.php";
+my $cfilesrc = "$opts->{'dir'}/configuration.php.new";
+my $err = &extract_script_archive($files->{'source'}, $temp, $d,
 				     $opts->{'dir'}, "whmcs");
 $err && return (0, "Failed to extract source : $err");
 
 # Apply security patches, if needed
 foreach my $k (keys %$files) {
 	if ($k =~ /^patch/) {
-		local $ptemp = &transname();
-		local $err = &extract_script_archive($files->{$k}, $ptemp, $d,
+		my $ptemp = &transname();
+		my $err = &extract_script_archive($files->{$k}, $ptemp, $d,
 						     $opts->{'dir'});
 		$err && return (0, "Failed to extract patch source : $err");
 		}
 	}
 
 # Copy loader to ~/etc , adjust php.ini
-local $inifile = &get_domain_php_ini($d, $opts->{'phpver'});
+my $inifile = &get_domain_php_ini($d, $opts->{'phpver'});
 $inifile && -r $inifile || return (0, "PHP configuration file was not found!");
 $sofile =~ /\/([^\/]+)$/;
-local $sodest = "$d->{'home'}/etc/$1";
+my $sodest = "$d->{'home'}/etc/$1";
 &copy_source_dest_as_domain_user($d, $sofile, $sodest);
 &foreign_require("phpini", "phpini-lib.pl");
-local $conf = &phpini::get_config($inifile);
-local @allzends = grep { $_->{'name'} eq 'zend_extension' } @$conf;
-local @zends = grep { $_->{'enabled'} } @allzends;
-local ($got) = grep { $_->{'value'} eq $sodest } @zends;
+my $conf = &phpini::get_config($inifile);
+my @allzends = grep { $_->{'name'} eq 'zend_extension' } @$conf;
+my @zends = grep { $_->{'enabled'} } @allzends;
+my ($got) = grep { $_->{'value'} eq $sodest } @zends;
 if (!$got) {
 	# Needs to be enabled
-	local $lref = &read_file_lines($inifile);
+	my $lref = &read_file_lines($inifile);
 	if (@zends) {
 		# After current extensions
 		splice(@$lref, $zends[$#zends]->{'line'}+1, 0,
@@ -362,10 +362,10 @@ if (!-r $cfile) {
 	}
 
 # Run install script
-local $ipath = $opts->{'path'}."/install/install.php";
+my $ipath = $opts->{'path'}."/install/install.php";
 if (!$upgrade) {
 	# Fetch config check page
-	local ($out, $err);
+	my ($out, $err);
 	&get_http_connection($d, $ipath."?step=2", \$out, \$err);
 	if ($err) {
 		return (-1, "Failed to fetch system check page : $err");
@@ -375,7 +375,7 @@ if (!$upgrade) {
 		}
 
 	# Post to DB setup page
-	local @params = (
+	my @params = (
 		[ "licenseKey", $opts->{'licensekey'} ],
 		[ "databaseHost", $dbhost ],
 		[ "databasePort", 3306 ],
@@ -383,8 +383,8 @@ if (!$upgrade) {
 		[ "databasePassword", $dbpass ],
 		[ "databaseName", $dbname ],
 		);
-	local $params = join("&", map { $_->[0]."=".&urlize($_->[1]) } @params);
-	local ($out, $err);
+	my $params = join("&", map { $_->[0]."=".&urlize($_->[1]) } @params);
+	my ($out, $err);
 	&post_http_connection($d, $ipath."?step=4", $params, \$out, \$err);
 	if ($err) {
 		return (-1, "Database setup page failed : $err");
@@ -394,14 +394,14 @@ if (!$upgrade) {
 		}
 
 	# Post to user creation page
-	local $firstname = $d->{'owner'};
+	my $firstname = $d->{'owner'};
 	$firstname =~ s/\s.*$//;
 	$firstname =~ s/['"]//g;
 	$firstname ||= $d->{'dom'};
 	if (length($dompass) <= 5) {
 		$dompass .= "1!aA45";
 		}
-	local @params = (
+	my @params = (
 		[ "firstName", $firstname ],
 		[ "lastName", "Virtualmin" ],
 		[ "email", $d->{'emailto_addr'} ],
@@ -409,8 +409,8 @@ if (!$upgrade) {
 		[ "password", $dompass ],
 		[ "confirmPassword", $dompass ],
 		);
-	local $params = join("&", map { $_->[0]."=".&urlize($_->[1]) } @params);
-	local ($out, $err);
+	my $params = join("&", map { $_->[0]."=".&urlize($_->[1]) } @params);
+	my ($out, $err);
 	&post_http_connection($d, $ipath."?step=5", $params, \$out, \$err);
 	if ($err) {
 		return (-1, "Account creation page failed : $err");
@@ -421,7 +421,7 @@ if (!$upgrade) {
 	}
 else {
 	# Fetch config check page
-	local ($out, $err);
+	my ($out, $err);
 	&get_http_connection($d, $ipath."?step=2", \$out, \$err);
 	if ($err) {
 		return (-1, "Failed to fetch upgrade check page : $err");
@@ -431,11 +431,11 @@ else {
 		}
 
 	# Post to DB upgrade page
-	local @params = (
+	my @params = (
 		[ "confirmBackup", 1 ],
 		);
-	local $params = join("&", map { $_->[0]."=".&urlize($_->[1]) } @params);
-	local ($out, $err);
+	my $params = join("&", map { $_->[0]."=".&urlize($_->[1]) } @params);
+	my ($out, $err);
 	&post_http_connection($d, $ipath."?step=upgrade", $params, \$out, \$err);
 	if ($err) {
 		return (-1, "Database upgrade page failed : $err");
@@ -446,7 +446,7 @@ else {
 	}
 
 # Setup cron job
-local $url = &script_path_url($d, $opts);
+my $url = &script_path_url($d, $opts);
 if (!$upgrade) {
 	&create_script_wget_job($d, $url."admin/cron.php",
 			        '0', int(rand()*24), 1);
@@ -456,9 +456,9 @@ if (!$upgrade) {
 &unlink_file_as_domain_user($d, "$opts->{'dir'}/install");
 
 # Return a URL for the user
-local $rp = $opts->{'dir'};
+my $rp = $opts->{'dir'};
 $rp =~ s/^$d->{'home'}\///;
-local $adminurl = $url."admin/";
+my $adminurl = $url."admin/";
 my $installtype = $upgrade ? 'upgrade' : 'installation';
 return (1, "WHMCS $installtype complete. It can be accessed at <a href=$url target=_blank>$url</a> and managed at <a href=$adminurl target=_blank>$adminurl</a>. For more information, see <a href=http://docs.whmcs.com/Installing_WHMCS target=_blank>http://docs.whmcs.com/Installing_WHMCS</a> and <a href=http://docs.whmcs.com/Virtualmin_Pro target=_blank>http://docs.whmcs.com/Virtualmin_Pro</a>.",
 	"Under $rp using $dbphptype database $dbname", $url,
@@ -470,7 +470,7 @@ return (1, "WHMCS $installtype complete. It can be accessed at <a href=$url targ
 # Returns 1 on success and a message, or 0 on failure and an error
 sub script_whmcs_uninstall
 {
-local ($d, $version, $opts) = @_;
+my ($d, $version, $opts) = @_;
 
 # Remove tbl* tables from the database
 &cleanup_script_database($d, $opts->{'db'}, "(tbl|mod_)");
@@ -479,7 +479,7 @@ local ($d, $version, $opts) = @_;
 &delete_script_wget_job($d, $sinfo->{'url'}."admin/cron.php");
 
 # Remove the contents of the target directory
-local $derr = &delete_script_install_directory($d, $opts);
+my $derr = &delete_script_install_directory($d, $opts);
 return (0, $derr) if ($derr);
 
 # Take out the DB
@@ -514,8 +514,8 @@ return $db_conn_desc;
 
 sub script_whmcs_latest
 {
-local ($ver) = @_;
-local $vwant = &compare_versions($ver, "9") >= 0 ? "9" :
+my ($ver) = @_;
+my $vwant = &compare_versions($ver, "9") >= 0 ? "9" :
 	       &compare_versions($ver, "8.13") >= 0 ? "8\\.13" : undef;
 if ($vwant) {
 	return ( "https://download.whmcs.com/assets/scripts/get-downloads.php",

--- a/scripts/wordpress.pl
+++ b/scripts/wordpress.pl
@@ -153,7 +153,7 @@ else {
 # Returns an error message if a required option is missing or invalid
 sub script_wordpress_check
 {
-local ($d, $ver, $opts, $upgrade) = @_;
+my ($d, $ver, $opts, $upgrade) = @_;
 $opts->{'dir'} =~ /^\// || return "Missing or invalid install directory";
 $opts->{'db'} || return "Missing database";
 if (-r "$opts->{'dir'}/wp-login.php") {
@@ -196,7 +196,7 @@ return ("unzip");
 # message, or 0 and an error
 sub script_wordpress_install
 {
-local ($d, $version, $opts, $files, $upgrade, $domuser, $dompass) = @_;
+my ($d, $version, $opts, $files, $upgrade, $domuser, $dompass) = @_;
 my ($out, $ex);
 if ($opts->{'newdb'} && !$upgrade) {
         my $err = create_script_database($d, $opts->{'db'});

--- a/scriptwarn.pl
+++ b/scriptwarn.pl
@@ -123,7 +123,7 @@ foreach my $u (@updates) {
 
 sub send_scriptwarn_email
 {
-local ($text, $emailto, $d) = @_;
+my ($text, $emailto, $d) = @_;
 if ($debug_mode) {
 	print STDERR "Sending to ",join(", ", @$emailto),"\n";
 	print STDERR "Sending from ",&get_global_from_address($d),"\n";

--- a/security-lib.pl
+++ b/security-lib.pl
@@ -53,41 +53,41 @@ else {
 # Runs some command as the owner of a virtual server, and returns the output
 sub run_as_domain_user
 {
-local ($d, $cmd, $bg, $nosu) = @_;
+my ($d, $cmd, $bg, $nosu) = @_;
 if ($d->{'parent'}) {
 	$d = &get_domain($d->{'parent'});
 	}
 
 # Set a reasonable environment for the command
-local %OLDENV = %ENV;
+my %OLDENV = %ENV;
 $ENV{'HOME'} = $uinfo[7];
 $ENV{'USER'} = $uinfo[0];
 $ENV{'LOGNAME'} = $uinfo[0];
 
 &foreign_require("proc");
-local @uinfo = getpwnam($d->{'user'});
-local @rv;
+my @uinfo = getpwnam($d->{'user'});
+my @rv;
 if (($uinfo[8] =~ /\/(sh|bash|tcsh|csh)$/ ||
      $gconfig{'os_type'} =~ /-linux$/) && !$nosu) {
 	# Usable shell .. use su
-	local $cmd = &command_as_user($d->{'user'}, 0, $cmd);
+	my $cmd = &command_as_user($d->{'user'}, 0, $cmd);
 	if ($bg) {
 		# No status available
 		&system_logged("$cmd &");
 		@rv = ( undef, 0 );
 		}
 	else {
-		local $out = &backquote_logged($cmd);
+		my $out = &backquote_logged($cmd);
 		@rv = ( $out, $? );
 		}
 	}
 else {
 	# Need to run ourselves
-	local $temp = &transname();
+	my $temp = &transname();
 	open(TEMP, ">$temp");
 	&proc::safe_process_exec_logged($cmd, $d->{'uid'}, $d->{'ugid'},\*TEMP);
-	local $ex = $?;
-	local $out;
+	my $ex = $?;
+	my $out;
 	close(TEMP);
 	local $_;
 	open(TEMP, "<".$temp);
@@ -113,12 +113,12 @@ sub make_dir_as_domain_user
 {
 my ($d, $dir, $perms, $recur) = @_;
 return 1 if (&is_readonly_mode());
-local $cmd = "mkdir ".($recur ? "-p " : "").quotemeta($dir)." 2>&1";;
+my $cmd = "mkdir ".($recur ? "-p " : "").quotemeta($dir)." 2>&1";;
 if ($perms) {
 	$cmd .= " && chmod ".sprintf("%o", $perms & 07777)." ".
 			     quotemeta($dir)." 2>&1";;
 	}
-local ($out, $ex) = &run_as_domain_user($d, $cmd);
+my ($out, $ex) = &run_as_domain_user($d, $cmd);
 return $ex ? 0 : 1;
 }
 
@@ -138,8 +138,8 @@ while(@files) {
 		@del = @files;
 		@files = ( );
 		}
-	local $cmd = "rm -rf ".join(" ", map { quotemeta($_) } @del)." 2>&1";
-	local ($out, $ex) = &run_as_domain_user($d, $cmd);
+	my $cmd = "rm -rf ".join(" ", map { quotemeta($_) } @del)." 2>&1";
+	my ($out, $ex) = &run_as_domain_user($d, $cmd);
 	return wantarray ? ($ex ? 0 : 1, $out) : $ex ? 0 : 1;
 	}
 return wantarray ? (1) : 1;
@@ -172,8 +172,8 @@ sub symlink_file_as_domain_user
 {
 my ($d, $src, $dest) = @_;
 return 1 if (&is_readonly_mode());
-local $cmd = "ln -s ".quotemeta($src)." ".quotemeta($dest)." 2>&1";
-local ($out, $ex) = &run_as_domain_user($d, $cmd);
+my $cmd = "ln -s ".quotemeta($src)." ".quotemeta($dest)." 2>&1";
+my ($out, $ex) = &run_as_domain_user($d, $cmd);
 return $ex ? 0 : 1;
 }
 
@@ -193,8 +193,8 @@ sub link_file_as_domain_user
 {
 my ($d, $src, $dest) = @_;
 return 1 if (&is_readonly_mode());
-local $cmd = "ln ".quotemeta($src)." ".quotemeta($dest)." 2>&1";
-local ($out, $ex) = &run_as_domain_user($d, $cmd);
+my $cmd = "ln ".quotemeta($src)." ".quotemeta($dest)." 2>&1";
+my ($out, $ex) = &run_as_domain_user($d, $cmd);
 return $ex ? 0 : 1;
 }
 

--- a/set-dkim.pl
+++ b/set-dkim.pl
@@ -41,7 +41,7 @@ if (!$module_name) {
 # Parse command-line args
 if (@ARGV > 0) {
 		while(@ARGV > 0) {
-		local $a = shift(@ARGV);
+		my $a = shift(@ARGV);
 		if ($a eq "--enable") {
 			$enabled = 1;
 			}

--- a/set-global-feature.pl
+++ b/set-global-feature.pl
@@ -39,7 +39,7 @@ if (!$module_name) {
 
 # Parse command-line args
 while(@ARGV > 0) {
-	local $a = shift(@ARGV);
+	my $a = shift(@ARGV);
 	if ($a eq "--enable-feature") {
 		push(@enable, shift(@ARGV));
 		}

--- a/set-mysql-pass.pl
+++ b/set-mysql-pass.pl
@@ -33,7 +33,7 @@ if (!$module_name) {
 &require_mysql();
 $user = $mysql::config{'login'};
 while(@ARGV > 0) {
-	local $a = shift(@ARGV);
+	my $a = shift(@ARGV);
 	if ($a eq "--pass") {
 		$pass = shift(@ARGV);
 		}

--- a/set-php-directory.pl
+++ b/set-php-directory.pl
@@ -35,7 +35,7 @@ if (!$module_name) {
 # Parse command-line args
 $owner = 1;
 while(@ARGV > 0) {
-	local $a = shift(@ARGV);
+	my $a = shift(@ARGV);
 	if ($a eq "--domain") {
 		$domain = shift(@ARGV);
 		}

--- a/set-spam.pl
+++ b/set-spam.pl
@@ -52,7 +52,7 @@ $config{'spam'} || &usage("Spam filtering is not enabled for Virtualmin");
 
 # Parse command-line args
 while(@ARGV > 0) {
-	local $a = shift(@ARGV);
+	my $a = shift(@ARGV);
 	if ($a =~ /^--use-(spamc|spamassassin)$/) {
 		$spam_client = $1;
 		}
@@ -146,8 +146,8 @@ $new_virus_host = defined($virus_host) ? $virus_host
 
 # Make sure the new virus scanner works
 if ($virus_scanner || $virus_host) {
-	local ($cmd, @args) = &split_quoted_string($new_virus_scanner);
-	local $shcmd = $cmd eq "clamdscan-remote" ? "clamdscan" : $cmd;
+	my ($cmd, @args) = &split_quoted_string($new_virus_scanner);
+	my $shcmd = $cmd eq "clamdscan-remote" ? "clamdscan" : $cmd;
 	&has_command($shcmd) ||
 		&usage("Virus scanning command $shcmd does not exist");
 	if (!$clamd || $new_virus_scanner ne "clamdscan") {

--- a/setup-repos.pl
+++ b/setup-repos.pl
@@ -43,7 +43,7 @@ if (!$module_name) {
 
 # Parse args
 while(@ARGV > 0) {
-	local $a = shift(@ARGV);
+	my $a = shift(@ARGV);
 	if ($a eq "--branch") {
 		$branch = shift(@ARGV);
 		&usage("Invalid branch '$branch', must be one of ".

--- a/simple-lib.pl
+++ b/simple-lib.pl
@@ -8,10 +8,10 @@ use Time::Local;
 # return undef.
 sub get_simple_alias
 {
-local ($d, $a, $allow_merge) = @_;
-local $simple;
+my ($d, $a, $allow_merge) = @_;
+my $simple;
 foreach my $v (@{$a->{'to'}}) {
-	local ($atype, $aval) = &alias_type($v, $a->{'user'} || $a->{'name'});
+	my ($atype, $aval) = &alias_type($v, $a->{'user'} || $a->{'name'});
 	if ($atype == 1) {
 		# Forward to an address
 		push(@{$simple->{'forward'}}, $aval);
@@ -43,9 +43,9 @@ foreach my $v (@{$a->{'to'}}) {
 		$simple->{'autoreply'} = $aval =~ /^\// ? $aval
 							: "$d->{'home'}/$aval";
 		$simple->{'auto'} = 1;
-		local $l = &read_autoreply(&command_as_user($d->{'user'}, 0,
+		my $l = &read_autoreply(&command_as_user($d->{'user'}, 0,
 		    "cat ".quotemeta($simple->{'autoreply'}))." |", $simple);
-		local @st = stat($simple->{'autoreply'});
+		my @st = stat($simple->{'autoreply'});
 		if ($st[7] && !$l) {
 			# Fall back to reading directly, if allowed
 			if ($st[4] == $d->{'uid'}) {
@@ -77,10 +77,10 @@ return $simple;
 # Updates a simple alias object with setting from an autoreply file
 sub read_autoreply
 {
-local ($file, $simple) = @_;
-local @lines;
+my ($file, $simple) = @_;
+my @lines;
 local $_;
-local $lines;
+my $lines;
 open(FILE, "<".$file);
 while(<FILE>) {
 	if (/^Reply-Tracking:\s*(.*)/) {
@@ -137,8 +137,8 @@ return $lines;
 # file needed
 sub save_simple_alias
 {
-local ($d, $alias, $simple) = @_;
-local @v;
+my ($d, $alias, $simple) = @_;
+my @v;
 push(@v, @{$simple->{'forward'}});
 if ($simple->{'bounce'}) {
 	push(@v, "BOUNCE");
@@ -146,7 +146,7 @@ if ($simple->{'bounce'}) {
 if ($simple->{'local'} &&
     (!$simple->{'local-all'} ||
      &indexof($simple->{'local'}, @{$simple->{'local-all'}}) == -1)) {
-	local $escuser = $simple->{'local'};
+	my $escuser = $simple->{'local'};
 	if ($mail_system == 0 && $escuser =~ /\@/) {
 		$escuser = &escape_replace_atsign_if_exists($escuser);
 		}
@@ -156,7 +156,7 @@ if ($simple->{'local'} &&
 	push(@v, "\\".$escuser);
 	}
 if ($simple->{'tome'}) {
-	local $escuser = $alias->{'user_extra'} || $alias->{'user'};
+	my $escuser = $alias->{'user_extra'} || $alias->{'user'};
 	if ($mail_system == 0 && $escuser =~ /\@/) {
 		$escuser = &escape_replace_atsign_if_exists($escuser);
 		}
@@ -165,12 +165,12 @@ if ($simple->{'tome'}) {
 		}
 	push(@v, "\\".($escuser || $alias->{'name'}));
 	}
-local $who = $alias->{'user'} || $alias->{'from'};
+my $who = $alias->{'user'} || $alias->{'from'};
 if ($simple->{'auto'} || $simple->{'autotext'}) {
 	$simple->{'autoreply'} ||= "$d->{'home'}/autoreply-$who.txt";
 	}
 if ($simple->{'auto'}) {
-	local $link = &convert_autoreply_file($d, $simple->{'autoreply'});
+	my $link = &convert_autoreply_file($d, $simple->{'autoreply'});
 	push(@v, "|$module_config_directory/autoreply.pl $simple->{'autoreply'} $who $link");
 	}
 if ($simple->{'everyone'}) {
@@ -185,7 +185,7 @@ $alias->{'cmt'} = $simple->{'cmt'};
 # Save the autoreply file for a simple alias defintion
 sub write_simple_autoreply
 {
-local ($d, $simple) = @_;
+my ($d, $simple) = @_;
 if ($simple->{'autotext'}) {
         # Save autoreply text
         &open_tempfile_as_domain_user($d, AUTO, ">$simple->{'autoreply'}");
@@ -229,7 +229,7 @@ if ($simple->{'autotext'}) {
 
 	# Hard link to the autoreply directory, which is readable by the mail
 	# server, unlike users' homes
-	local $link = &convert_autoreply_file($d, $simple->{'autoreply'});
+	my $link = &convert_autoreply_file($d, $simple->{'autoreply'});
 	if ($link) {
 		&unlink_file_as_domain_user($d, $link);
 		&link_file_as_domain_user($d, $simple->{'autoreply'}, $link) ||
@@ -240,7 +240,7 @@ if ($simple->{'autotext'}) {
 elsif ($simple->{'autoreply'}) {
 	# Clean up old autoreply file
 	&unlink_file_as_domain_user($d, $simple->{'autoreply'});
-	local $link = &convert_autoreply_file($d, $simple->{'autoreply'});
+	my $link = &convert_autoreply_file($d, $simple->{'autoreply'});
 	if ($link) {
 		&unlink_file_as_domain_user($d, $link);
 		}
@@ -252,13 +252,13 @@ elsif ($simple->{'autoreply'}) {
 # being re-saved)
 sub delete_simple_autoreply
 {
-local ($d, $simple) = @_;
+my ($d, $simple) = @_;
 if ($simple->{'auto'} &&
     $simple->{'autoreply'} &&
     $simple->{'autoreply'} =~ /\/autoreply-(\S+)\.txt$/) {
-	local @st = stat($simple->{'autoreply'});
+	my @st = stat($simple->{'autoreply'});
 	if ($st[4] == $d->{'uid'}) {
-		local $link = &convert_autoreply_file(
+		my $link = &convert_autoreply_file(
 			$d, $simple->{'autoreply'});
 		&unlink_file_as_domain_user($d, $simple->{'autoreply'});
 		&unlink_file_as_domain_user($d, $link) if ($link);
@@ -271,7 +271,7 @@ if ($simple->{'auto'} &&
 # Outputs ui_table_row entries for a simple mail forwarding form
 sub show_simple_form
 {
-local ($simple, $nofrom, $nolocal, $nobounce, $noeveryone, $tds, $sfx) = @_;
+my ($simple, $nofrom, $nolocal, $nobounce, $noeveryone, $tds, $sfx) = @_;
 $sfx ||= "alias";
 
 if ($nolocal) {
@@ -366,13 +366,13 @@ print &ui_table_row(&hlink($text{$sfx.'_period'}, $sfx."_period"),
 
 # Autoreply date range
 foreach my $p ('start', 'end') {
-	local @tm;
+	my @tm;
 	if ($simple->{'autoreply_'.$p}) {
 		@tm = localtime($simple->{'autoreply_'.$p});
 		$tm[4]++; $tm[5] += 1900;
 		}
-	local $dis1 = &js_disable_inputs([ 'd'.$p, 'm'.$p, 'y'.$p ], [ ]);
-	local $dis2 = &js_disable_inputs([ ], [ 'd'.$p, 'm'.$p, 'y'.$p ]);
+	my $dis1 = &js_disable_inputs([ 'd'.$p, 'm'.$p, 'y'.$p ], [ ]);
+	my $dis2 = &js_disable_inputs([ ], [ 'd'.$p, 'm'.$p, 'y'.$p ]);
 	print &ui_table_row(&hlink($text{'alias_'.$p}, 'alias_'.$p),
 		&ui_radio($p.'_def', $simple->{'autoreply_'.$p} ? 0 : 1,
 			  [ [ 1, $text{'alias_pdef'}, "onClick='$dis1'" ],
@@ -405,7 +405,7 @@ print &ui_hidden_table_row_end("aopts");
 # Updates a simple delivery object with settings from &in
 sub parse_simple_form
 {
-local ($simple, $in, $d, $nofrom, $nolocal, $nobounce, $name) = @_;
+my ($simple, $in, $d, $nofrom, $nolocal, $nobounce, $name) = @_;
 
 if ($nolocal) {
 	# Check to-me option
@@ -466,9 +466,9 @@ if ($in->{'autotext'}) {
 			}
 		else {
 			# Fix existing file
-			local $adir = &get_autoreply_file_dir();
+			my $adir = &get_autoreply_file_dir();
 			if (!&is_under_directory($adir, $simple->{'replies'})) {
-				local $c = &convert_autoreply_file(
+				my $c = &convert_autoreply_file(
 						$d, "replies-$name");
 				$simple->{'replies'} = $c if ($c);
 				}
@@ -494,9 +494,9 @@ if ($in->{'autotext'}) {
 	# Save autoreply start and end
 	foreach my $p ('start', 'end') {
 		if ($in{'d'.$p}) {
-			local ($s, $m, $h) = $p eq 'start' ? (0, 0, 0) :
+			my ($s, $m, $h) = $p eq 'start' ? (0, 0, 0) :
 						(59, 59, 23);
-			local $tm = timelocal($s, $m, $h, $in{'d'.$p},
+			my $tm = timelocal($s, $m, $h, $in{'d'.$p},
                                         $in{'m'.$p}-1, $in{'y'.$p}-1900);
 			$tm || &error($text{'alias_e'.$p});
 			$simple->{'autoreply_'.$p} = $tm;
@@ -534,10 +534,10 @@ $simple->{'auto'} = $in->{'auto'} && $mb_or_alias;
 # Returns the directory for autoreply file links
 sub get_autoreply_file_dir
 {
-local $autoreply_file_dir = "/var/virtualmin-autoreply";
+my $autoreply_file_dir = "/var/virtualmin-autoreply";
 &require_useradmin();
-local @hst = stat($home_base);
-local @vst = stat("/var");
+my @hst = stat($home_base);
+my @vst = stat("/var");
 if ($hst[0] != $vst[0]) {
 	# /var and /home are on different FS
 	$autoreply_file_dir = "$home_base/virtualmin-autoreply";
@@ -553,10 +553,10 @@ return $autoreply_file_dir;
 # Returns a file in the autoreply directory, for hard linking to
 sub convert_autoreply_file
 {
-local ($d, $file) = @_;
-local $dir = &get_autoreply_file_dir();
+my ($d, $file) = @_;
+my $dir = &get_autoreply_file_dir();
 return undef if (!$dir);
-local $origdir;
+my $origdir;
 if ($file =~ /\/(autoreply-([^\/]+)\.txt)$/) {
 	# Autoreply file in directory
 	$linkpath = "$dir/$d->{'id'}-$1";
@@ -575,8 +575,8 @@ else {
 	$file =~ s/\//_/g;
 	$linkpath = "$dir/$d->{'id'}-$file";
 	}
-local @fst = stat($origdir);
-local @lst = stat($dir);
+my @fst = stat($origdir);
+my @lst = stat($dir);
 if ($fst[0] == $lst[0]) {
 	return $linkpath;
 	}
@@ -592,20 +592,20 @@ else {
 # autoresponders, create hard links and update the aliases to use them.
 sub create_autoreply_alias_links
 {
-local ($d) = @_;
-local $adir = &get_autoreply_file_dir();
+my ($d) = @_;
+my $adir = &get_autoreply_file_dir();
 
 # Fix up aliases
 foreach my $virt (&list_domain_aliases($d)) {
-	local $simple = &get_simple_alias($d, $virt);
+	my $simple = &get_simple_alias($d, $virt);
 	if ($simple && $simple->{'auto'}) {
-		local $link = &convert_autoreply_file(
+		my $link = &convert_autoreply_file(
 			$d, $simple->{'autoreply'});
 		if ($link) {
-			local @st = stat($link);
+			my @st = stat($link);
 			if (!@st || $st[3] == 1) {
 				# Need to create the link, and re-write alias
-				local $oldvirt = { %$virt };
+				my $oldvirt = { %$virt };
 				unlink($link);
 				link($simple->{'autoreply'}, $link);
 				&save_simple_alias($d, $virt, $simple);
@@ -624,15 +624,15 @@ foreach my $virt (&list_domain_aliases($d)) {
 
 # Fix up users
 foreach my $user (&list_domain_users($d)) {
-	local $simple = &get_simple_alias($d, $user);
+	my $simple = &get_simple_alias($d, $user);
 	if ($simple && $simple->{'auto'}) {
-		local $link = &convert_autoreply_file(
+		my $link = &convert_autoreply_file(
 			$d, $simple->{'autoreply'});
 		if ($link) {
-			local @st = stat($link);
+			my @st = stat($link);
 			if (!@st || $st[3] == 1) {
 				# Need to create the link, and re-write alias
-				local $olduser = { %$user };
+				my $olduser = { %$user };
 				unlink($link);
 				link($simple->{'autoreply'}, $link);
 				&save_simple_alias($d, $user, $simple);
@@ -656,12 +656,12 @@ foreach my $user (&list_domain_users($d)) {
 # we want.
 sub break_autoreply_alias_links        
 {                               
-local ($d) = @_;                
-local $adir = &get_autoreply_file_dir();
+my ($d) = @_;
+my $adir = &get_autoreply_file_dir();
 foreach my $virt (&list_domain_aliases($d), &list_domain_users($d)) {
-	local $simple = &get_simple_alias($d, $virt);
+	my $simple = &get_simple_alias($d, $virt);
 	if ($simple && $simple->{'auto'}) {
-		local $link = &convert_autoreply_file(
+		my $link = &convert_autoreply_file(
 			$d, $simple->{'autoreply'});
 		if ($link && -r $link && $link ne $simple->{'autoreply'}) {
 			&unlink_file($link);
@@ -671,4 +671,3 @@ foreach my $virt (&list_domain_aliases($d), &list_domain_users($d)) {
 }
 
 1;
-

--- a/spamclear.pl
+++ b/spamclear.pl
@@ -81,11 +81,11 @@ foreach $d (&list_domains()) {
 		}
 
 	# Work out the spam, virus and trash folders for this domain
-	local $sfname = "spam";
-	local $vfname = "virus";
-	local $tfname = "trash";
-	local $fd = $mailboxes::config{'mail_usermin'};
-	local ($sdmode, $sdpath) = &get_domain_spam_delivery($d);
+	my $sfname = "spam";
+	my $vfname = "virus";
+	my $tfname = "trash";
+	my $fd = $mailboxes::config{'mail_usermin'};
+	my ($sdmode, $sdpath) = &get_domain_spam_delivery($d);
 	if ($sdmode == 1 && $sdpath =~ /^\Q$fd\E\/(.+)$/) {
 		$sfname = lc($1);
 		$sfname =~ s/^\.//;
@@ -94,7 +94,7 @@ foreach $d (&list_domains()) {
 	elsif ($sdmode == 4 || $sdmode == 6) {
 		$sfname = $sdpath;
 		}
-	local ($vdmode, $vdpath) = &get_domain_virus_delivery($d);
+	my ($vdmode, $vdpath) = &get_domain_virus_delivery($d);
 	if ($vdmode == 1 && $vdpath =~ /^\Q$fd\E\/(.+)$/) {
 		$vfname = lc($1);
 		$vfname =~ s/^\.//;
@@ -172,9 +172,9 @@ foreach $d (&list_domains()) {
 
 			# Verify the index on the folder
 			if ($folder->{'type'} == 0) {
-				local $ifile = &mailboxes::user_index_file(
+				my $ifile = &mailboxes::user_index_file(
 						$folder->{'file'});
-				local %index;
+				my %index;
 				eval {
 					&mailboxes::build_dbm_index(
 						$folder->{'file'}, \%index);
@@ -189,7 +189,7 @@ foreach $d (&list_domains()) {
 				}
 
 			# Work out the threshold
-			local ($days, $size);
+			my ($days, $size);
 			if ($fn eq $tfname) {
 				($days, $size) = ($auto->{'trashdays'},
 						  $auto->{'trashsize'});
@@ -263,7 +263,7 @@ foreach $d (&list_domains()) {
 # after being reduced.
 sub process_spam_mails
 {
-local ($mail, $days, $size, $folder, $needsize) = @_;
+my ($mail, $days, $size, $folder, $needsize) = @_;
 my @delmail;
 if ($days) {
 	# Find mail older than some number of days

--- a/spamtrap.pl
+++ b/spamtrap.pl
@@ -177,7 +177,7 @@ foreach $d (&list_domains()) {
 		foreach $lm (@learnm) {
 			print STDERR "$d->{'dom'}: $user->{'user'}: subject=",
 				   "$lm->{'header'}->{'subject'}\n" if ($debug);
-			local $cmd = $m->{'spamtrap'} ? "$salearn --spam"
+			my $cmd = $m->{'spamtrap'} ? "$salearn --spam"
 						      : "$salearn --ham";
 			$cmd = &command_as_user($user->{'user'}, 0, $cmd);
 			$temp = &transname();
@@ -249,7 +249,7 @@ foreach $d (&list_domains()) {
 # find_user_by_email(email, &users, &aliases)
 sub find_user_by_email
 {
-local ($e, $users, $aliasdoms) = @_;
+my ($e, $users, $aliasdoms) = @_;
 $e = lc($e);
 foreach my $u (@$users) {
 	foreach my $ee ($u->{'email'}, @{$u->{'extraemail'}}) {
@@ -258,7 +258,7 @@ foreach my $u (@$users) {
 			return $u;
 			}
 		# Check for same email address in alias domain
-		local ($mb, $dname) = split(/\@/, $ee);
+		my ($mb, $dname) = split(/\@/, $ee);
 		foreach my $ad (@aliasdoms) {
 			if ($e eq $mb."\@".lc($ad->{'dom'})) {
 				return $u;

--- a/start-stop-script.pl
+++ b/start-stop-script.pl
@@ -37,7 +37,7 @@ if (!$module_name) {
 # Parse command-line args
 &set_all_text_print();
 while(@ARGV > 0) {
-	local $a = shift(@ARGV);
+	my $a = shift(@ARGV);
 	if ($a eq "--domain") {
 		$domain = shift(@ARGV);
 		}

--- a/stats-lib.pl
+++ b/stats-lib.pl
@@ -4,7 +4,7 @@
 # Returns a hash ref with info about the units and class of some stat
 sub historic_stat_info
 {
-local ($name, $maxes) = @_;
+my ($name, $maxes) = @_;
 if ($name =~ /count$/) {
 	return { 'type' => 'email', 'units' => $text{'history_messages'} };
 	}

--- a/syncmx-domain.pl
+++ b/syncmx-domain.pl
@@ -35,7 +35,7 @@ if (!$module_name) {
 
 # Parse command-line args
 while(@ARGV > 0) {
-	local $a = shift(@ARGV);
+	my $a = shift(@ARGV);
 	if ($a eq "--domain") {
 		push(@domains, shift(@ARGV));
 		}

--- a/test-imap.pl
+++ b/test-imap.pl
@@ -33,7 +33,7 @@ if (!$module_name) {
 # Parse command-line args
 $server = "localhost";
 while(@ARGV > 0) {
-	local $a = shift(@ARGV);
+	my $a = shift(@ARGV);
 	if ($a eq "--server") {
 		$server = shift(@ARGV);
 		}

--- a/test-pop3.pl
+++ b/test-pop3.pl
@@ -30,7 +30,7 @@ if (!$module_name) {
 $server = "localhost";
 $port = 110;
 while(@ARGV > 0) {
-	local $a = shift(@ARGV);
+	my $a = shift(@ARGV);
 	if ($a eq "--server") {
 		$server = shift(@ARGV);
 		}

--- a/test-smtp.pl
+++ b/test-smtp.pl
@@ -47,7 +47,7 @@ $server = "localhost";
 $from = "nobody\@virtualmin.com";
 $auth = "Plain";
 while(@ARGV > 0) {
-	local $a = shift(@ARGV);
+	my $a = shift(@ARGV);
 	if ($a eq "--server") {
 		$server = shift(@ARGV);
 		}
@@ -137,15 +137,15 @@ eval {
 						'user' => $user,
 						'pass' => $pass } );
 		&error("Failed to create Authen::SASL object") if (!$sasl);
-		local $conn = $sasl->client_new("smtp", &get_system_hostname());
-		local $arv = &mailboxes::smtp_command($h, "auth $auth\r\n", 1);
+		my $conn = $sasl->client_new("smtp", &get_system_hostname());
+		my $arv = &mailboxes::smtp_command($h, "auth $auth\r\n", 1);
 		if ($arv =~ /^(334)(\-\S+)?\s+(.*)/) {
 			# Server says to go ahead
 			$extra = $3;
-			local $initial = $conn->client_start();
-			local $auth_ok;
+			my $initial = $conn->client_start();
+			my $auth_ok;
 			if ($initial) {
-				local $enc = &encode_base64($initial);
+				my $enc = &encode_base64($initial);
 				$enc =~ s/\r|\n//g;
 				$arv = &mailboxes::smtp_command($h, "$enc\r\n", 1);
 				if ($arv =~ /^(\d+)(\-\S+)?\s+(.*)/) {
@@ -159,9 +159,9 @@ eval {
 				$extra = $3;
 				}
 			while(!$auth_ok) {
-				local $message = &decode_base64($extra);
-				local $return = $conn->client_step($message);
-				local $enc = &encode_base64($return);
+				my $message = &decode_base64($extra);
+				my $return = $conn->client_step($message);
+				my $enc = &encode_base64($return);
 				$enc =~ s/\r|\n//g;
 				$arv = &mailboxes::smtp_command($h, "$enc\r\n", 1);
 				if ($arv =~ /^(\d+)(\-\S+)?\s+(.*)/) {

--- a/transfer-domain.pl
+++ b/transfer-domain.pl
@@ -57,7 +57,7 @@ if (!$module_name) {
 # Parse command-line args
 $proto = "ssh";
 while(@ARGV > 0) {
-	local $a = shift(@ARGV);
+	my $a = shift(@ARGV);
 	if ($a eq "--domain") {
 		$domain = lc(shift(@ARGV));
 		}

--- a/unalias-domain.pl
+++ b/unalias-domain.pl
@@ -36,7 +36,7 @@ $second_print = \&second_text_print;
 
 # Parse command-line args
 while(@ARGV > 0) {
-	local $a = shift(@ARGV);
+	my $a = shift(@ARGV);
 	if ($a eq "--domain") {
 		$domain = lc(shift(@ARGV));
 		}

--- a/uninstall.pl
+++ b/uninstall.pl
@@ -29,7 +29,7 @@ if ($init::init_mode eq 'systemd' && $gconfig{'os_type'} eq 'redhat-linux') {
 	}
 
 # Delete API helper
-local $api_helper_command = &get_api_helper_command();
+my $api_helper_command = &get_api_helper_command();
 if (-r $api_helper_command && !-d $api_helper_command) {
 	&unlink_file($api_helper_command);
 	}

--- a/unsub-domain.pl
+++ b/unsub-domain.pl
@@ -36,7 +36,7 @@ $second_print = \&second_text_print;
 
 # Parse command-line args
 while(@ARGV > 0) {
-	local $a = shift(@ARGV);
+	my $a = shift(@ARGV);
 	if ($a eq "--domain") {
 		$domain = lc(shift(@ARGV));
 		}

--- a/upgrade-licence.pl
+++ b/upgrade-licence.pl
@@ -33,7 +33,7 @@ if (!$module_name) {
 
 # Parse args
 while(@ARGV > 0) {
-	local $a = shift(@ARGV);
+	my $a = shift(@ARGV);
 	if ($a eq "--serial") {
 		$serial = shift(@ARGV);
 		}
@@ -115,7 +115,7 @@ elsif ($itype eq "deb") {
 			# For the Virtualmin package, select pro
 			# version explicitly so that the GPL is
 			# replaced.
-			local ($ver) = grep { !/\.gpl/ }
+			my ($ver) = grep { !/\.gpl/ }
 				&apt_package_versions($p->{'name'});
                             push(@packages, $ver ? $p->{'name'}."=".$ver
 					     : $p->{'name'});
@@ -147,8 +147,8 @@ else {
 
 sub apt_package_versions
 {
-local ($name) = @_;
-local @rv;
+my ($name) = @_;
+my @rv;
 open(OUT, "apt-cache show ".quotemeta($name)." |");
 while(<OUT>) {
 	if (/^Version:\s+(\S+)/) {

--- a/upgrade.cgi
+++ b/upgrade.cgi
@@ -154,7 +154,7 @@ elsif ($itype eq "deb") {
 			# For the Virtualmin package, select pro
 			# version explicitly so that the GPL is
 			# replaced.
-			local ($ver) = grep { !/\.gpl/ }
+			my ($ver) = grep { !/\.gpl/ }
 				&apt_package_versions($p->{'name'});
                             push(@packages, $ver ? $p->{'name'}."=".$ver
 					     : $p->{'name'});
@@ -204,11 +204,11 @@ else {
 		&$first_print(&text('upgrade_mod', $mod, $ver));
 
 		# Check if we have a later version
-		local %minfo = &get_module_info($mod);
-		local %tinfo = &get_theme_info($mod);
-		local %info = %minfo ? %minfo : %tinfo;
-		local $current_ver = &round_hundred($info{'version'});
-		local $new_ver = &round_hundred($ver);
+		my %minfo = &get_module_info($mod);
+		my %tinfo = &get_theme_info($mod);
+		my %info = %minfo ? %minfo : %tinfo;
+		my $current_ver = &round_hundred($info{'version'});
+		my $new_ver = &round_hundred($ver);
 		if (%info) {
 			# Already installed .. but can we upgrade?
 			$can_upgrade = 0;
@@ -264,9 +264,9 @@ else {
 		&set_all_html_print();	# In case changed by postinstall
 		if (ref($irv)) {
 			# Worked!
-			local $dir = $irv->[1]->[0];
+			my $dir = $irv->[1]->[0];
 			$dir =~ s/^.*\///g;
-			local %tinfo = &get_theme_info($dir);
+			my %tinfo = &get_theme_info($dir);
 			&$second_print(&text(%tinfo ? 'upgrade_themeok' :
 						      'upgrade_modok', $irv->[0]->[0]));
 			}
@@ -332,8 +332,8 @@ else {
 
 sub apt_package_versions
 {
-local ($name) = @_;
-local @rv;
+my ($name) = @_;
+my @rv;
 open(OUT, "apt-cache show ".quotemeta($name)." |");
 while(<OUT>) {
 	if (/^Version:\s+(\S+)/) {
@@ -349,7 +349,7 @@ return sort { &compare_versions($b, $a) } @rv;
 # Also strips suffixes like .gpl.
 sub round_hundred
 {
-local ($v) = @_;
+my ($v) = @_;
 if ($v =~ /^(\d+)\.(\d\d)/) {
 	return "$1.$2";
 	}

--- a/upload-api-docs.pl
+++ b/upload-api-docs.pl
@@ -197,10 +197,10 @@ if (!$noupload) {
 # the program summary line.
 sub convert_to_html
 {
-local ($data) = @_;
+my ($data) = @_;
 my $parser = Pod::Simple::HTML->new('dokuwiki');
-local $infile = "/tmp/pod2html.in";
-local $outfile = "/tmp/pod2html.out";
+my $infile = "/tmp/pod2html.in";
+my $outfile = "/tmp/pod2html.out";
 open(INFILE, ">$infile");
 print INFILE $data;
 close(INFILE);
@@ -210,13 +210,13 @@ $parser->output_fh(*OUTFILE);
 $parser->parse_file(*INFILE);
 close(INFILE);
 close(OUTFILE);
-local $html = `cat $outfile`;
+my $html = `cat $outfile`;
 return ($html, &extract_html_title($html));
 }
 
 sub extract_html_title
 {
-local ($html) = @_;
+my ($html) = @_;
 if ($html =~ /<p>([^<]+)<\/p>/i) {
 	return $1;
 	}
@@ -227,7 +227,7 @@ return undef;
 # Returns the unique elements of some array
 sub unique
 {
-local(%found, @rv, $e);
+my(%found, @rv, $e);
 foreach $e (@_) {
 	if (!$found{$e}++) { push(@rv, $e); }
 	}
@@ -237,7 +237,7 @@ return @rv;
 # indexof(string, array)
 # Returns the index of some value in an array, or -1
 sub indexof {
-  local($i);
+  my($i);
   for($i=1; $i <= $#_; $i++) {
     if ($_[$i] eq $_[0]) { return $i - 1; }
   }

--- a/upload-dropbox-file.pl
+++ b/upload-dropbox-file.pl
@@ -30,7 +30,7 @@ if (!$module_name) {
 # Parse command-line args
 $tries = 1;
 while(@ARGV > 0) {
-	local $a = shift(@ARGV);
+	my $a = shift(@ARGV);
 	if ($a eq "--source") {
 		$source = shift(@ARGV);
 		}

--- a/upload-rs-file.pl
+++ b/upload-rs-file.pl
@@ -39,7 +39,7 @@ if (!$module_name) {
 # Parse command-line args
 $tries = 1;
 while(@ARGV > 0) {
-	local $a = shift(@ARGV);
+	my $a = shift(@ARGV);
 	if ($a eq "--source") {
 		$source = shift(@ARGV);
 		}

--- a/upload-s3-file.pl
+++ b/upload-s3-file.pl
@@ -46,7 +46,7 @@ if (!$module_name) {
 # Parse command-line args
 $tries = 1;
 while(@ARGV > 0) {
-	local $a = shift(@ARGV);
+	my $a = shift(@ARGV);
 	if ($a eq "--source") {
 		$source = shift(@ARGV);
 		}

--- a/useradmin_update.pl
+++ b/useradmin_update.pl
@@ -19,10 +19,10 @@ sub useradmin_delete_user
 sub useradmin_modify_user
 {
 if ($_[0]->{'olduser'} && $_[0]->{'olduser'} ne $_[0]->{'user'}) {
-	local $d = &get_user_domain($_[0]->{'user'});
+	my $d = &get_user_domain($_[0]->{'user'});
 	if ($d) {
 		# User was renamed .. update mailbox plainpass
-		local %plain;
+		my %plain;
 		&read_file_cached("$plainpass_dir/$d->{'id'}", \%plain);
 		if ($plain{$_[0]->{'olduser'}}) {
 			$plain{$_[0]->{'user'}} = $plain{$_[0]->{'olduser'}};
@@ -31,7 +31,7 @@ if ($_[0]->{'olduser'} && $_[0]->{'olduser'} ne $_[0]->{'user'}) {
 			}
 
 		# And hashed passwords
-		local %hash;
+		my %hash;
 		&read_file_cached("$hashpass_dir/$d->{'id'}", \%hash);
 		if ($hash{$_[0]->{'olduser'}}) {
 			foreach my $s (@hashpass_types) {
@@ -64,7 +64,7 @@ if ($_[0]->{'passmode'} == 3) {
 		# updated by caller
 		foreach my $f (@features) {
 			if ($f ne "unix" && $config{$f} && $d->{$f}) {
-				local $mfunc = "modify_".$f;
+				my $mfunc = "modify_".$f;
 				&$mfunc($d, $oldd);
 				}
 			}
@@ -78,9 +78,9 @@ if ($_[0]->{'passmode'} == 3) {
 		}
 
 	# Update mailbox user passwords
-	local $d = &get_user_domain($_[0]->{'user'});
+	my $d = &get_user_domain($_[0]->{'user'});
 	if ($d && $d->{'user'} ne $_[0]->{'user'}) {
-		local ($user) = grep { $_->{'user'} eq $_[0]->{'user'} }
+		my ($user) = grep { $_->{'user'} eq $_[0]->{'user'} }
 				     &list_domain_users($d, 1, 0, 0, 0);
 		if ($user) {
 			$olduser = { %$user };

--- a/validate-domains.pl
+++ b/validate-domains.pl
@@ -32,7 +32,7 @@ if (!$module_name) {
 
 # Parse command-line args
 while(@ARGV > 0) {
-	local $a = shift(@ARGV);
+	my $a = shift(@ARGV);
 	if ($a eq "--domain") {
 		# Add a domain to validate
 		$dname = shift(@ARGV);

--- a/virtual-server-lib-funcs.pl
+++ b/virtual-server-lib-funcs.pl
@@ -84,9 +84,9 @@ foreach my $m (@migration_types) {
 # Returns a list of structures containing information about hosted domains
 sub list_domains
 {
-local (@rv, $d);
-local @files;
-local @st = stat($domains_dir);
+my (@rv, $d);
+my @files;
+my @st = stat($domains_dir);
 if (scalar(@main::list_domains_cache) &&
     $st[9] == $main::list_domains_cache_time) {
 	# Use cache of domain IDs in RAM
@@ -135,9 +135,9 @@ return @rv;
 # Those that should be indented have the 'indent' field set to some number.
 sub sort_indent_domains
 {
-local @doms = @{$_[0]};
-local $sortfield = $config{'domains_sort'} || "user";
-local %sortkey;
+my @doms = @{$_[0]};
+my $sortfield = $config{'domains_sort'} || "user";
+my %sortkey;
 if ($sortfield eq 'dom' || $sortfield eq 'sub') {
 	%sortkey = map { $_->{'id'}, &show_domain_name($_) } @doms;
 	}
@@ -154,7 +154,7 @@ foreach my $d (@doms) {
 if ($sortfield eq 'user' || $sortfield eq 'sub') {
 	# Re-categorize by owner, with sub-servers indented one and alias
 	# servers indented two under their targets
-	local @catdoms;
+	my @catdoms;
 	foreach my $d (grep { !$_->{'parent'} } @doms) {
 		push(@catdoms, $d);
 		foreach my $ad (grep { $_->{'alias'} eq $d->{'id'} } @doms) {
@@ -206,12 +206,12 @@ return @ax <=> @bx;
 # Looks up a domain object by ID
 sub get_domain
 {
-local ($id, $file, $force) = @_;
+my ($id, $file, $force) = @_;
 return undef if (!$id && !$file);
 if ($id && defined($main::get_domain_cache{$id}) && !$force) {
 	return $main::get_domain_cache{$id};
 	}
-local %dom;
+my %dom;
 $file ||= "$domains_dir/$id";
 &read_file($file, \%dom) || return undef;
 $dom{'file'} = "$domains_dir/$id";
@@ -228,7 +228,7 @@ delete($dom->{'missing'});	# never set in a saved domain
 if ($id) {
 	if ($main::get_domain_cache{$id} && $force) {
 		# In forced re-read mode, update existing object in cache
-		local $cache = $main::get_domain_cache{$id};
+		my $cache = $main::get_domain_cache{$id};
 		%$cache = %dom;
 		}
 	else {
@@ -243,7 +243,7 @@ return \%dom;
 # Fills in any missing fields in a domain object
 sub complete_domain
 {
-local ($dom) = @_;
+my ($dom) = @_;
 $dom->{'mail'} = 1 if (!defined($dom->{'mail'}));	# compat - assume mail is on
 if (!defined($dom->{'ugid'})) {
 	# compat - assume user's group is domain's group
@@ -311,14 +311,14 @@ if (!defined($dom->{'prefix'})) {
 	$dom->{'prefix'} = $dom->{'group'};
 	}
 if (!defined($dom->{'home'})) {
-	local @u = getpwnam($dom->{'user'});
+	my @u = getpwnam($dom->{'user'});
 	if (@u && $u[7] ne '/' && $u[7] ne '/root') {
 		$dom->{'home'} = $u[7];
 		}
 	}
 if (!defined($dom->{'plan'}) && !$main::no_auto_plan) {
 	# assume first plan
-	local @plans = sort { $a->{'id'} <=> $b->{'id'} } &list_plans();
+	my @plans = sort { $a->{'id'} <=> $b->{'id'} } &list_plans();
 	$dom->{'plan'} = $plans[0]->{'id'};
 	}
 if ($dom->{'db'} eq '' && ($dom->{'mysql'} || $dom->{'postgres'})) {
@@ -360,7 +360,7 @@ if (!$dom->{'emailto_addr'} ||
 	}
 
 # Set edit limits based on ability to edit domains
-local %acaps = map { $_, 1 } &list_automatic_capabilities($dom->{'domslimit'});
+my %acaps = map { $_, 1 } &list_automatic_capabilities($dom->{'domslimit'});
 foreach my $ed (@edit_limits) {
 	if (!defined($dom->{'edit_'.$ed})) {
 		$dom->{'edit_'.$ed} = $acaps{$ed} || 0;
@@ -373,8 +373,8 @@ delete($dom->{'pass_set'});	# Only set by callers for modify_* functions
 # Populate the emailto field based on the email field
 sub compute_emailto
 {
-local ($dom) = @_;
-local $parent;
+my ($dom) = @_;
+my $parent;
 if ($dom->{'parent'} && ($parent = &get_domain($dom->{'parent'}))) {
 	$dom->{'emailto'} = $parent->{'emailto'};
 	}
@@ -396,7 +396,7 @@ else {
 # Returns a list of default capabilities for a domain owner or plan
 sub list_automatic_capabilities
 {
-local ($cancreate) = @_;
+my ($cancreate) = @_;
 if ($cancreate) {
 	return @edit_limits;
 	}
@@ -411,11 +411,11 @@ else {
 # The special value _ANY_ matches any domains where the field is non-empty
 sub get_domain_by
 {
-local @rv;
+my @rv;
 for(my $i=0; $i<@_; $i+=2) {
-	local $mf = $get_domain_by_maps{$_[$i]};
-	local @possible;
-	local %map;
+	my $mf = $get_domain_by_maps{$_[$i]};
+	my @possible;
+	my %map;
 	if ($mf && &read_file_cached($mf, \%map)) {
 		# The map knows relevant domains
 		if ($_[$i+1] eq "_ANY_") {
@@ -423,7 +423,7 @@ for(my $i=0; $i<@_; $i+=2) {
 			foreach my $k (keys %map) {
 				next if ($k eq '');
 				foreach my $did (split(" ", $map{$k})) {
-					local $d = &get_domain($did);
+					my $d = &get_domain($did);
 					push(@possible, $d) if ($d);
 					}
 				}
@@ -431,7 +431,7 @@ for(my $i=0; $i<@_; $i+=2) {
 		else {
 			# Check for a match
 			foreach my $did (split(" ", $map{$_[$i+1]})) {
-				local $d = &get_domain($did);
+				my $d = &get_domain($did);
 				push(@possible, $d) if ($d);
 				}
 			}
@@ -448,7 +448,7 @@ for(my $i=0; $i<@_; $i+=2) {
 		}
 	else {
 		# Later field, so winnow down prevent results with new set
-		local %possible = map { $_->{'id'}, $_ } @possible;
+		my %possible = map { $_->{'id'}, $_ } @possible;
 		@rv = grep { $possible{$_->{'id'}} } @rv;
 		}
 	}
@@ -461,14 +461,14 @@ return wantarray ? @rv : $rv[0];
 # domains (unioned). May callback to the error function if one cannot be found.
 sub get_domains_by_names_users
 {
-local ($dnames, $users, $efunc, $plans, $subs) = @_;
+my ($dnames, $users, $efunc, $plans, $subs) = @_;
 foreach my $domain (&unique(@$dnames)) {
-	local $d = &get_domain_by("dom", $domain);
+	my $d = &get_domain_by("dom", $domain);
 	$d || &$efunc("Virtual server $domain does not exist");
 	push(@doms, $d);
 	}
 foreach my $uname (&unique(@$users)) {
-	local $dinfo = &get_domain_by("user", $uname, "parent", "");
+	my $dinfo = &get_domain_by("user", $uname, "parent", "");
 	if ($dinfo) {
 		push(@doms, $dinfo);
 		push(@doms, &get_domain_by("parent", $dinfo->{'id'}));
@@ -495,7 +495,7 @@ if ($subs) {
 		}
 	push(@doms, @add);
 	}
-local %donedomain;
+my %donedomain;
 @doms = grep { !$donedomain{$_->{'id'}}++ } @doms;
 return @doms;
 }
@@ -504,10 +504,10 @@ return @doms;
 # Given a domain owner's Webmin login, return his top-level domain
 sub get_domain_by_user
 {
-local ($user) = @_;
+my ($user) = @_;
 if ($access{'admin'}) {
 	# Extra admin
-	local $d = &get_domain($access{'admin'});
+	my $d = &get_domain($access{'admin'});
 	if ($d && $d->{'parent'}) {
 		$d = &get_domain($d->{'parent'});
 		}
@@ -515,7 +515,7 @@ if ($access{'admin'}) {
 	}
 else {
 	# Domain owner
-	local $d = &get_domain_by("user", $user, "parent", "");
+	my $d = &get_domain_by("user", $user, "parent", "");
 	return $d;
 	}
 }
@@ -524,7 +524,7 @@ else {
 # Given a list of domain names, returns the domain objects (where they exist)
 sub get_domains_by_names
 {
-local @rv;
+my @rv;
 foreach my $dname (@_) {
 	my $d = &get_domain_by("dom", $dname);
 	push(@rv, $d) if ($d);
@@ -554,7 +554,7 @@ return grep { !$done{$_->{'id'}}++ } @rv;
 # Returns a new unique domain ID
 sub domain_id
 {
-local $rv = time().$$.$main::domain_id_count;
+my $rv = time().$$.$main::domain_id_count;
 $main::domain_id_count++;
 return $rv;
 }
@@ -581,8 +581,8 @@ $id = $id->{'id'} if (ref($id));
 # Write domain information to disk
 sub save_domain
 {
-local ($d, $creating) = @_;
-local $file = "$domains_dir/$d->{'id'}";
+my ($d, $creating) = @_;
+my $file = "$domains_dir/$d->{'id'}";
 if (!$creating && $d->{'id'} && !-r $file) {
 	# Deleted from under us! Don't save
 	print STDERR "Domain $file was deleted before saving!\n";
@@ -596,7 +596,7 @@ if ($d->{'dom'} eq '') {
 	}
 &make_dir($domains_dir, 0700);
 &lock_file($file);
-local $oldd = { };
+my $oldd = { };
 if (&read_file($file, $oldd)) {
 	my @st = stat($file);
 	if ($d->{'lastread_time'} && $st[9] > $d->{'lastread_time'}) {
@@ -627,7 +627,7 @@ if (scalar(@main::list_domains_cache)) {
 		&unique(@main::list_domains_cache, $d->{'id'});
 	}
 # Only rebuild maps if something relevant changed
-local $mchanged = 0;
+my $mchanged = 0;
 foreach my $m (keys %get_domain_by_maps) {
 	$mchanged++ if ($d->{$m} ne $oldd->{$m});
 	}
@@ -655,7 +655,7 @@ my $id = $d->{'id'};
 
 if (defined(&get_autoreply_file_dir)) {
 	# Delete any autoreply file links
-	local $dir = &get_autoreply_file_dir();
+	my $dir = &get_autoreply_file_dir();
 	opendir(AUTODIR, $dir);
 	foreach my $f (readdir(AUTODIR)) {
 		next if ($f eq "." || $f eq "..");
@@ -736,11 +736,11 @@ if (scalar(@main::list_domains_cache)) {
 # or parent
 sub build_domain_maps
 {
-local @doms = &list_domains();
+my @doms = &list_domains();
 foreach my $m (keys %get_domain_by_maps) {
-	local %map;
+	my %map;
 	foreach my $d (@doms) {
-		local $v = $d->{$m};
+		my $v = $d->{$m};
 		#next if ($v eq '');
 		if (!defined($map{$v})) {
 			$map{$v} = $d->{'id'};
@@ -771,10 +771,10 @@ return 0;
 # If domain is omitted, returns local users.
 sub list_domain_users
 {
-local ($d, $skipunix, $novirts, $noquotas, $nodbs, $includeextra) = @_;
+my ($d, $skipunix, $novirts, $noquotas, $nodbs, $includeextra) = @_;
 
 # Get all aliases (and maybe generics) to look for those that match users
-local (%aliases, %generics);
+my (%aliases, %generics);
 if ($config{'mail'} && !$novirts) {
 	&require_mail();
 	if ($mail_system == 1) {
@@ -793,19 +793,19 @@ if ($config{'mail'} && !$novirts) {
 	}
 
 # Get all virtusers to look for those for users
-local @virts;
+my @virts;
 if (!$novirts) {
 	@virts = &list_virtusers();
 	}
 
 # Are we setting quotas individually?
-local $ind_quota = 0;
+my $ind_quota = 0;
 if (&has_quota_commands() && $config{'quota_get_user_command'} && $d) {
 	$ind_quota = 1;
 	}
 
 # Limit to domain users.
-local @users = &list_all_users_quotas($noquotas || $ind_quota);
+my @users = &list_all_users_quotas($noquotas || $ind_quota);
 @users = grep { $d->{'gid'} ne '' &&
 		$_->{'gid'} == $d->{'gid'} ||
 		$_->{'user'} eq $d->{'user'} } @users;
@@ -833,15 +833,15 @@ foreach my $u (@users) {
 		}
 	if ($ind_quota && !$noquotas) {
 		# Call quota getting command for each user
-		local $out = &run_quota_command(
+		my $out = &run_quota_command(
 				"get_user", $u->{'user'});
-		local ($used, $soft, $hard) = split(/\s+/, $out);
+		my ($used, $soft, $hard) = split(/\s+/, $out);
 		$u->{'softquota'} = $soft;
 		$u->{'hardquota'} = $hard;
 		$u->{'uquota'} = $used;
 		}
 	}
-local @subdoms;
+my @subdoms;
 if ($d->{'parent'}) {
 	# This is a subdomain - exclude parent domain users, including
 	# jailed users
@@ -860,14 +860,14 @@ elsif (@subdoms = &get_domain_by("parent", $d->{'id'})) {
 # Remove users with @ in their names for whom a user with the @ replace
 # already exists (for Postfix)
 if ($mail_system == 0) {
-	local %umap = map { &replace_atsign($_->{'user'}), $_ }
+	my %umap = map { &replace_atsign($_->{'user'}), $_ }
 			grep { $_->{'user'} =~ /\@/ } @users;
 	@users = grep { !$umap{$_->{'user'}} } @users;
 	}
 
 # Find users with broken home dir (not under homes, or
 # domain's home, or public_html (for web ftp users))
-local $phd = &public_html_dir($d);
+my $phd = &public_html_dir($d);
 foreach my $u (@users) {
 	if (!$u->{'webowner'} && $u->{'home'} &&
 	    $u->{'home'} !~ /^$d->{'home'}\/$config{'homes_dir'}\// &&
@@ -900,7 +900,7 @@ if ($d->{'hashpass'}) {
 	}
 else {
 	# Merge in plain text passwords
-	local (%plain, $need_plainpass_save);
+	my (%plain, $need_plainpass_save);
 	&read_file_cached("$plainpass_dir/$d->{'id'}", \%plain);
 	foreach my $u (@users) {
 		if ($u->{'domainowner'}) {
@@ -947,9 +947,9 @@ else {
 	}
 
 # Set appropriate quota field
-local $tmpl = &get_template($d ? $d->{'template'} : 0);
-local $qtype = $tmpl->{'quotatype'};
-local $u;
+my $tmpl = &get_template($d ? $d->{'template'} : 0);
+my $qtype = $tmpl->{'quotatype'};
+my $u;
 foreach $u (@users) {
 	$u->{'quota'} = $u->{$qtype.'quota'} if (!defined($u->{'quota'}));
 	}
@@ -965,17 +965,17 @@ if ($d) {
 	}
 
 # Check if spamc is being used
-local $spamc;
+my $spamc;
 if ($d && $d->{'spam'}) {
-	local $spamclient = &get_domain_spam_client($d);
+	my $spamclient = &get_domain_spam_client($d);
 	$spamc = 1 if ($spamclient =~ /spamc/);
 	}
 
 # Detect user who are close to their quota
 if (&has_home_quotas()) {
-	local $bsize = &quota_bsize("home");
+	my $bsize = &quota_bsize("home");
 	foreach $u (@users) {
-		local $diff = $u->{'quota'}*$bsize - $u->{'uquota'}*$bsize;
+		my $diff = $u->{'quota'}*$bsize - $u->{'uquota'}*$bsize;
 		if ($u->{'quota'} && $diff < $quota_spam_margin &&
 		    $d->{'spam'} && !$spamc) {
 			# Close to quota, which will block spamassassin ..
@@ -1012,7 +1012,7 @@ if (!$novirts) {
 		$u->{'email'} = $u->{'virt'} = undef;
 		$u->{'alias'} = $u->{'to'} = $u->{'generic'} = undef;
 		$u->{'extraemail'} = $u->{'extravirt'} = undef;
-		local ($al, $va);
+		my ($al, $va);
 		if ($al = $aliases{&escape_alias($u->{'user'})}) {
 			$u->{'alias'} = $al;
 			$u->{'to'} = $al->{'values'};
@@ -1023,19 +1023,19 @@ if (!$novirts) {
 			}
 		elsif ($mail_system == 2) {
 			# Find .qmail file
-			local $alias = &get_dotqmail(&dotqmail_file($u));
+			my $alias = &get_dotqmail(&dotqmail_file($u));
 			if ($alias) {
 				$u->{'alias'} = $alias;
 				$u->{'to'} = $u->{'alias'}->{'values'};
 				}
 			}
 		$u->{'generic'} = $generics{$u->{'user'}};
-		local $pop3 = $d ? &remove_userdom($u->{'user'}, $d)
+		my $pop3 = $d ? &remove_userdom($u->{'user'}, $d)
 				    : $u->{'user'};
-		local $email = $d ? "$pop3\@$d->{'dom'}" : undef;
-		local $escuser = &escape_user($u->{'user'});
-		local $escalias = &escape_alias($u->{'user'});
-		local $v;
+		my $email = $d ? "$pop3\@$d->{'dom'}" : undef;
+		my $escuser = &escape_user($u->{'user'});
+		my $escalias = &escape_alias($u->{'user'});
+		my $v;
 		foreach $v (@virts) {
 			if (@{$v->{'to'}} == 1 &&
 			    ($v->{'to'}->[0] eq $escuser ||
@@ -1066,18 +1066,18 @@ push(@users, &list_extra_db_users($d))
 
 if (!$nodbs && $d) {
 	# Add accessible databases
-	local @dbs = &domain_databases($d);
-	local $db;
-	local %dbdone;
+	my @dbs = &domain_databases($d);
+	my $db;
+	my %dbdone;
 	foreach $u (@users) {
 		$u->{'dbs'} = [ ];
 		}
 	foreach $db (@dbs) {
-		local @dbu;
-		local $ufunc;
+		my @dbu;
+		my $ufunc;
 		if (&indexof($db->{'type'}, &list_database_plugins()) < 0) {
 			# Core database
-			local $dfunc = "list_".$db->{'type'}."_database_users";
+			my $dfunc = "list_".$db->{'type'}."_database_users";
 			next if (!defined(&$dfunc));
 			$ufunc = $db->{'type'}."_username";
 			@dbu = &$dfunc($d, $db->{'name'});
@@ -1089,10 +1089,10 @@ if (!$nodbs && $d) {
 			@dbu = &plugin_call($db->{'type'}, "database_users",
 					    $d, $db->{'name'});
 			}
-		local %dbu = map { $_->[0], $_->[1] } @dbu;
-		local $u;
-		local $domufunc = $db->{'type'}.'_user';
-		local $domu = defined(&$domufunc) ? &$domufunc($d) : undef;
+		my %dbu = map { $_->[0], $_->[1] } @dbu;
+		my $u;
+		my $domufunc = $db->{'type'}.'_user';
+		my $domu = defined(&$domufunc) ? &$domufunc($d) : undef;
 		foreach $u (@users) {
 			# Domain owner always gets all databases
 			next if ($u->{'user'} eq $d->{'user'});
@@ -1100,7 +1100,7 @@ if (!$nodbs && $d) {
 			# For each user, add this DB to his list if there
 			# is a user for it with the same name. Unless this
 			# is the same as the domain owner's DB username.
-			local $uname = $ufunc ? &$ufunc($u->{'user'}) :
+			my $uname = $ufunc ? &$ufunc($u->{'user'}) :
 				&plugin_call($db->{'type'}, "database_user",
 					     $u->{'user'});
 			if (exists($dbu{$uname}) &&
@@ -1114,7 +1114,7 @@ if (!$nodbs && $d) {
 		}
 
 	# Add plugin databases
-	local @dbs = &domain_databases($d);
+	my @dbs = &domain_databases($d);
 	foreach $db (@dbs) {
 		next if (&indexof($db->{'type'}, &list_database_plugins()) == -1);
 		}
@@ -1127,16 +1127,16 @@ if ($includeextra && &domain_has_website($d) &&
 	}
 
 # Add any secondary groups in the template
-local @sgroups = &allowed_secondary_groups($d);
+my @sgroups = &allowed_secondary_groups($d);
 if (@sgroups) {
-	local @groups = &list_all_groups();
+	my @groups = &list_all_groups();
 	foreach my $u (@users) {
 		$u->{'secs'} = [ ];
 		}
 	foreach my $g (@sgroups) {
-		local ($group) = grep { $_->{'group'} eq $g } @groups;
+		my ($group) = grep { $_->{'group'} eq $g } @groups;
 		if ($group) {
-			local %mems = map { $_, 1 }
+			my %mems = map { $_, 1 }
 					  split(/,/, $group->{'members'});
 			foreach my $u (@users) {
 				if ($mems{$u->{'user'}}) {
@@ -1149,7 +1149,7 @@ if (@sgroups) {
 
 # Add no-spam flags
 if ($d) {
-	local %nospam;
+	my %nospam;
 	&read_file_cached("$nospam_dir/$d->{'id'}", \%nospam);
 	foreach my $u (@users) {
 		if (!defined($u->{'nospam'})) {
@@ -1219,7 +1219,7 @@ foreach my $dt (&unique(map { $_->{'type'} } &domain_databases($d))) {
 		local $main::error_must_die = 1;
 		if (&indexof($dt, &list_database_plugins()) < 0) {
 			# Delete from core database
-			local $dlfunc = "delete_${dt}_database_user";
+			my $dlfunc = "delete_${dt}_database_user";
 			if (defined(&$dlfunc)) {
 				&$dlfunc($d, $user);
 				}
@@ -1243,8 +1243,8 @@ return wantarray ? (0, \@dts) : undef;
 # Tries to call unix_crypt, returns undef if it fails
 sub safe_unix_crypt
 {
-local ($pass, $salt) = @_;
-local $uc;
+my ($pass, $salt) = @_;
+my $uc;
 eval {
 	local $main::error_must_die = 1;
 	$uc = &unix_crypt($pass, $salt);
@@ -1279,13 +1279,13 @@ sub list_all_users_quotas
 {
 # Get quotas for all users
 &require_useradmin($_[0]);
-local $hascmds = &has_quota_commands();
+my $hascmds = &has_quota_commands();
 if ($hascmds) {
 	# Get from user quota command
 	if (!%main::soft_home_quota && !$_[0]) {
-		local $out = &run_quota_command("list_users");
+		my $out = &run_quota_command("list_users");
 		foreach my $l (split(/\r?\n/, $out)) {
-			local ($user, $used, $soft, $hard) = split(/\s+/, $l);
+			my ($user, $used, $soft, $hard) = split(/\s+/, $l);
 			$main::soft_home_quota{$user} = $soft;
 			$main::hard_home_quota{$user} = $hard;
 			$main::used_home_quota{$user} = $used;
@@ -1310,11 +1310,11 @@ else {
 	}
 
 # Get user list and add in quota info
-local @users = &foreign_call($usermodule, "list_users");
-local %uidmap;
+my @users = &foreign_call($usermodule, "list_users");
+my %uidmap;
 foreach my $u (@users) {
 	$u->{'module'} = $usermodule;
-	local $sameu = $uidmap{$u->{'uid'}};
+	my $sameu = $uidmap{$u->{'uid'}};
 	if ($sameu && !$hascmds) {
 		# Quotas are set on a per-uid basis, so copy from previously
 		# seem user with same ID
@@ -1352,9 +1352,9 @@ sub list_all_groups_quotas
 if (&has_quota_commands()) {
 	# Get from user quota command
 	if (!%main::gsoft_home_quota && !$_[0]) {
-		local $out = &run_quota_command("list_groups");
+		my $out = &run_quota_command("list_groups");
 		foreach my $l (split(/\r?\n/, $out)) {
-			local ($group, $used, $soft, $hard) = split(/\s+/, $l);
+			my ($group, $used, $soft, $hard) = split(/\s+/, $l);
 			$main::gsoft_home_quota{$group} = $soft;
 			$main::ghard_home_quota{$group} = $hard;
 			$main::gused_home_quota{$group} = $used;
@@ -1379,8 +1379,8 @@ else {
 	}
 
 # Get group list and add in quota info
-local @groups = &foreign_call($usermodule, "list_groups");
-local $u;
+my @groups = &foreign_call($usermodule, "list_groups");
+my $u;
 foreach $u (@groups) {
 	$u->{'module'} = $usermodule;
 	$u->{'softquota'} = $main::gsoft_home_quota{$u->{'group'}};
@@ -1417,7 +1417,7 @@ return $needextra;
 # Create a mailbox or local user, his virtuser and possibly his alias
 sub create_user
 {
-local $pop3 = &remove_userdom($_[0]->{'user'}, $_[1]);
+my $pop3 = &remove_userdom($_[0]->{'user'}, $_[1]);
 &require_useradmin();
 &require_mail();
 
@@ -1427,7 +1427,7 @@ if ($config{'ldap_mail'}) {
 	if ($_[0]->{'email'}) {
 		push(@{$_[0]->{'ldap_attrs'}}, "mail",$_[0]->{'email'});
 		}
-	local $ea = $config{'ldap_mail'} == 2 ?
+	my $ea = $config{'ldap_mail'} == 2 ?
 			'mailAlternateAddress' : 'mail';
 	push(@{$_[0]->{'ldap_attrs'}},
 	     map { ( $ea, $_ ) } @{$_[0]->{'extraemail'}});
@@ -1442,7 +1442,7 @@ if ($config{'ldap_mail'}) {
 
 # If we are running Postfix and the username has an @ in it, create an extra
 # Unix user without the @ but all the other details the same
-local $extrauser;
+my $extrauser;
 if (&need_extra_user($_[0])) {
 	$extrauser = { %{$_[0]} };
 	$extrauser->{'user'} = &replace_atsign($extrauser->{'user'});
@@ -1455,13 +1455,13 @@ if (&need_extra_user($_[0])) {
 	}
 
 # Add virtusers
-local $firstemail;
-local @to = @{$_[0]->{'to'}};
-local $vto = @to ? &escape_alias($_[0]->{'user'}) :
+my $firstemail;
+my @to = @{$_[0]->{'to'}};
+my $vto = @to ? &escape_alias($_[0]->{'user'}) :
 	     $extrauser ? $extrauser->{'user'} :
 			  &escape_user($_[0]->{'user'});
 if ($_[0]->{'email'}) {
-	local $virt = { 'from' => $_[0]->{'email'},
+	my $virt = { 'from' => $_[0]->{'email'},
 			'to' => [ $vto ] };
 	&create_virtuser($virt);
 	$_[0]->{'virt'} = $virt;
@@ -1470,15 +1470,15 @@ if ($_[0]->{'email'}) {
 elsif ($can_alias_types{9} && $_[1] && !$_[0]->{'noprimary'} &&
        $_[1]->{'mail'}) {
 	# Add bouncer if email disabled
-	local $virt = { 'from' => "$pop3\@$_[1]->{'dom'}",
+	my $virt = { 'from' => "$pop3\@$_[1]->{'dom'}",
 			'to' => [ "BOUNCE" ] };
 	&create_virtuser($virt);
 	$_[0]->{'virt'} = $virt;
 	}
-local @extravirt;
-local $e;
+my @extravirt;
+my $e;
 foreach $e (&unique(@{$_[0]->{'extraemail'}})) {
-	local $virt = { 'from' => $e,
+	my $virt = { 'from' => $e,
 			'to' => [ $vto ] };
 	&create_virtuser($virt);
 	push(@extravirt, $virt);
@@ -1488,7 +1488,7 @@ $_[0]->{'extravirt'} = \@extravirt;
 
 # Add his alias, if any
 if (@to) {
-	local $alias = { 'name' => &escape_alias($_[0]->{'user'}),
+	my $alias = { 'name' => &escape_alias($_[0]->{'user'}),
 			 'enabled' => 1,
 			 'values' => $_[0]->{'to'} };
 	&check_alias_clash($_[0]->{'user'}) &&
@@ -1506,7 +1506,7 @@ if (@to) {
 		}
 	elsif ($mail_system == 2) {
 		# Set up user's .qmail file
-		local $dqm = &dotqmail_file($_[0]);
+		my $dqm = &dotqmail_file($_[0]);
 		&lock_file($dqm);
 		&save_dotqmail($alias, $dqm, $pop3);
 		&unlock_file($dqm);
@@ -1527,16 +1527,16 @@ if (!$_[0]->{'noquota'}) {
 
 # Grant access to databases (unless this is the domain owner)
 if ($_[1] && !$_[0]->{'domainowner'}) {
-	local $dt;
+	my $dt;
 	foreach $dt (&unique(map { $_->{'type'} } &domain_databases($_[1]))) {
 		eval {
 			local $main::error_must_die = 1;
-			local @dbs = map { $_->{'name'} }
+			my @dbs = map { $_->{'name'} }
 				 grep { $_->{'type'} eq $dt } @{$_[0]->{'dbs'}};
 			next if (!@dbs);
 			if (&indexof($dt, &list_database_plugins()) < 0) {
 				# Create in core database
-				local $crfunc = "create_${dt}_database_user";
+				my $crfunc = "create_${dt}_database_user";
 				&$crfunc($_[1], \@dbs, $_[0]->{'user'},
 					 $_[0]->{'plainpass'},
 					 $_[0]->{$dt.'_pass'});
@@ -1556,12 +1556,12 @@ if ($_[1] && !$_[0]->{'domainowner'}) {
 	}
 
 # Add user to any secondary groups
-local @groups;
+my @groups;
 @groups = &list_all_groups() if (@{$_[0]->{'secs'}});
 foreach my $g (@{$_[0]->{'secs'}}) {
-	local ($group) = grep { $_->{'group'} eq $g } @groups;
+	my ($group) = grep { $_->{'group'} eq $g } @groups;
 	if ($group) {
-		local @mems = split(/,/, $group->{'members'});
+		my @mems = split(/,/, $group->{'members'});
 		push(@mems, $_[0]->{'user'});
 		$group->{'members'} = join(",", @mems);
 		&foreign_call($group->{'module'}, "modify_group",
@@ -1585,9 +1585,9 @@ if ($_[1]->{'hashpass'}) {
 		mkdir($hashpass_dir, 0700);
 		}
 	if (defined($_[0]->{'plainpass'})) {
-		local %hash;
+		my %hash;
 		&read_file_cached("$hashpass_dir/$_[1]->{'id'}", \%hash);
-		local $g = &generate_password_hashes(
+		my $g = &generate_password_hashes(
 				$_[0], $_[0]->{'plainpass'}, $_[1]);
 		foreach my $s (@hashpass_types) {
 			$hash{$_[0]->{'user'}.' '.$s} = $g->{$s};
@@ -1601,7 +1601,7 @@ else {
 		mkdir($plainpass_dir, 0700);
 		}
 	if (defined($_[0]->{'plainpass'})) {
-		local %plain;
+		my %plain;
 		&read_file_cached("$plainpass_dir/$_[1]->{'id'}", \%plain);
 		$plain{$_[0]->{'user'}} = $_[0]->{'plainpass'};
 		$plain{$_[0]->{'user'}." encrypted"} = $_[0]->{'pass'};
@@ -1614,7 +1614,7 @@ if (!-d $nospam_dir) {
 	mkdir($nospam_dir, 0700);
 	}
 if ($_[0]->{'nospam'}) {
-	local %nospam;
+	my %nospam;
 	&read_file_cached("$nospam_dir/$_[1]->{'id'}", \%nospam);
 	$nospam{$_[0]->{'user'}} = 1;
 	&write_file("$nospam_dir/$_[1]->{'id'}", \%nospam);
@@ -1660,8 +1660,8 @@ my ($user, $olduser, $d, $noaliases) = @_;
 # Rename any of his cron jobs
 &rename_unix_cron_jobs($user->{'user'}, $olduser->{'user'});
 
-local $pop3 = &remove_userdom($user->{'user'}, $d);
-local $extrauser;
+my $pop3 = &remove_userdom($user->{'user'}, $d);
+my $extrauser;
 &require_useradmin();
 &require_mail();
 
@@ -1671,7 +1671,7 @@ if ($config{'ldap_mail'}) {
 	if ($user->{'email'}) {
 		push(@{$user->{'ldap_attrs'}}, "mail",$user->{'email'});
 		}
-	local $ea = $config{'ldap_mail'} == 2 ?
+	my $ea = $config{'ldap_mail'} == 2 ?
 			'mailAlternateAddress' : 'mail';
 	push(@{$user->{'ldap_attrs'}},
 	     map { ( $ea, $_ ) } @{$user->{'extraemail'}});
@@ -1685,9 +1685,9 @@ if ($config{'ldap_mail'}) {
 &foreign_call($usermodule, "made_changes");
 
 if ($mail_system == 0 && $olduser->{'user'} =~ /\@/) {
-	local $esc = &replace_atsign($olduser->{'user'});
-	local @allusers = &list_all_users_quotas(1);
-	local ($oldextrauser) = grep { $_->{'user'} eq $esc } @allusers;
+	my $esc = &replace_atsign($olduser->{'user'});
+	my @allusers = &list_all_users_quotas(1);
+	my ($oldextrauser) = grep { $_->{'user'} eq $esc } @allusers;
 	if ($oldextrauser) {
 		# Found him .. fix up
 		$extrauser = { %{$user} };
@@ -1708,7 +1708,7 @@ if ($mail_system == 0 && $olduser->{'user'} =~ /\@/) {
 goto NOALIASES if ($noaliases);	# no need to touch aliases and virtusers
 
 # Check if email has changed
-local $echanged;
+my $echanged;
 if (!$user->{'email'} && $olduser->{'virt'} &&		# disabling
      $olduser->{'virt'}->{'to'}->[0] !~ /^BOUNCE/ ||
     $user->{'email'} && !$olduser->{'virt'} ||		# enabling
@@ -1720,8 +1720,8 @@ if (!$user->{'email'} && $olduser->{'virt'} &&		# disabling
 	# Primary has changed
 	$echanged = 1;
 	}
-local $oldextra = join(" ", map { $_->{'from'} } @{$olduser->{'extravirt'}});
-local $newextra = join(" ", @{$user->{'extraemail'}});
+my $oldextra = join(" ", map { $_->{'from'} } @{$olduser->{'extravirt'}});
+my $newextra = join(" ", @{$user->{'extraemail'}});
 if ($oldextra ne $newextra) {
 	# Extra has changed
 	$echanged = 1;
@@ -1730,29 +1730,29 @@ if ($user->{'user'} ne $olduser->{'user'}) {
 	# Always update on a rename
 	$echanged = 1;
 	}
-local $oldto = join(" ", @{$olduser->{'to'}});
-local $newto = join(" ", @{$user->{'to'}});
+my $oldto = join(" ", @{$olduser->{'to'}});
+my $newto = join(" ", @{$user->{'to'}});
 if ($oldto ne $newto) {
 	# Always update if forwarding dest has changed
 	$echanged = 1;
 	}
 
-local $firstemail;
-local @to = @{$user->{'to'}};
-local @oldto = @{$olduser->{'to'}};
+my $firstemail;
+my @to = @{$user->{'to'}};
+my @oldto = @{$olduser->{'to'}};
 if ($echanged) {
 	# Take away all virtusers and add new ones, for non Qmail+LDAP users
 	&delete_virtuser($olduser->{'virt'}) if ($olduser->{'virt'});
-	local %oldcmt;
+	my %oldcmt;
 	foreach my $e (@{$olduser->{'extravirt'}}) {
 		$oldcmt{$e->{'from'}} = $e->{'cmt'};
 		&delete_virtuser($e);
 		}
-	local $vto = @to ? &escape_alias($user->{'user'}) :
+	my $vto = @to ? &escape_alias($user->{'user'}) :
 		     $extrauser ? $extrauser->{'user'} :
 				  &escape_user($user->{'user'});
 	if ($user->{'email'}) {
-		local $virt = { 'from' => $user->{'email'},
+		my $virt = { 'from' => $user->{'email'},
 				'to' => [ $vto ],
 				'cmt' => $oldcmt{$user->{'email'}} };
 		&create_virtuser($virt);
@@ -1762,15 +1762,15 @@ if ($echanged) {
 	elsif ($can_alias_types{9} && $d && !$user->{'noprimary'} &&
 	       $d->{'mail'}) {
 		# Add bouncer if email disabled
-		local $virt = { 'from' => "$pop3\@$d->{'dom'}",
+		my $virt = { 'from' => "$pop3\@$d->{'dom'}",
 				'to' => [ "BOUNCE" ],
 				'cmt' => $oldcmt{"$pop3\@$d->{'dom'}"} };
 		&create_virtuser($virt);
 		$user->{'virt'} = $virt;
 		}
-	local @extravirt;
+	my @extravirt;
 	foreach my $e (&unique(@{$user->{'extraemail'}})) {
-		local $virt = { 'from' => $e,
+		my $virt = { 'from' => $e,
 				'to' => [ $vto ],
 				'cmt' => $oldcmt{$e} };
 		&create_virtuser($virt);
@@ -1792,7 +1792,7 @@ else {
 # Update, create or delete alias
 if (@to && !@oldto) {
 	# Need to add alias
-	local $alias = { 'name' => &escape_alias($user->{'user'}),
+	my $alias = { 'name' => &escape_alias($user->{'user'}),
 			 'enabled' => 1,
 			 'values' => $user->{'to'} };
 	&check_alias_clash($user->{'user'}) &&
@@ -1812,7 +1812,7 @@ if (@to && !@oldto) {
 		}
 	elsif ($mail_system == 2) {
 		# Set up user's .qmail file
-		local $dqm = &dotqmail_file($user);
+		my $dqm = &dotqmail_file($user);
 		&lock_file($dqm);
 		&save_dotqmail($alias, $dqm, $pop3);
 		&unlock_file($dqm);
@@ -1836,13 +1836,13 @@ elsif (!@to && @oldto) {
 		}
 	elsif ($mail_system == 2) {
 		# Remove user's .qmail file
-		local $dqm = &dotqmail_file($user);
+		my $dqm = &dotqmail_file($user);
 		&unlink_logged($dqm);
 		}
 	}
 elsif (@to && @oldto && join(" ", @to) ne join(" ", @oldto)) {
 	# Need to update the alias
-	local $alias = { 'name' => &escape_alias($user->{'user'}),
+	my $alias = { 'name' => &escape_alias($user->{'user'}),
 			 'enabled' => 1,
 			 'values' => $user->{'to'} };
 	if ($mail_system == 1) {
@@ -1860,7 +1860,7 @@ elsif (@to && @oldto && join(" ", @to) ne join(" ", @oldto)) {
 		}
 	elsif ($mail_system == 2) {
 		# Set up user's .qmail file
-		local $dqm = &dotqmail_file($user);
+		my $dqm = &dotqmail_file($user);
 		&lock_file($dqm);
 		&save_dotqmail($alias, $dqm, $pop3);
 		&unlock_file($dqm);
@@ -1893,7 +1893,7 @@ if ($d && $user->{'user'} ne $d->{'user'} &&
 
 # Update the plain-text password file, except for a domain owner
 if (!$user->{'domainowner'} && $d && !$d->{'hashpass'}) {
-	local %plain;
+	my %plain;
 	mkdir($plainpass_dir, 0700);
 	&read_file_cached("$plainpass_dir/$d->{'id'}", \%plain);
 	if ($user->{'user'} ne $olduser->{'user'}) {
@@ -1912,7 +1912,7 @@ if (!$user->{'domainowner'} && $d && !$d->{'hashpass'}) {
 
 # Update hashed passwords file, except for domain owner
 if (!$user->{'domainowner'} && $d && $d->{'hashpass'}) {
-	local %hash;
+	my %hash;
 	mkdir($hashpass_dir, 0700);
 	&read_file_cached("$hashpass_dir/$d->{'id'}", \%hash);
 	if ($user->{'user'} ne $olduser->{'user'}) {
@@ -1924,7 +1924,7 @@ if (!$user->{'domainowner'} && $d && $d->{'hashpass'}) {
 		}
 	if (defined($user->{'plainpass'})) {
 		# Re-hash new password
-		local $g = &generate_password_hashes(
+		my $g = &generate_password_hashes(
 				$user, $user->{'plainpass'}, $d);
 		foreach my $s (@hashpass_types) {
 			$hash{$user->{'user'}.' '.$s} = $g->{$s};
@@ -1939,13 +1939,13 @@ if (!$user->{'domainowner'} && $d && $d->{'hashpass'}) {
 &modify_database_user(@_);
 
 # Rename user in secondary groups, and update membership
-local @groups = &list_all_groups();
-local %secs = map { $_, 1 } @{$user->{'secs'}};
-local @sgroups = &allowed_secondary_groups($d);
+my @groups = &list_all_groups();
+my %secs = map { $_, 1 } @{$user->{'secs'}};
+my @sgroups = &allowed_secondary_groups($d);
 foreach my $group (@groups) {
-	local @mems = split(/,/, $group->{'members'});
-	local $idx = &indexof($olduser->{'user'}, @mems);
-	local $changed;
+	my @mems = split(/,/, $group->{'members'});
+	my $idx = &indexof($olduser->{'user'}, @mems);
+	my $changed;
 	if ($idx >= 0) {
 		# User is currently in group
 		if ($user->{'user'} ne $olduser->{'user'}) {
@@ -1991,7 +1991,7 @@ if ($d) {
 		mkdir($nospam_dir, 0700);
 		}
 	if (defined($user->{'nospam'})) {
-		local %nospam;
+		my %nospam;
 		&read_file_cached("$nospam_dir/$d->{'id'}", \%nospam);
 		if ($user->{'user'} ne $olduser->{'user'}) {
 			delete($nospam{$olduser->{'user'}});
@@ -2111,9 +2111,9 @@ $_[0]->{'uid'} == 0 && &error("Cannot delete UID 0 user!");
 
 if ($mail_system == 0 && $_[0]->{'user'} =~ /\@/) {
 	# Find the Unix user with the @ escaped and delete it too
-	local $esc = &replace_atsign_if_exists($_[0]->{'user'});
-	local @allusers = &list_all_users_quotas(1);
-	local ($extrauser) = grep { $_->{'user'} eq $esc } @allusers;
+	my $esc = &replace_atsign_if_exists($_[0]->{'user'});
+	my @allusers = &list_all_users_quotas(1);
+	my ($extrauser) = grep { $_->{'user'} eq $esc } @allusers;
 	if ($extrauser) {
 		&foreign_call($usermodule, "set_user_envs", $extrauser, 'DELETE_USER');
 		&set_virtualmin_user_envs($_[0], $_[1]);
@@ -2125,7 +2125,7 @@ if ($mail_system == 0 && $_[0]->{'user'} =~ /\@/) {
 
 # Delete any virtusers (extra email addresses for this user)
 &delete_virtuser($_[0]->{'virt'}) if ($_[0]->{'virt'});
-local $e;
+my $e;
 foreach $e (@{$_[0]->{'extravirt'}}) {
 	&delete_virtuser($e);
 	}
@@ -2163,13 +2163,13 @@ if ($config{'generics'} && $_[0]->{'generic'}) {
 
 # Delete database access (unless this is the domain owner)
 if ($_[1] && !$_[0]->{'domainowner'}) {
-	local $dt;
+	my $dt;
 	foreach $dt (&unique(map { $_->{'type'} } &domain_databases($_[1]))) {
-		local @dbs = map { $_->{'name'} }
+		my @dbs = map { $_->{'name'} }
 				 grep { $_->{'type'} eq $dt } @{$_[0]->{'dbs'}};
 		if (@dbs && &indexof($dt, &list_database_plugins()) < 0) {
 			# Delete from core database
-			local $dlfunc = "delete_${dt}_database_user";
+			my $dlfunc = "delete_${dt}_database_user";
 			&$dlfunc($_[1], $_[0]->{'user'});
 			}
 		elsif (@dbs && &indexof($dt, &list_database_plugins()) >= 0) {
@@ -2181,10 +2181,10 @@ if ($_[1] && !$_[0]->{'domainowner'}) {
 	}
 
 # Take the user out of any secondary groups
-local @groups = &list_all_groups();
+my @groups = &list_all_groups();
 foreach my $group (@groups) {
-	local @mems = split(/,/, $group->{'members'});
-	local $idx = &indexof($_[0]->{'user'}, @mems);
+	my @mems = split(/,/, $group->{'members'});
+	my $idx = &indexof($_[0]->{'user'}, @mems);
 	if ($idx >= 0) {
 		splice(@mems, $idx, 1);
 		$group->{'members'} = join(",", @mems);
@@ -2204,7 +2204,7 @@ if ($_[1]) {
 	}
 
 # Remove the plain-text password
-local %plain;
+my %plain;
 if (!-d $plainpass_dir) {
 	mkdir($plainpass_dir, 0700);
 	}
@@ -2214,7 +2214,7 @@ delete($plain{$_[0]->{'user'}." encrypted"});
 &write_file("$plainpass_dir/$_[1]->{'id'}", \%plain);
 
 # Remove the hashed password
-local %hash;
+my %hash;
 if (!-d $hashpass_dir) {
 	mkdir($hashpass_dir, 0700);
 	}
@@ -2225,7 +2225,7 @@ foreach my $s (@hashpass_types) {
 &write_file("$hashpass_dir/$_[1]->{'id'}", \%hash);
 
 # Clear the no-spam flag
-local %spam;
+my %spam;
 if (!-d $nospam_dir) {
 	mkdir($nospam_dir, 0700);
 	}
@@ -2332,7 +2332,7 @@ if ($_[2] && !$_[0]->{'domainowner'} &&
 # IMAP password
 sub set_usermin_imap_password
 {
-local ($user) = @_;
+my ($user) = @_;
 return 0 if (!$user->{'home'});
 return 0 if (!$user->{'plainpass'});
 
@@ -2340,7 +2340,7 @@ return 0 if (!$user->{'plainpass'});
 return 0 if (!&foreign_check("usermin"));
 &foreign_require("usermin");
 return 0 if (!&usermin::get_usermin_module_info("mailbox"));
-local %mconfig;
+my %mconfig;
 &read_file("$usermin::config{'usermin_dir'}/mailbox/config", \%mconfig);
 return 0 if ($mconfig{'mail_system'} != 4);
 return 0 if ($mconfig{'pop3_server'} eq '*');	# Via Dovecot IMAP command
@@ -2352,8 +2352,8 @@ return 0 if ($mconfig{'pop3_server'} ne '' &&
 # Set the password
 &create_usermin_module_directory($user, "mailbox");
 if (-d "$user->{'home'}/.usermin/mailbox") {
-	local %inbox;
-	local $imapfile = "$user->{'home'}/.usermin/mailbox/inbox.imap";
+	my %inbox;
+	my $imapfile = "$user->{'home'}/.usermin/mailbox/inbox.imap";
 	&read_file($imapfile, \%inbox);
 	if (&usermin::get_usermin_version() >= 1.323) {
 		$inbox{'user'} = '*';
@@ -2428,10 +2428,10 @@ return 0;
 # Delete all Cron jobs belonging to some Unix user
 sub delete_unix_cron_jobs
 {
-local ($username) = @_;
+my ($username) = @_;
 &foreign_require("cron");
-local @jobs = &cron::list_cron_jobs();
-local $cronfile;
+my @jobs = &cron::list_cron_jobs();
+my $cronfile;
 foreach my $j (@jobs) {
 	if ($j->{'user'} eq $username) {
 		$cronfile ||= &cron::cron_file($j);
@@ -2450,7 +2450,7 @@ if ($cron::config{'cron_dir'} && $username) {
 # Change the name of the user who owns any cron jobs
 sub rename_unix_cron_jobs
 {
-local ($username, $oldusername) = @_;
+my ($username, $oldusername) = @_;
 return if ($username eq $oldusername);
 &foreign_require("cron");
 if (-r "$cron::config{'cron_dir'}/$oldusername") {
@@ -2459,8 +2459,8 @@ if (-r "$cron::config{'cron_dir'}/$oldusername") {
 		       "$cron::config{'cron_dir'}/$username");
 	}
 # Rename jobs in other files
-local @jobs = &cron::list_cron_jobs();
-local $cronfile;
+my @jobs = &cron::list_cron_jobs();
+my $cronfile;
 foreach my $j (@jobs) {
 	if ($j->{'user'} eq $oldusername) {
 		$cronfile ||= &cron::cron_file($j);
@@ -2476,13 +2476,13 @@ foreach my $j (@jobs) {
 # Duplicate all cron jobs for some domain user
 sub copy_unix_cron_jobs
 {
-local ($username, $oldusername) = @_;
+my ($username, $oldusername) = @_;
 return if ($username eq $oldusername);
 &foreign_require("cron");
-local @jobs = &cron::list_cron_jobs();
+my @jobs = &cron::list_cron_jobs();
 foreach my $j (@jobs) {
 	if ($j->{'user'} eq $oldusername) {
-		local $newj = { %$j };
+		my $newj = { %$j };
 		$newj->{'user'} = $username;
 		&cron::create_cron_job($newj);
 		}
@@ -2493,10 +2493,10 @@ foreach my $j (@jobs) {
 # Disable all Cron jobs belonging to some Unix user
 sub disable_unix_cron_jobs
 {
-local ($username) = @_;
+my ($username) = @_;
 &foreign_require("cron");
-local @jobs = &cron::list_cron_jobs();
-local $cronfile;
+my @jobs = &cron::list_cron_jobs();
+my $cronfile;
 foreach my $j (@jobs) {
 	if ($j->{'user'} eq $username && $j->{'active'} && !$j->{'name'}) {
 		$cronfile ||= &cron::cron_file($j);
@@ -2515,10 +2515,10 @@ foreach my $j (@jobs) {
 # Enable all Cron jobs belonging to some Unix user
 sub enable_unix_cron_jobs
 {
-local ($username) = @_;
+my ($username) = @_;
 &foreign_require("cron");
-local @jobs = &cron::list_cron_jobs();
-local $cronfile;
+my @jobs = &cron::list_cron_jobs();
+my $cronfile;
 foreach my $j (@jobs) {
 	if ($j->{'user'} eq $username && !$j->{'active'} && !$j->{'name'} &&
 	    $j->{'command'} =~ /#\s+VIRTUALMIN\s+DISABLE/) {
@@ -2537,7 +2537,7 @@ foreach my $j (@jobs) {
 # or an error message on failure
 sub validate_user
 {
-local ($d, $user, $old) = @_;
+my ($d, $user, $old) = @_;
 if ($d && @{$user->{'dbs'}} && (!$old || !@{$old->{'dbs'}})) {
 	# Enabling database access .. make sure a password was given
 	if (!$user->{'plainpass'} && !$user->{'pass_mysql'}) {
@@ -2560,7 +2560,7 @@ return undef;
 # Sets the quotas for a mailbox user
 sub set_user_quotas
 {
-local $tmpl = &get_template($_[3] ? $_[3]->{'template'} : 0);
+my $tmpl = &get_template($_[3] ? $_[3]->{'template'} : 0);
 if (&has_quota_commands()) {
 	# Call the external quota program
 	&run_quota_command("set_user", $_[0],
@@ -2605,10 +2605,10 @@ foreach my $user (@$users) {
 # returns the output.
 sub run_quota_command
 {
-local ($cfg, @args) = @_;
-local $cmd = $config{'quota_'.$cfg.'_command'}." ".
+my ($cfg, @args) = @_;
+my $cmd = $config{'quota_'.$cfg.'_command'}." ".
 	     join(" ", map { quotemeta($_) } @args);
-local $out = &backquote_logged("$cmd 2>&1 </dev/null");
+my $out = &backquote_logged("$cmd 2>&1 </dev/null");
 if ($?) {
 	&error(&text('equotacommand', "<tt>$cmd</tt>",
 		     "<pre>".&html_escape($out)."</pre>"));
@@ -2624,8 +2624,8 @@ else {
 sub encrypt_user_password
 {
 &require_useradmin();
-local ($user, $pass) = @_;
-local $salt = $user->{'pass'};
+my ($user, $pass) = @_;
+my $salt = $user->{'pass'};
 $salt =~ s/^\!//;
 return &foreign_call($usermodule, "encrypt_password", $pass, $salt);
 }
@@ -2640,20 +2640,20 @@ return &foreign_call($usermodule, "encrypt_password", $pass, $salt);
 # digest - Web digest authentication hash
 sub generate_password_hashes
 {
-local ($user, $pass, $d) = @_;
-local $tmpl = &get_template($d->{'template'});
+my ($user, $pass, $d) = @_;
+my $tmpl = &get_template($d->{'template'});
 if ($tmpl->{'hashtypes'} eq 'none') {
 	# Don't return any hash types
 	return { };
 	}
 &require_useradmin();
-local %rv;
-local $salt = $user->{'pass'} && $user->{'pass'} !~ /\$/ ? $user->{'pass'}
+my %rv;
+my $salt = $user->{'pass'} && $user->{'pass'} !~ /\$/ ? $user->{'pass'}
 							 : &random_salt();
 $salt =~ s/^\!// if ($salt);
 $rv{'crypt'} = &unix_crypt($pass, $salt);
 if (!&useradmin::check_md5()) {
-	local $salt = $user->{'pass'} &&
+	my $salt = $user->{'pass'} &&
 		      $user->{'pass'} =~ /\$1\$/ ? $user->{'pass'} : undef;
 	$salt =~ s/^\!// if ($salt);
 	$rv{'md5'} = &useradmin::encrypt_md5($pass);
@@ -2664,9 +2664,9 @@ if ($config{'mysql'}) {
 	eval {
 		# This can fail if MySQL is down
 		local $main::error_must_die = 1;
-		local $qpass = &mysql_escape($pass);
-		local $pf = &get_mysql_password_func($d);
-		local $rv = &execute_dom_sql($d, $mysql::master_db,
+		my $qpass = &mysql_escape($pass);
+		my $pf = &get_mysql_password_func($d);
+		my $rv = &execute_dom_sql($d, $mysql::master_db,
 					     "select $pf('$qpass')");
 		$rv{'mysql'} = $rv->{'data'}->[0]->[0];
 		};
@@ -2678,7 +2678,7 @@ if (&foreign_check("htaccess-htpasswd")) {
 	}
 if ($tmpl->{'hashtypes'} ne '' && $tmpl->{'hashtypes'} ne '*') {
 	# Remove disabled types
-	local %newrv;
+	my %newrv;
 	foreach my $t (split(/\s+/, $tmpl->{'hashtypes'})) {
 		$newrv{$t} = $rv{$t} if (defined($rv{$t}));
 		}
@@ -2702,8 +2702,8 @@ return ( map { [ $_, $text{'hashtype_'.$_} ] } @hashpass_types );
 # when creating a new domain.
 sub generate_domain_password_hashes
 {
-local ($d, $newdom) = @_;
-local $parent = $d->{'parent'} ? &get_domain($d->{'parent'}) : undef;
+my ($d, $newdom) = @_;
+my $parent = $d->{'parent'} ? &get_domain($d->{'parent'}) : undef;
 if ($newdom) {
 	if ($parent) {
 		# Inherit from parent
@@ -2711,7 +2711,7 @@ if ($newdom) {
 		}
 	else {
 		# Inherit from template
-		local $tmpl = &get_template($d->{'template'});
+		my $tmpl = &get_template($d->{'template'});
 		$d->{'hashpass'} ||= $tmpl->{'hashpass'};
 		}
 	}
@@ -2727,8 +2727,8 @@ if ($d->{'parent'}) {
 else {
 	# Hash and store
 	return if (!$d->{'pass'});	# Plaintext password unknown
-	local $fakeuinfo = { 'user' => $d->{'user'} };
-	local $hashes = &generate_password_hashes(
+	my $fakeuinfo = { 'user' => $d->{'user'} };
+	my $hashes = &generate_password_hashes(
 				$fakeuinfo, $d->{'pass'}, $d);
 	$d->{'enc_pass'} = $hashes->{'unix'};
 	if (!$d->{'mysql_pass'}) {
@@ -2746,11 +2746,11 @@ delete($d->{'pass'});
 # Creates the home directory for a new mail user, and copies skel files into it
 sub create_user_home
 {
-local ($user, $d, $always) = @_;
-local $home = $user->{'home'};
+my ($user, $d, $always) = @_;
+my $home = $user->{'home'};
 if ($home) {
 	# Create his homedir
-	local @st = $d ? stat($d->{'home'}) : ( undef, undef, 0755 );
+	my @st = $d ? stat($d->{'home'}) : ( undef, undef, 0755 );
 	if (!-e $home || $always) {
 		&lock_file($home);
 		&make_dir($home, $st[2] & 0777);
@@ -2775,7 +2775,7 @@ if ($home) {
 # Deletes the home directory of a user, if valid
 sub delete_user_home
 {
-local ($user, $d) = @_;
+my ($user, $d) = @_;
 if (-d $user->{'home'} &&
     !&same_file($user->{'home'}, $d->{'home'}) &&
     &safe_delete_dir($d, $user->{'home'})) {
@@ -2799,7 +2799,7 @@ return &text('indom', "<tt>".&show_domain_name($_[0])."</tt>");
 # Copy files to the home directory of some new user
 sub copy_skel_files
 {
-local ($uf, $user, $home, $group, $d) = @_;
+my ($uf, $user, $home, $group, $d) = @_;
 return if (!$uf);
 
 # Find all files under the skeleton dir
@@ -2807,16 +2807,16 @@ my @files = &find_recursive_files($uf);
 my @copied;
 foreach my $f (@files) {
 	local $src = "$uf/$f";		# Needs to be local, for subs
-	local $dst = "$home/$f";
+	my $dst = "$home/$f";
 	my $func;
 
 	# Get file info as root before copying
-	local @st = stat($src);
-	local $data;
+	my @st = stat($src);
+	my $data;
 	if (-f $src) {
 		$data = &read_file_contents($src);
 		}
-	local $lnk = readlink($src);
+	my $lnk = readlink($src);
 
 	if (-l $src) {
 		# Re-create symlink
@@ -2847,7 +2847,7 @@ foreach my $f (@files) {
 
 # Perform variable substition on the files, if requested
 if ($d) {
-	local $tmpl = &get_template($d->{'template'});
+	my $tmpl = &get_template($d->{'template'});
 	if ($tmpl->{'skel_subs'}) {
 		foreach my $c (@copied) {
 			if (-r $c && !-d $c && !-l $c &&
@@ -2855,7 +2855,7 @@ if ($d) {
 			     &match_skel_subs($c, $tmpl->{'skel_onlysubs'})) &&
 			    !&match_skel_subs($c, $tmpl->{'skel_nosubs'}) &&
 			    &guess_mime_type($c) !~ /^image\//) {
-				local $data =
+				my $data =
 				    &read_file_contents_as_domain_user($d, $c);
 				&open_tempfile_as_domain_user($d, OUT, ">$c");
 				&print_tempfile(OUT,
@@ -2927,7 +2927,7 @@ if ($access{'reseller'}) {
 else {
 	return 1 if ($access{'domains'} eq "*");
 	return 0 if (!$_[0]->{'id'});
-	local $d;
+	my $d;
 	foreach $d (split(/\s+/, $access{'domains'})) {
 		return 1 if ($d eq $_[0]->{'id'});
 		}
@@ -2938,7 +2938,7 @@ else {
 # can_delete_domain(&domain)
 sub can_delete_domain
 {
-local ($d) = @_;
+my ($d) = @_;
 return &can_edit_domain($d) && !$d->{'protected'} &&
        (&master_admin() || &reseller_admin() && !$access{'nodelete'} ||
 	$_[0]->{'parent'} && $access{'edit_delete'});
@@ -2953,7 +2953,7 @@ return &master_admin();
 
 sub can_move_domain
 {
-local ($d) = @_;
+my ($d) = @_;
 return &can_edit_domain($d) &&
        (&master_admin() || &reseller_admin());
 }
@@ -3049,7 +3049,7 @@ elsif ($config{'allow_subdoms'} eq '0') {
 	return 0;
 	}
 else {
-	local @subdoms = grep { $_->{'subdom'} } &list_domains();
+	my @subdoms = grep { $_->{'subdom'} } &list_domains();
 	return @subdoms ? 1 : 0;
 	}
 }
@@ -3099,7 +3099,7 @@ return $config{'show_ugroup'} && &master_admin();
 # or enable or disable it for existing domains
 sub can_use_feature
 {
-local ($f) = @_;
+my ($f) = @_;
 if (&master_admin()) {
 	# Master admin can use anything
 	return 1;
@@ -3125,7 +3125,7 @@ else {
 # IP for a virtual server
 sub can_select_ip
 {
-local @shared = &list_shared_ips();
+my @shared = &list_shared_ips();
 return &can_use_feature("virt") ||
        @shared && &can_edit_sharedips();
 }
@@ -3134,7 +3134,7 @@ return &can_use_feature("virt") ||
 # IPv6 address for a virtual server
 sub can_select_ip6
 {
-local @shared = &list_shared_ip6s();
+my @shared = &list_shared_ip6s();
 return &can_use_feature("virt6") ||
        @shared && &can_edit_sharedips();
 }
@@ -3209,7 +3209,7 @@ return &master_admin() || &reseller_admin() || !$access{'nodbname'};
 
 sub can_edit_admins
 {
-local ($d) = @_;
+my ($d) = @_;
 return $d->{'webmin'} &&
        (&master_admin() ||
 	&reseller_admin() && !$access{'noadmins'} ||
@@ -3307,7 +3307,7 @@ return !$access{'admin'} && &can_backup_domain();
 # Allow master admin, resellers, domain owners with DNS options permissions
 sub can_edit_dns
 {
-local ($d) = @_;
+my ($d) = @_;
 return &master_admin() || &reseller_admin() || $access{'edit_spf'};
 }
 
@@ -3315,7 +3315,7 @@ return &master_admin() || &reseller_admin() || $access{'edit_spf'};
 # Allow master admin, resellers, domain owners with DNS options permissions
 sub can_edit_dmarc
 {
-local ($d) = @_;
+my ($d) = @_;
 return &master_admin() || &reseller_admin() || $access{'edit_spf'};
 }
 
@@ -3323,7 +3323,7 @@ return &master_admin() || &reseller_admin() || $access{'edit_spf'};
 # Allow master admin, resellers, domain owners with DNS records permission
 sub can_edit_records
 {
-local ($d) = @_;
+my ($d) = @_;
 return &master_admin() || &reseller_admin() || $access{'edit_records'};
 }
 
@@ -3335,7 +3335,7 @@ return &master_admin() || &reseller_admin() || $access{'edit_mail'};
 # Returns 1 if the current user can disable and enable the given domain
 sub can_disable_domain
 {
-local ($d) = @_;
+my ($d) = @_;
 return &can_edit_domain($d) && !$d->{'protected'} &&
        (&master_admin() || &reseller_admin() ||
         $d->{'parent'} && !$d->{'alias'} && $access{'edit_disable'});
@@ -3357,7 +3357,7 @@ return $config{'edit_afiles'} || &master_admin();
 # Returns 1 if the current user can change the IP of a domain
 sub can_change_ip
 {
-local $tmpl = &get_template($_[0]->{'template'});
+my $tmpl = &get_template($_[0]->{'template'});
 return &master_admin() ||
        $access{'edit_ip'} && &can_use_feature("virt") &&
        $tmpl->{'ranges'} ne "none";
@@ -3368,7 +3368,7 @@ return &master_admin() ||
 # mailbox user
 sub can_mailbox_home
 {
-local ($user) = @_;
+my ($user) = @_;
 return &master_admin() ||
        $config{'edit_homes'} == 1 ||
        $config{'edit_homes'} == 2 && $user->{'webowner'};
@@ -3411,21 +3411,21 @@ return &master_admin() || $config{'edit_quota'};
 # Returns 1 if some template can be used by the current user, or his reseller
 sub can_use_template
 {
-local ($tmpl) = @_;
+my ($tmpl) = @_;
 if (&master_admin()) {
 	# Root can use all templates
 	return 1;
 	}
 if ($tmpl->{'resellers'} ne '*') {
 	# Template has a reseller restriction, check it
-	local %resels = map { $_, 1 } split(/\s+/, $tmpl->{'resellers'});
+	my %resels = map { $_, 1 } split(/\s+/, $tmpl->{'resellers'});
 	if (&reseller_admin()) {
 		# Is current user in the reseller list?
 		return 0 if (!$resels{$base_remote_user});
 		}
 	else {
 		# Is user's reseller in list?
-		local $dom = &get_domain_by("user", $base_remote_user,
+		my $dom = &get_domain_by("user", $base_remote_user,
 					    "parent", undef);
 		if (!($dom && $dom->{'reseller'} &&
 		      $resels{$dom->{'reseller'}})) {
@@ -3435,7 +3435,7 @@ if ($tmpl->{'resellers'} ne '*') {
 	}
 if ($tmpl->{'owners'} ne '*' && !&reseller_admin()) {
 	# Template has owner restrictions, check them
-	local %owners = map { $_, 1 } split(/\s+/, $tmpl->{'owners'});
+	my %owners = map { $_, 1 } split(/\s+/, $tmpl->{'owners'});
 	return 0 if (!$owners{$base_remote_user});
 	}
 return 1;
@@ -3457,7 +3457,7 @@ return &master_admin();
 # Returns 1 if the current user can switch to the Webmin login for some domain
 sub can_switch_user
 {
-local ($d, $admin) = @_;
+my ($d, $admin) = @_;
 return $main::session_id &&	# When using session auth
        !$access{'admin'} &&	# Not for extra admins
        (&master_admin() ||	# Master can switch, or domain owner to extras
@@ -3469,7 +3469,7 @@ return $main::session_id &&	# When using session auth
 # Returns 1 if the current user is allowed to switch to Usermin
 sub can_switch_usermin
 {
-local ($d, $user) = @_;
+my ($d, $user) = @_;
 return &can_edit_domain($d) &&
        &master_admin() || $config{'usermin_switch'};
 }
@@ -3478,7 +3478,7 @@ return &can_edit_domain($d) &&
 # Returns 1 if Usermin can accept a one-time login URL
 sub can_create_usermin_login_url
 {
-local ($miniserv) = @_;
+my ($miniserv) = @_;
 &foreign_require("acl");
 return $miniserv->{'session'} &&
        defined(&acl::open_session_db) &&
@@ -3490,16 +3490,16 @@ return $miniserv->{'session'} &&
 # Creates a one-time URL that logs into Usermin as some user
 sub create_usermin_login_url
 {
-local ($d, $user, $lifetime) = @_;
+my ($d, $user, $lifetime) = @_;
 &foreign_require("usermin");
-local %miniserv;
+my %miniserv;
 &usermin::get_usermin_miniserv_config(\%miniserv);
 &can_create_usermin_login_url(\%miniserv) ||
 	&error($text{'user_eswitch'});
 &check_pid_file($miniserv{'pidfile'}) ||
 	&error($text{'user_eswitch'});
 $lifetime ||= 5*60;
-local $sid = &create_usermin_login_session(\%miniserv, "-".$user,
+my $sid = &create_usermin_login_session(\%miniserv, "-".$user,
 					   $lifetime);
 $sid || &error($text{'user_eswitch'});
 
@@ -3507,7 +3507,7 @@ $sid || &error($text{'user_eswitch'});
 # stopping the service or racing its PID file re-creation.
 &usermin::reload_usermin_miniserv();
 
-local $url = &get_usermin_login_base_url(\%miniserv);
+my $url = &get_usermin_login_base_url(\%miniserv);
 $url =~ s/\/+$//;
 return $url."/session_login.cgi?session=".&urlize($sid);
 }
@@ -3516,12 +3516,12 @@ return $url."/session_login.cgi?session=".&urlize($sid);
 # Creates a one-time Usermin session token for the current browser
 sub create_usermin_login_session
 {
-local ($miniserv, $user, $lifetime) = @_;
+my ($miniserv, $user, $lifetime) = @_;
 return if (&is_readonly_mode());
-local $sid = &acl::generate_random_session_id();
+my $sid = &acl::generate_random_session_id();
 return if (!$sid);
-local $ip = $ENV{'REMOTE_ADDR'} || "127.0.0.1";
-local $now = time();
+my $ip = $ENV{'REMOTE_ADDR'} || "127.0.0.1";
+my $now = time();
 &acl::open_session_db($miniserv);
 $acl::sessiondb{$sid} = "$user $now $ip".($lifetime ? " ".$lifetime : "");
 dbmclose(%acl::sessiondb);
@@ -3532,20 +3532,20 @@ return $sid;
 # Returns the base URL to use for browser handoff to Usermin
 sub get_usermin_login_base_url
 {
-local ($miniserv) = @_;
+my ($miniserv) = @_;
 return $miniserv->{'redirect_url'} if ($miniserv->{'redirect_url'});
 
-local %uconfig;
+my %uconfig;
 &usermin::get_usermin_config(\%uconfig);
-local $ssl = $miniserv->{'ssl'} || $miniserv->{'inetd_ssl'};
+my $ssl = $miniserv->{'ssl'} || $miniserv->{'inetd_ssl'};
 eval "use Net::SSLeay";
 $ssl = 0 if ($@);
-local ($host, $port);
+my ($host, $port);
 if ($uconfig{'host'}) {
 	$host = $uconfig{'host'};
 	}
 else {
-	local @sockets = &webmin::get_miniserv_sockets($miniserv);
+	my @sockets = &webmin::get_miniserv_sockets($miniserv);
 	if (@sockets && $sockets[0]->[0] ne "*") {
 		$host = $sockets[0]->[0];
 		$port = $sockets[0]->[1] if ($sockets[0]->[1] ne '*');
@@ -3563,7 +3563,7 @@ return ($ssl ? "https://" : "http://").$host.":".$port;
 # none was given). Also returns 0 if mail logs are not enabled.
 sub can_view_maillog
 {
-local ($d) = @_;
+my ($d) = @_;
 return 0 if ($config{'maillog_hide'} == 2 ||
 	     $config{'maillog_hide'} == 1 && !&master_admin());
 return 0 if (!&procmail_logging_enabled());
@@ -3623,16 +3623,16 @@ return 1;
 # Display a list of domains in a table, with links for editing
 sub domains_table
 {
-local ($doms, $checks, $noprint, $exclude) = @_;
+my ($doms, $checks, $noprint, $exclude) = @_;
 $exclude ||= [ ];
-local %emap = map { $_, 1 } @$exclude;
-local $usercounts = &count_domain_users();
-local $aliascounts = &count_domain_aliases(1);
-local @table_features = grep { $config{$_} } split(/,/, $config{'index_fcols'});
-local $showchecks = $checks && &can_config_domain($_[0]->[0]);
+my %emap = map { $_, 1 } @$exclude;
+my $usercounts = &count_domain_users();
+my $aliascounts = &count_domain_aliases(1);
+my @table_features = grep { $config{$_} } split(/,/, $config{'index_fcols'});
+my $showchecks = $checks && &can_config_domain($_[0]->[0]);
 
 # Generate headers
-local @heads;
+my @heads;
 if ($showchecks) {
 	push(@heads, "");
 	}
@@ -3658,11 +3658,11 @@ foreach my $f (&list_custom_fields()) {
 push(@heads, map { $text{'index_'.$_} } @table_features);
 
 # Generate the table contents
-local @table;
+my @table;
 foreach my $d (&sort_indent_domains($doms)) {
 	$done{$d->{'id'}}++;
-	local $pfx = "&nbsp;" x ($d->{'indent'} * 2);
-	local @cols;
+	my $pfx = "&nbsp;" x ($d->{'indent'} * 2);
+	my @cols;
 
 	# Add configured columns
 	foreach my $c (@colnames) {
@@ -3774,7 +3774,7 @@ foreach my $d (&sort_indent_domains($doms)) {
 				    $d->{'quota'}*&quota_bsize("home") : undef;
 				my ($hq, $dbq) = &get_domain_quota($d, 1);
 				my $ut = $hq*&quota_bsize("home") + $dbq;
-				local $txt = &nice_size($ut);
+				my $txt = &nice_size($ut);
 				if ($qmax && $bytes > $qmax) {
 					$txt ="<font color=#ff0000>$txt</font>";
 					}
@@ -3853,7 +3853,7 @@ foreach my $d (&sort_indent_domains($doms)) {
 	}
 
 # Output the table
-local $rv = &ui_columns_table(\@heads, 100, \@table);
+my $rv = &ui_columns_table(\@heads, 100, \@table);
 if ($noprint) {
 	return $rv;
 	}
@@ -3909,9 +3909,9 @@ else {
 # Returns the append_style number used for some username, or undef if unknown
 sub guess_append_style
 {
-local ($name, $d) = @_;
-local $p = $d->{'prefix'};
-local $dom = $d->{'dom'};
+my ($name, $d) = @_;
+my $p = $d->{'prefix'};
+my $dom = $d->{'dom'};
 return $name =~ /\.\Q$p\E$/ ? 0 :
        $name =~ /\-\Q$p\E$/ ? 1 :
        $name =~ /^\Q$p\E\./ ? 2 :
@@ -3928,9 +3928,9 @@ sub remove_userdom
 {
 return $_[0] if (!$_[1]);			# No domain
 return $_[0] if ($_[0] eq $_[1]->{'user'});	# Domain owner has no prefix
-local $g = $_[1]->{'prefix'};
-local $d = $_[1]->{'dom'};
-local $rv = $_[0];
+my $g = $_[1]->{'prefix'};
+my $d = $_[1]->{'dom'};
+my $rv = $_[0];
 ($rv =~ s/\@(\Q$d\E)$//) || ($rv =~ s/(\.|\-|_|\%)\Q$g\E$//) || ($rv =~ s/^\Q$g\E(\.|\-|_|\%)//);
 return $rv;
 }
@@ -3939,7 +3939,7 @@ return $rv;
 # Returns an error message if a username is too long for this Unix variant
 sub too_long
 {
-local $max = &max_username_length();
+my $max = &max_username_length();
 if ($max && length($_[0]) > $max) {
 	return &text('user_elong', "<tt>$_[0]</tt>", $max);
 	}
@@ -3952,7 +3952,7 @@ else {
 # Returns an error message if an alias name contains bogus characters
 sub valid_alias_name
 {
-local ($name) = @_;
+my ($name) = @_;
 if ($name !~ /^[^ \t:\&\(\)\|\;\<\>\*\?\!\/\\]+$/) {
 	return $text{'user_euser'};
 	}
@@ -3964,9 +3964,9 @@ return undef;
 # a reserved name
 sub valid_mailbox_name
 {
-local ($name) = @_;
+my ($name) = @_;
 &require_useradmin();
-local $err = &valid_alias_name($name);
+my $err = &valid_alias_name($name);
 return $err if ($err);
 if ($name eq "domains" || $name eq $home_virtualmin_backup) {
 	return &text('user_ereserved', $name);
@@ -3992,11 +3992,11 @@ return $uconfig{'max_length'};
 # has a custom IP, use that.
 sub get_default_ip
 {
-local ($reselname) = @_;
+my ($reselname) = @_;
 if ($reselname && defined(&get_reseller)) {
 	# Check if the reseller has an IP
 	foreach my $r (split(/\s+/, $reselname)) {
-		local $resel = &get_reseller($r);
+		my $resel = &get_reseller($r);
 		if ($resel && $resel->{'acl'}->{'defip'}) {
 			return $resel->{'acl'}->{'defip'};
 			}
@@ -4009,7 +4009,7 @@ if ($config{'defip'}) {
 elsif (&running_in_zone()) {
 	# From zone's interface
 	&foreign_require("net");
-	local ($iface) = grep { $_->{'up'} &&
+	my ($iface) = grep { $_->{'up'} &&
 				&net::iface_type($_->{'name'}) =~ /ethernet/i }
 			      &net::active_interfaces();
 	return $iface ? $iface->{'address'} : undef;
@@ -4017,8 +4017,8 @@ elsif (&running_in_zone()) {
 else {
 	# From interface detected at check time
 	&foreign_require("net");
-	local $ifacename = $config{'iface'} || &first_ethernet_iface();
-	local ($iface) = grep { $_->{'fullname'} eq $ifacename }
+	my $ifacename = $config{'iface'} || &first_ethernet_iface();
+	my ($iface) = grep { $_->{'fullname'} eq $ifacename }
 			      &net::active_interfaces();
 	if ($iface) {
 		return $iface->{'address'};
@@ -4034,10 +4034,10 @@ else {
 # has a custom IP, use that.
 sub get_default_ip6
 {
-local ($reselname) = @_;
+my ($reselname) = @_;
 if ($reselname && defined(&get_reseller)) {
 	# Check if the reseller has an IP
-	local $resel = &get_reseller($reselname);
+	my $resel = &get_reseller($reselname);
 	if ($resel && $resel->{'acl'}->{'defip6'}) {
 		return $resel->{'acl'}->{'defip6'};
 		}
@@ -4049,8 +4049,8 @@ if ($config{'defip6'}) {
 else {
 	# From interface detected at check time
 	&foreign_require("net");
-	local $ifacename = $config{'iface'} || &first_ethernet_iface();
-	local ($iface) = grep { $_->{'fullname'} eq $ifacename }
+	my $ifacename = $config{'iface'} || &first_ethernet_iface();
+	my ($iface) = grep { $_->{'fullname'} eq $ifacename }
 			      &net::boot_interfaces();
 	if ($iface) {
 		# Use address on the boot interface if possible, as active
@@ -4073,7 +4073,7 @@ else {
 # Returns the best IPv6 address (not local) from an interface
 sub best_ip6_address
 {
-local ($iface) = @_;
+my ($iface) = @_;
 return undef if (!$iface->{'address6'});
 foreach my $a (@{$iface->{'address6'}}) {
 	next if ($a eq '::1');		 # localhost
@@ -4121,9 +4121,9 @@ return undef;
 # Given an IPv4 or v6 address, returns the interface name
 sub get_address_iface
 {
-local ($a) = @_;
+my ($a) = @_;
 &foreign_require("net");
-local ($iface) = grep {
+my ($iface) = grep {
 	$_->{'address'} eq $a ||
 	&indexof(&net::canonicalize_ip6($a),
 		 (map { &net::canonicalize_ip6($_) } @{$_->{'address6'}})) >= 0
@@ -4135,8 +4135,8 @@ return $iface ? $iface->{'fullname'} : undef;
 # Returns an error string if the default Apache directives don't look valid
 sub check_apache_directives
 {
-local ($d, $gotname, $gotdom, $gotdoc, $gotproxy);
-local @dirs = split(/\t+/, defined($_[0]) ? $_[0] : $config{'apache_config'});
+my ($d, $gotname, $gotdom, $gotdoc, $gotproxy);
+my @dirs = split(/\t+/, defined($_[0]) ? $_[0] : $config{'apache_config'});
 foreach $d (@dirs) {
 	$d =~ s/#.*$//;
 	if ($d =~ /^\s*ServerName\s+(\S+)$/i) {
@@ -4197,7 +4197,7 @@ sub indent_text_print { $indent_text .= "    "; }
 sub outdent_text_print { $indent_text = substr($indent_text, 4); }
 sub html_tags_to_text
 {
-local ($rv, $disallow_newlines, $allow_links) = @_;
+my ($rv, $disallow_newlines, $allow_links) = @_;
 my $newline = "\n";
 if ($disallow_newlines) {
 	$newline = " " if ($disallow_newlines);
@@ -4268,7 +4268,7 @@ push(@print_function_stack, [ $first_print, $second_print,
 }
 sub pop_all_print
 {
-local $p = pop(@print_function_stack);
+my $p = pop(@print_function_stack);
 ($first_print, $second_print, $indent_print, $outdent_print) = @$p;
 }
 
@@ -4298,7 +4298,7 @@ if ($print_capture) {
 # Returns 1 if email would be sent to this domain at signup time
 sub will_send_domain_email
 {
-local $tmpl = &get_template($_[0]->{'template'});
+my $tmpl = &get_template($_[0]->{'template'});
 return $tmpl->{'mail_on'} ne 'none';
 }
 
@@ -4308,20 +4308,20 @@ return $tmpl->{'mail_on'} ne 'none';
 # messages.
 sub send_domain_email
 {
-local ($d, $forceto, $pass) = @_;
-local $tmpl = &get_template($d->{'template'});
-local $mail = $tmpl->{'mail'};
-local $subject = $tmpl->{'mail_subject'};
-local $cc = $tmpl->{'mail_cc'};
-local $bcc = $tmpl->{'mail_bcc'};
+my ($d, $forceto, $pass) = @_;
+my $tmpl = &get_template($d->{'template'});
+my $mail = $tmpl->{'mail'};
+my $subject = $tmpl->{'mail_subject'};
+my $cc = $tmpl->{'mail_cc'};
+my $bcc = $tmpl->{'mail_bcc'};
 if ($tmpl->{'mail_on'} eq 'none') {
 	return (1, undef);
 	}
 &$first_print($text{'setup_email'});
 
-local %hash = &make_domain_substitions($d, 1);
+my %hash = &make_domain_substitions($d, 1);
 $hash{'pass'} = $pass if ($pass);
-local @erv = &send_template_email($mail, $forceto || $d->{'emailto'},
+my @erv = &send_template_email($mail, $forceto || $d->{'emailto'},
 			    	  \%hash, $subject, $cc, $bcc, undef,
 				  &get_global_from_address($d));
 if ($erv[0]) {
@@ -4337,9 +4337,9 @@ return @erv;
 # Returns a hash of substitions for email to a virtual server
 sub make_domain_substitions
 {
-local ($d, $nice_sizes) = @_;
-local %hash = %$d;
-local $tmpl = &get_template($d->{'template'});
+my ($d, $nice_sizes) = @_;
+my %hash = %$d;
+my $tmpl = &get_template($d->{'template'});
 
 delete($hash{''});
 $hash{'idndom'} = &show_domain_name($d->{'dom'});	# With unicode
@@ -4350,7 +4350,7 @@ if ($d->{'disabled_time'}) {
 	}
 
 # Add parent domain info
-local $parent;
+my $parent;
 if ($d->{'parent'}) {
 	$parent = &get_domain($d->{'parent'});
 	foreach my $k (keys %$parent) {
@@ -4361,7 +4361,7 @@ if ($d->{'parent'}) {
 
 # Add alias target domain info
 if ($d->{'alias'}) {
-	local $alias = &get_domain($d->{'alias'});
+	my $alias = &get_domain($d->{'alias'});
 	foreach my $k (keys %$alias) {
 		$hash{'alias_domain_'.$k} = $alias->{$k};
 		}
@@ -4371,8 +4371,8 @@ if ($d->{'alias'}) {
 # Add (first) reseller details
 if ($d->{'reseller'} && defined(&get_reseller)) {
 	my @r = split(/\s+/, $d->{'reseller'});
-	local $resel = &get_reseller($r[0]);
-	local $acl = $resel->{'acl'};
+	my $resel = &get_reseller($r[0]);
+	my $acl = $resel->{'acl'};
 	$hash{'reseller_name'} = $resel->{'name'};
 	$hash{'reseller_theme'} = $resel->{'theme'};
 	$hash{'reseller_modules'} = join(" ", @{$resel->{'modules'}});
@@ -4382,7 +4382,7 @@ if ($d->{'reseller'} && defined(&get_reseller)) {
 	}
 
 # Add plan details, if any
-local $plan = &get_plan($d->{'plan'});
+my $plan = &get_plan($d->{'plan'});
 if ($plan) {
 	foreach my $k (keys %$plan) {
 		$hash{'plan_'.$k} = $plan->{$k};
@@ -4413,13 +4413,13 @@ if ($config{'dns'}) {
 
 # Add webmin and usermin ports
 $hash{'virtualmin_url'} = &get_virtualmin_url($d);
-local %miniserv;
+my %miniserv;
 &get_miniserv_config(\%miniserv);
 $hash{'webmin_port'} = $miniserv{'port'};
 $hash{'webmin_proto'} = $miniserv{'ssl'} ? 'https' : 'http';
 if (&foreign_installed('usermin')) {
 	&foreign_require('usermin');
-	local %uminiserv;
+	my %uminiserv;
 	&usermin::get_usermin_miniserv_config(\%uminiserv);
 	$hash{'usermin_port'} = $uminiserv{'port'};
 	$hash{'usermin_proto'} = $uminiserv{'ssl'} ? 'https' : 'http';
@@ -4488,9 +4488,9 @@ for(my $i=1; $i<=10; $i++) {
 	}
 
 # Add secondary mail servers
-local %ids = map { $_, 1 } split(/\s+/, $d->{'mx_servers'});
+my %ids = map { $_, 1 } split(/\s+/, $d->{'mx_servers'});
 if (%ids) {
-	local @servers = grep { $ids{$_->{'id'}} } &list_mx_servers();
+	my @servers = grep { $ids{$_->{'id'}} } &list_mx_servers();
 	$hash{'mx_slaves'} = join(" ", map { $_->{'host'} } @servers);
 	}
 else {
@@ -4499,8 +4499,8 @@ else {
 
 # Add secondary nameservers
 if ($config{'dns'}) {
-	local %on = map { $_, 1 } split(/\s+/, $d->{'dns_slave'});
-	local @servers = grep { $on{$_->{'host'}} || $on{$_->{'nsname'}} }
+	my %on = map { $_, 1 } split(/\s+/, $d->{'dns_slave'});
+	my @servers = grep { $on{$_->{'host'}} || $on{$_->{'nsname'}} }
 			      &bind8::list_slave_servers();
 	$hash{'dns_server'} = &get_master_nameserver($tmpl);
 	$hash{'dns_slave'} = join(" ", map { $_->{'nsname'} || $_->{'host'} }
@@ -4550,10 +4550,10 @@ return %hash;
 # has been deactivated, or if the domain doesn't even have email
 sub will_send_user_email
 {
-local ($d, $isnew) = @_;
+my ($d, $isnew) = @_;
 return 0 if ($d->{'domainowner'});
-local $tmpl = &get_template($d ? $d->{'template'} : 0);
-local $tmode = !$d || $isnew ? "newuser" : "updateuser";
+my $tmpl = &get_template($d ? $d->{'template'} : 0);
+my $tmode = !$d || $isnew ? "newuser" : "updateuser";
 if ($tmpl->{$tmode.'_on'} eq 'none' ||
     $tmode eq "newuser" && !$tmpl->{$tmode.'_to_mailbox'}) {
         return 0;
@@ -4569,35 +4569,35 @@ else {
 # and an optional message
 sub send_user_email
 {
-local ($d, $user, $userto, $mode) = @_;
-local $tmpl = &get_template($d ? $d->{'template'} : 0);
-local $tmode = $mode ? "updateuser" : "newuser";
-local $subject = $tmpl->{$tmode.'_subject'};
+my ($d, $user, $userto, $mode) = @_;
+my $tmpl = &get_template($d ? $d->{'template'} : 0);
+my $tmode = $mode ? "updateuser" : "newuser";
+my $subject = $tmpl->{$tmode.'_subject'};
 if ($tmpl->{$tmode.'_on'} eq 'none') {
 	return (1, undef);
 	}
 
 # Work out who we CC to
-local @ccs;
+my @ccs;
 push(@ccs, $tmpl->{$tmode.'_cc'}) if ($tmpl->{$tmode.'_cc'});
 push(@ccs, $d->{'emailto'}) if ($d && $tmpl->{$tmode.'_to_owner'});
 if ($tmpl->{$tmode.'_to_reseller'} && $d && $d->{'reseller'} &&
     defined(&get_reseller)) {
 	foreach my $r (split(/\s+/, $d->{'reseller'})) {
-		local $resel = &get_reseller($r);
+		my $resel = &get_reseller($r);
 		if ($resel && $resel->{'acl'}->{'email'}) {
 			push(@ccs, &extract_address_parts(
 				$resel->{'acl'}->{'email'}));
 			}
 		}
 	}
-local $cc = join(",", @ccs);
-local $bcc = $tmpl->{$tmode.'_bcc'};
+my $cc = join(",", @ccs);
+my $bcc = $tmpl->{$tmode.'_bcc'};
 
-local $mail = $tmpl->{$tmode};
+my $mail = $tmpl->{$tmode};
 return (1, undef) if ($mail eq 'none');
-local %hash = &make_user_substitutions($user, $d);
-local $email = $d ? $hash{'mailbox'}.'@'.$hash{'dom'}
+my %hash = &make_user_substitutions($user, $d);
+my $email = $d ? $hash{'mailbox'}.'@'.$hash{'dom'}
 		  : $hash{'user'}.'@'.&get_system_hostname();
 
 # Work out who we send to
@@ -4621,8 +4621,8 @@ return &send_template_email($mail, $email, \%hash,
 # Create a hash of email substitions for a user in some domain
 sub make_user_substitutions
 {
-local ($user, $d) = @_;
-local %hash;
+my ($user, $d) = @_;
+my %hash;
 if ($d) {
 	%hash = ( %$d, %$user );
 	$hash{'mailbox'} = &remove_userdom($user->{'user'}, $d);
@@ -4635,7 +4635,7 @@ $hash{'plainpass'} ||= "";
 $hash{'extra'} = join(" ", @{$user->{'extraemail'}});
 
 # Check SSH and FTP shells
-local ($shell) = grep { $_->{'shell'} eq $user->{'shell'} }
+my ($shell) = grep { $_->{'shell'} eq $user->{'shell'} }
 		      &list_available_shells();
 if ($shell) {
 	$hash{'ftp'} = $shell->{'id'} eq 'nologin' ? 0 : 1;
@@ -4660,9 +4660,9 @@ return %hash;
 # ensure_template(file)
 sub ensure_template
 {
-local ($file) = @_;
-local $mpath = "$module_root_directory/$file";
-local $cpath = "$module_config_directory/$file";
+my ($file) = @_;
+my $mpath = "$module_root_directory/$file";
+my $cpath = "$module_config_directory/$file";
 if (!-s $cpath) {
 	&copy_source_dest($mpath, $cpath);
 	}
@@ -4680,7 +4680,7 @@ if ($ENV{'SERVER_PORT'}) {
 	}
 else {
 	# Get from miniserv config
-	local %miniserv;
+	my %miniserv;
 	&get_miniserv_config(\%miniserv);
 	return ( $miniserv{'port'},
 		 $miniserv{'ssl'} ? 'https' : 'http',
@@ -4726,8 +4726,8 @@ return $proto."://".$host.$portstr;
 # by the home directory
 sub send_template_email
 {
-local ($template, $to, $subs, $subject, $cc, $bcc, $d, $from) = @_;
-local %hash = %$subs;
+my ($template, $to, $subs, $subject, $cc, $bcc, $d, $from) = @_;
+my %hash = %$subs;
 
 # Add in Webmin info to the hash
 ($hash{'webmin_port'}, $hash{'webmin_proto'}) = &get_miniserv_port_proto();
@@ -4736,8 +4736,8 @@ $template = &substitute_virtualmin_template($template, \%hash);
 # Work out the From: address - if a domain is given, use it's email address
 # as long as that address is in a local domain with mail
 if (!$from && $remote_user && !&master_admin() && $d) {
-	local $localdom = 0;
-	local ($emailtouser, $emailtodom) = split(/\@/, $d->{'emailto_addr'});
+	my $localdom = 0;
+	my ($emailtouser, $emailtodom) = split(/\@/, $d->{'emailto_addr'});
 	foreach my $ld (grep { $_->{'mail'} } &list_domains()) {
 		if (lc($ld->{'dom'}) eq lc($emailtodom)) {
 			$localdom = 1;
@@ -4752,8 +4752,8 @@ if (!$from && $remote_user && !&master_admin() && $d) {
 	}
 
 # Actually send using the mailboxes module
-local $subject = &substitute_virtualmin_template($subject, \%hash);
-local $cc = &substitute_virtualmin_template($cc, \%hash);
+my $subject = &substitute_virtualmin_template($subject, \%hash);
+my $cc = &substitute_virtualmin_template($cc, \%hash);
 if (!$to) {
 	# This can happen when a mailbox is not notified about its
 	# own update or creation
@@ -4764,16 +4764,16 @@ if (!$to) {
 
 # Set content type and encoding based on whether the email contains HTML
 # and/or non-ascii characters
-local $ctype = $template =~ /<html[^>]*>|<body[^>]*>/i ? "text/html"
+my $ctype = $template =~ /<html[^>]*>|<body[^>]*>/i ? "text/html"
 						       : "text/plain";
-local $cs = &get_charset();
-local $attach =
+my $cs = &get_charset();
+my $attach =
     { 'headers' => [ [ 'Content-Type', $ctype.'; charset='.$cs ],
                      [ 'Content-Transfer-Encoding', 'quoted-printable' ] ],
       'data' => &mailboxes::quoted_encode($template) };
 
 # Construct and send the email object
-local $mail = { 'headers' => [ [ 'From', $from ||
+my $mail = { 'headers' => [ [ 'From', $from ||
 					 $config{'from_addr'} ||
 					 &mailboxes::get_from_address() ],
 			       [ 'To', $to ],
@@ -4801,13 +4801,13 @@ else {
 # or users.
 sub send_notify_email
 {
-local ($from, $recips, $d, $subject, $body, $attach, $attachfile, $attachtype,
+my ($from, $recips, $d, $subject, $body, $attach, $attachfile, $attachtype,
        $admins, $many, $charset, $also) = @_;
 &foreign_require("mailboxes");
-local %done;
+my %done;
 foreach my $r (@$recips) {
 	# Work out recipient type and addresses
-	local (@emails, %hash);
+	my (@emails, %hash);
 	if ($r->{'id'}) {
 		# A domain
 		push(@emails, $r->{'emailto'});
@@ -4829,11 +4829,11 @@ foreach my $r (@$recips) {
 	# Send to them
 	foreach my $email (@emails) {
 		next if (!$many && $done{$email}++);
-		local $ct = 'text/plain';
+		my $ct = 'text/plain';
 		if ($charset) {
 			$ct .= "; charset=".$charset;
 			}
-		local $mail = { 'headers' =>
+		my $mail = { 'headers' =>
 		    [ [ 'From' => $from ],
 		      [ 'To' => $email ],
 		      [ 'Subject' => &entities_to_ascii(
@@ -4843,10 +4843,10 @@ foreach my $r (@$recips) {
 		        'data' => &entities_to_ascii(
 		          &substitute_virtualmin_template($body, \%hash)) } ] };
 		if ($attach) {
-			local $filename = $attachfile;
+			my $filename = $attachfile;
 			$filename =~ s/^.*(\\|\/)//;
-			local $type = $attachtype." name=\"$filename\"";
-			local $disp = "inline; filename=\"$filename\"";
+			my $type = $attachtype." name=\"$filename\"";
+			my $disp = "inline; filename=\"$filename\"";
 			push(@{$mail->{'attach'}},
 			     { 'data' => $in{'attach'},
 			       'headers' => [
@@ -4864,13 +4864,13 @@ foreach my $r (@$recips) {
 # be the reseller's email (if set), or the system-wide default
 sub get_global_from_address
 {
-local ($d) = @_;
+my ($d) = @_;
 &foreign_require("mailboxes");
-local $rv = $config{'from_addr'} || &mailboxes::get_from_address();
+my $rv = $config{'from_addr'} || &mailboxes::get_from_address();
 if ($d && $d->{'reseller'} && defined(&get_reseller) && $config{'from_reseller'}) {
 	# From first reseller
 	my @r = split(/\s+/, $d->{'reseller'});
-	local $resel = &get_reseller($r[0]);
+	my $resel = &get_reseller($r[0]);
 	if ($resel && $resel->{'acl'}->{'email'}) {
 		# Reseller has an email .... but is it valid for this system?
 		if ($resel->{'acl'}->{'from'}) {
@@ -4920,7 +4920,7 @@ return $_[0];
 # 13- Everyone in some domain
 sub alias_type
 {
-local @rv;
+my @rv;
 if ($_[0] =~ /^\|\s*$module_config_directory\/autoreply.pl\s+(\S+)/) {
         @rv = (5, $1);
         }
@@ -4973,7 +4973,7 @@ sub set_alias_programs
 &require_mail();
 
 # Copy autoresponder
-local $mailmod = &foreign_check("sendmail") ? "sendmail" :
+my $mailmod = &foreign_check("sendmail") ? "sendmail" :
 		 $mail_system == 1 ? "sendmail" :
 		 $mail_system == 0 ? "postfix" :
 					       "qmailadmin";
@@ -5000,11 +5000,11 @@ if (-d $sendmail::config{'smrsh_dir'} &&
 # CREATE_DOMAIN, MODIFY_DOMAIN or DELETE_DOMAIN
 sub set_domain_envs
 {
-local ($d, $action, $newd, $oldd, $others) = @_;
+my ($d, $action, $newd, $oldd, $others) = @_;
 &reset_domain_envs();
 $ENV{'VIRTUALSERVER_ACTION'} = $action;
 foreach my $e (keys %$d) {
-	local $env = uc($e);
+	my $env = uc($e);
 	$env =~ s/\-/_/g;
 	$ENV{'VIRTUALSERVER_'.$env} = $d->{$e};
 	}
@@ -5013,7 +5013,7 @@ if ($newd) {
 	# Set details of virtual server being changed to. This is only
 	# done in the pre-modify call
 	foreach my $e (keys %$newd) {
-		local $env = uc($e);
+		my $env = uc($e);
 		$env =~ s/\-/_/g;
 		$ENV{'VIRTUALSERVER_NEWSERVER_'.$env} = $newd->{$e};
 		}
@@ -5023,28 +5023,28 @@ if ($newd) {
 if ($oldd) {
 	# Set details of virtual server being changed from, in post-modify
 	foreach my $e (keys %$oldd) {
-		local $env = uc($e);
+		my $env = uc($e);
 		$env =~ s/\-/_/g;
 		$ENV{'VIRTUALSERVER_OLDSERVER_'.$env} = $oldd->{$e};
 		}
 	$ENV{'VIRTUALSERVER_OLDSERVER_IDNDOM'} =
 		&show_domain_name($oldd->{'dom'});
 	}
-local $parent = $d->{'parent'} ? &get_domain($d->{'parent'}) : undef;
-local $alias = $d->{'alias'} ? &get_domain($d->{'alias'}) : undef;
+my $parent = $d->{'parent'} ? &get_domain($d->{'parent'}) : undef;
+my $alias = $d->{'alias'} ? &get_domain($d->{'alias'}) : undef;
 if (defined(&get_reseller)) {
 	# Set (first) reseller details, if we have one
-	local $rd = $d->{'reseller'} ? $d :
+	my $rd = $d->{'reseller'} ? $d :
 		    $parent && $parent->{'reseller'} ? $parent : undef;
-	local ($r) = $rd ? split(/\s+/, $rd->{'reseller'}) : undef;
-	local $resel = $r ? &get_reseller($r) : undef;
+	my ($r) = $rd ? split(/\s+/, $rd->{'reseller'}) : undef;
+	my $resel = $r ? &get_reseller($r) : undef;
 	if ($resel) {
-		local $acl = $resel->{'acl'};
+		my $acl = $resel->{'acl'};
 		$ENV{'RESELLER_NAME'} = $resel->{'name'};
 		$ENV{'RESELLER_THEME'} = $resel->{'theme'};
 		$ENV{'RESELLER_MODULES'} = join(" ", @{$resel->{'modules'}});
 		foreach my $a (keys %$acl) {
-			local $env = uc($a);
+			my $env = uc($a);
 			$env =~ s/\-/_/g;
 			$ENV{'RESELLER_'.$env} = $acl->{$a};
 			}
@@ -5053,7 +5053,7 @@ if (defined(&get_reseller)) {
 if ($parent) {
 	# Set parent domain variables
 	foreach my $e (keys %$parent) {
-		local $env = uc($e);
+		my $env = uc($e);
 		$env =~ s/\-/_/g;
 		$ENV{'PARENT_VIRTUALSERVER_'.$env} = $parent->{$e};
 		}
@@ -5063,7 +5063,7 @@ if ($parent) {
 if ($alias) {
 	# Set alias domain variables
 	foreach my $e (keys %$alias) {
-		local $env = uc($e);
+		my $env = uc($e);
 		$env =~ s/\-/_/g;
 		$ENV{'ALIAS_VIRTUALSERVER_'.$env} = $alias->{$e};
 		}
@@ -5103,7 +5103,7 @@ my $cmd = $ENV{'VIRTUALMIN_PRE_COMMAND'} || $config{'pre_command'};
 my $output = $ENV{'VIRTUALMIN_OUTPUT_COMMAND'} || $config{'output_command'};
 if ($cmd =~ /\S/) {
 	&clean_changes_environment();
-	local $out = &backquote_logged(
+	my $out = &backquote_logged(
 		"($cmd) 2>&1 </dev/null");
 	if ($output && !$? && $out =~ /\S/) {
 		&$second_print($out);
@@ -5123,7 +5123,7 @@ my $cmd = $ENV{'VIRTUALMIN_POST_COMMAND'} || $config{'post_command'};
 my $output = $ENV{'VIRTUALMIN_OUTPUT_COMMAND'} || $config{'output_command'};
 if ($cmd =~ /\S/) {
 	&clean_changes_environment();
-	local $out = &backquote_logged(
+	my $out = &backquote_logged(
 		"($cmd) 2>&1 </dev/null");
 	if ($output && !$? && $out =~ /\S/) {
 		&$second_print($out);
@@ -5143,7 +5143,7 @@ foreach my $e (keys %UNCLEAN_ENV) {
 
 sub clean_changes_environment
 {
-local $e;
+my $e;
 %UNCLEAN_ENV = %ENV;
 foreach $e ('SERVER_ROOT', 'SCRIPT_NAME',
 	    'FOREIGN_MODULE_NAME', 'FOREIGN_ROOT_DIRECTORY',
@@ -5168,20 +5168,20 @@ print "$text{'sub_if'}<p>\n";
 # Prints HTML for selecting 0 or more alias destinations
 sub alias_form
 {
-local ($to, $left, $d, $mode, $who, $tds) = @_;
+my ($to, $left, $d, $mode, $who, $tds) = @_;
 &require_mail();
-local @typenames = map { $text{"alias_type$_"} } (0 .. 13);
+my @typenames = map { $text{"alias_type$_"} } (0 .. 13);
 $typenames[0] = "&lt;$typenames[0]&gt;";
 
-local @values = @$to;
-local $i;
+my @values = @$to;
+my $i;
 for(my $i=0; $i<=@values+2; $i++) {
-	local ($type, $val) = $values[$i] ? &alias_type($values[$i], $_[4])
+	my ($type, $val) = $values[$i] ? &alias_type($values[$i], $_[4])
 					  : (0, "");
 
 	# Generate drop-down menu for alias type
-	local @opts;
-	local $j;
+	my @opts;
+	my $j;
 	for($j=0; $j<@typenames; $j++) {
 		next if ($j == 8 && $_[3] eq "user");	# to domain not valid
 							# for users
@@ -5195,24 +5195,24 @@ for(my $i=0; $i<=@values+2; $i++) {
 			push(@opts, [ $j, $typenames[$j] ]);
 			}
 		}
-	local $f = &ui_select("type_$i", $type, \@opts);
+	my $f = &ui_select("type_$i", $type, \@opts);
 	if ($type == 7) {
 		$val = &unescape_user($val);
 		}
 	elsif ($type == 13) {
 		# Everyone in some domain
-		local $d = &get_domain($val);
+		my $d = &get_domain($val);
 		if ($d) {
 			$val = $d->{'dom'};
 			}
 		}
 	$f .= &ui_textbox("val_$i", $val, 30)."\n";
 	if (&can_edit_afiles()) {
-		local $prog = $type == 2 ? "edit_afile.cgi" :
+		my $prog = $type == 2 ? "edit_afile.cgi" :
 			      $type == 5 ? "edit_rfile.cgi" :
 			      $type == 6 ? "edit_ffile.cgi" : undef;
 		if ($prog && $_[2]) {
-			local $di = $_[2] ? $_[2]->{'id'} : undef;
+			my $di = $_[2] ? $_[2]->{'id'} : undef;
 			$f .= "<a href='$prog?dom=$di&amp;file=$val&amp;$_[3]=$_[4]&amp;idx=$i'>$text{'alias_afile'}</a>\n";
 			}
 		}
@@ -5226,11 +5226,11 @@ for(my $i=0; $i<=@values+2; $i++) {
 # &alias_form
 sub parse_alias
 {
-local (@values, $i, $t, $anysame, $anybounce);
+my (@values, $i, $t, $anysame, $anybounce);
 for($i=0; defined($t = $in{"type_$i"}); $i++) {
 	!$t || $can_alias_types{$t} ||
 		&error($text{'alias_etype'}." : ".$text{'alias_type'.$t});
-	local $v = $in{"val_$i"};
+	my $v = $in{"val_$i"};
 	$v =~ s/^\s+//;
 	$v =~ s/\s+$//;
 	if ($t == 1 && $v !~ /^([^\|\:\"\' \t\/\\\%]\S*)$/) {
@@ -5305,7 +5305,7 @@ for($i=0; defined($t = $in{"type_$i"}); $i++) {
 		}
 	elsif ($t == 13) {
 		# Work out ID for everyone file
-		local $d = &get_domain_by("dom", $v);
+		my $d = &get_domain_by("dom", $v);
 		&create_everyone_file($d);
 		push(@values, ":include:$everyone_alias_dir/$d->{'id'}");
 		}
@@ -5324,7 +5324,7 @@ return @values;
 sub set_pass_change
 {
 &require_useradmin();
-local $pft = &useradmin::passfiles_type();
+my $pft = &useradmin::passfiles_type();
 if ($pft == 2 || $pft == 5 || $config{'ldap'}) {
 	$_[0]->{'change'} = int(time() / (60*60*24));
 	}
@@ -5336,7 +5336,7 @@ elsif ($pft == 4) {
 # set_pass_disable(&user, disable)
 sub set_pass_disable
 {
-local ($user, $disable) = @_;
+my ($user, $disable) = @_;
 if ($disable && $user->{'pass'} !~ /^\!/) {
 	$user->{'pass'} = "!".$user->{'pass'};
 	}
@@ -5356,7 +5356,7 @@ return 1;
 sub list_all_users
 {
 &require_useradmin();
-local @rv;
+my @rv;
 foreach my $u (&useradmin::list_users()) {
 	$u->{'module'} = 'useradmin';
 	push(@rv, $u);
@@ -5375,7 +5375,7 @@ return @rv;
 sub list_all_groups
 {
 &require_useradmin();
-local @rv;
+my @rv;
 foreach my $g (&useradmin::list_groups()) {
 	$g->{'module'} = 'useradmin';
 	push(@rv, $g);
@@ -5398,8 +5398,8 @@ my ($uidmap, $usermap, $users) = @_;
 &require_useradmin();
 
 # Add Unix users
-local @users = $users ? @$users : &list_all_users();
-local $u;
+my @users = $users ? @$users : &list_all_users();
+my $u;
 foreach $u (@users) {
 	$uidmap->{$u->{'uid'}} ||= 'user' if ($uidmap);
 	$usermap->{$u->{'user'}} ||= 'user' if ($usermap);
@@ -5414,7 +5414,7 @@ while(my @uinfo = getpwent()) {
 endpwent();
 
 # Add domain users
-local $d;
+my $d;
 foreach $d (&list_domains()) {
 	$uidmap->{$d->{'uid'}} ||= 'dom' if ($uidmap);
 	$usermap->{$d->{'user'}} ||= 'dom' if ($usermap);
@@ -5439,8 +5439,8 @@ my ($gidmap, $groupmap, $groups) = @_;
 &require_useradmin();
 
 # Add Unix groups
-local @groups = $groups ? @$groups : &list_all_groups();
-local $g;
+my @groups = $groups ? @$groups : &list_all_groups();
+my $g;
 foreach $g (@groups) {
 	$gidmap->{$g->{'gid'}} ||= 'group' if ($gidmap);
 	$groupmap->{$g->{'group'}} ||= 'group' if ($groupmap);
@@ -5455,7 +5455,7 @@ while(my @ginfo = getgrent()) {
 endgrent();
 
 # Add domains
-local $d;
+my $d;
 foreach $d (&list_domains()) {
 	$gidmap->{$d->{'gid'}} ||= 'dom' if ($gidmap);
 	$groupmap->{$d->{'group'}} ||= 'dom' if ($groupmap);
@@ -5475,7 +5475,7 @@ foreach my $gid (keys %gids) {
 # Given a hash of used UIDs, return one that is free
 sub allocate_uid
 {
-local $uid;
+my $uid;
 if ($usermodule eq "ldap-useradmin") {
 	$uid = $luconfig{'base_uid'};
 	}
@@ -5490,7 +5490,7 @@ return $uid;
 # Given a hash of used GIDs, return one that is free
 sub allocate_gid
 {
-local $gid;
+my $gid;
 if ($usermodule eq "ldap-useradmin") {
 	$gid = $luconfig{'base_gid'};
 	}
@@ -5509,13 +5509,13 @@ my ($d, $parent) = @_;
 &require_useradmin();
 if ($d->{'parent'}) {
 	# Owned by some existing user, so under his home
-	local $dname = $d->{'dom'};
+	my $dname = $d->{'dom'};
 	$dname =~ s/^xn(-+)//;
 	return "$parent->{'home'}/domains/$dname";
 	}
 elsif ($config{'home_format'}) {
 	# Use the template from the module config
-	local $home = "$home_base/$config{'home_format'}";
+	my $home = "$home_base/$config{'home_format'}";
 	return &substitute_domain_template($home, $d);
 	}
 else {
@@ -5547,7 +5547,7 @@ sub set_server_quotas
 my ($d, $uquota, $quota) = @_;
 $uquota = $d->{'uquota'} if (!defined($uquota));
 $quota = $d->{'quota'} if (!defined($quota));
-local $tmpl = &get_template($d->{'template'});
+my $tmpl = &get_template($d->{'template'});
 if (&has_quota_commands()) {
 	# User and group quotas are set externally
 	&run_quota_command("set_user", $d->{'user'},
@@ -5568,7 +5568,7 @@ else {
 	if (&has_group_quotas() && $d->{'group'}) {
 		# Set group quotas for home
 		&require_useradmin();
-		local @qargs;
+		my @qargs;
 		if ($tmpl->{'quotatype'} eq 'hard') {
 			@qargs = ( int($quota), int($quota), 0, 0 );
 			}
@@ -5586,14 +5586,14 @@ else {
 # operations don't fail
 sub disable_quotas
 {
-local ($d) = @_;
+my ($d) = @_;
 return if (!&has_home_quotas());
 if ($d->{'parent'}) {
-	local $pd = &get_domain($d->{'parent'});
+	my $pd = &get_domain($d->{'parent'});
 	&disable_quotas($pd);
 	}
 elsif ($d->{'unix'} && $d->{'quota'}) {
-	local $nqd = { %$d };
+	my $nqd = { %$d };
 	$nqd->{'quota'} = 0;
 	$nqd->{'uquota'} = 0;
 	&set_server_quotas($nqd);
@@ -5611,10 +5611,10 @@ elsif ($d->{'unix'} && $d->{'quota'}) {
 # Must be called after disable_quotas to re-activate quotas for some domain
 sub enable_quotas
 {
-local ($d) = @_;
+my ($d) = @_;
 return if (!&has_home_quotas());
 if ($d->{'parent'}) {
-        local $pd = &get_domain($d->{'parent'});
+        my $pd = &get_domain($d->{'parent'});
         &enable_quotas($pd);
         }
 elsif ($d->{'unix'} && $d->{'quota'}) {
@@ -5633,16 +5633,16 @@ elsif ($d->{'unix'} && $d->{'quota'}) {
 # Output a table of mailbox users
 sub users_table
 {
-local ($users, $d, $cgi, $buttons, $links, $empty) = @_;
+my ($users, $d, $cgi, $buttons, $links, $empty) = @_;
 
-local $can_quotas = &has_home_quotas();
-local @ashells = &list_available_shells($d);
-local $users_cols = $config{'users_cols'};
+my $can_quotas = &has_home_quotas();
+my @ashells = &list_available_shells($d);
+my $users_cols = $config{'users_cols'};
 if (!defined($users_cols)) {
 	$users_cols = join(",", grep { $config{$_} }
 		qw(show_mailsize show_lastlogin show_dbs show_plugins));
 	}
-local %users_cols = map { $_ => 1 } grep { $_ }
+my %users_cols = map { $_ => 1 } grep { $_ }
 		    split(/,/, $users_cols);
 
 # Given a list of services return
@@ -5665,7 +5665,7 @@ my $login_access_label = sub {
 	};
 
 # Work out table header
-local @headers;
+my @headers;
 push(@headers, "") if ($cgi);
 push(@headers, $text{'users_name'},
 	       $text{'user_user2'},
@@ -5685,10 +5685,10 @@ if (($d->{'mysql'} || $d->{'postgres'}) && $users_cols{'show_dbs'}) {
 	push(@headers, $text{'users_db'});
 	}
 # Other plugins columns
-local ($f, %plugcol);
+my ($f, %plugcol);
 if ($users_cols{'show_plugins'}) {
 	foreach $f (&list_mail_plugins()) {
-		local $col = &plugin_call($f, "mailbox_header", $d);
+		my $col = &plugin_call($f, "mailbox_header", $d);
 		if ($col) {
 			$plugcol{$f} = $col;
 			push(@headers, $col);
@@ -5721,18 +5721,18 @@ if ($need_paginations) {
 	}
 
 # Build table contents
-local $u;
-local $did = $d ? $d->{'id'} : 0;
-local @table;
-local $userdesc;
+my $u;
+my $did = $d ? $d->{'id'} : 0;
+my @table;
+my $userdesc;
 my @domsdbs = &domain_databases($d);
 foreach $u (@$users) {
-	local $pop3 = $d ? &remove_userdom($u->{'user'}, $d) : $u->{'user'};
-	local $pop3_dis =
+	my $pop3 = $d ? &remove_userdom($u->{'user'}, $d) : $u->{'user'};
+	my $pop3_dis =
 		&ui_text_color($pop3.&vui_inline_label('users_disabled_label', undef, 'disabled'), 'danger');
 	$pop3 = &html_escape($pop3);
-	local @cols;
-	local $filetype = $u->{'extra'} ? "&type=".&urlize($u->{'type'}) : "";
+	my @cols;
+	my $filetype = $u->{'extra'} ? "&type=".&urlize($u->{'type'}) : "";
 	my $col_text =
 	  ($u->{'domainowner'} ?
 	   "<b>$pop3</b>".&vui_inline_label('users_owner_label') :
@@ -5750,9 +5750,9 @@ foreach $u (@$users) {
 	$userdesc++ if ($u->{'real'});
 
 	# Add columns for quotas
-	local $quota;
+	my $quota;
 	$quota += $u->{'quota'} if (&has_home_quotas());
-	local $uquota;
+	my $uquota;
 	$uquota += $u->{'uquota'} if (&has_home_quotas());
 	if (($u->{'webowner'} || $u->{'extra'}) && defined($quota)) {
 		# Website owners, virtual database and web users have no
@@ -5778,13 +5778,13 @@ foreach $u (@$users) {
 
 	if ($users_cols{'show_mailsize'} && $d->{'mail'}) {
 		# Mailbox link, if this user has email enabled or is the owner
-		local ($szmsg, $sz, $szb);
+		my ($szmsg, $sz, $szb);
 		if (!$u->{'nomailfile'} &&
 		    ($u->{'email'} || @{$u->{'extraemail'}})) {
 			($sz) = &mail_file_size($u);
 			$szb = $sz;
 			$sz = $sz ? &nice_size($sz) : $text{'users_empty'};
-			local $lnk = &read_mail_link($u, $d);
+			my $lnk = &read_mail_link($u, $d);
 			if ($lnk) {
 				$szmsg = &ui_link($lnk, $sz);
 				}
@@ -5817,7 +5817,7 @@ foreach $u (@$users) {
 	if ($u->{'domainowner'}) {
 		$u->{'shell'} = &get_domain_shell($d, $u);
 		}
-	local ($shell) = grep { $_->{'shell'} eq &get_user_shell($u) } @ashells;
+	my ($shell) = grep { $_->{'shell'} eq &get_user_shell($u) } @ashells;
 	my $udbs = scalar(@{$u->{'dbs'}}) || $u->{'domainowner'};
 	push(@cols, ($u->{'extra'} && $u->{'type'} eq 'db') ? &$login_access_label('db') :
 		    ($u->{'extra'} && $u->{'type'} eq 'web') ? &$login_access_label('web') :
@@ -5927,9 +5927,9 @@ if (&has_quota_commands()) {
 	# When using quota commands, the block size is always 1024
 	return 1024;
 	}
-local $fs = $_[0] eq "home" ? $config{'home_quotas'} : $_[0];
+my $fs = $_[0] eq "home" ? $config{'home_quotas'} : $_[0];
 return undef if ($fs eq "mail");	# Deprecated
-local $forfs = int($_[1]);
+my $forfs = int($_[1]);
 if ($gconfig{'os_type'} =~ /-linux$/) {
 	# On linux, the quota block size is ALWAYS 1024, so we can shortcut
 	# any actual filesystem tests
@@ -5937,7 +5937,7 @@ if ($gconfig{'os_type'} =~ /-linux$/) {
 	}
 &require_useradmin();
 if (defined(&quota::block_size)) {
-	local $bsize;
+	my $bsize;
 	if (!exists($bsize_cache{$fs,$forfs})) {
 		$bsize_cache{$fs,$forfs} = &quota::block_size($fs, $forfs);
 		}
@@ -5956,7 +5956,7 @@ if (!$n) {
 	       $zeromode == 0 ? $text{'resel_unlimit'} : 0;
 	}
 else {
-	local $bsize = &quota_bsize($fs);
+	my $bsize = &quota_bsize($fs);
 	if ($bsize) {
 		return &nice_size($n*$bsize);
 		}
@@ -5984,11 +5984,11 @@ else {
 # Returns HTML for a field for selecting a quota or unlimited
 sub opt_quota_input
 {
-local ($name, $value, $fs, $third, $label) = @_;
-local $dis1 = &js_disable_inputs([ $name, $name."_units" ], [ ]);
-local $dis2 = &js_disable_inputs([ ], [ $name, $name."_units" ]);
-local $mode = $value eq "" ? 1 : $value eq "0" ? 1 : $value eq "none" ? 2 : 0;
-local $qi = $fs eq "none" ? &ui_textbox($name, $mode ? "" : $value, 10)
+my ($name, $value, $fs, $third, $label) = @_;
+my $dis1 = &js_disable_inputs([ $name, $name."_units" ], [ ]);
+my $dis2 = &js_disable_inputs([ ], [ $name, $name."_units" ]);
+my $mode = $value eq "" ? 1 : $value eq "0" ? 1 : $value eq "none" ? 2 : 0;
+my $qi = $fs eq "none" ? &ui_textbox($name, $mode ? "" : $value, 10)
 			  : &quota_input($name, $mode ? "" : $value, $fs,$mode);
 return &ui_radio($name."_def", $mode,
 	  [ $third ? ([ 2, $third, "onClick='$dis1'" ]) : ( ),
@@ -6000,7 +6000,7 @@ return &ui_radio($name."_def", $mode,
 # Converts an entered quota into blocks
 sub quota_parse
 {
-local $bsize = &quota_bsize($_[1]);
+my $bsize = &quota_bsize($_[1]);
 if (!$bsize) {
 	return $in{$_[0]};
 	}
@@ -6038,13 +6038,13 @@ return undef;
 # Returns Javascript to set some quota field using Javascript
 sub quota_javascript
 {
-local ($name, $value, $fs, $unlimited) = @_;
-local $bsize = $fs eq "none" ? 0 : $fs eq "bw" ? 1 : &quota_bsize($fs);
-local $rv;
+my ($name, $value, $fs, $unlimited) = @_;
+my $bsize = $fs eq "none" ? 0 : $fs eq "bw" ? 1 : &quota_bsize($fs);
+my $rv;
 if ($bsize) {
 	# Set value and units
-	local $val = $value eq "" ? "" : $value*$bsize;
-	local $index;
+	my $val = $value eq "" ? "" : $value*$bsize;
+	my $index;
 	if ($val >= 1024*1024*1024) {
 		$val = $val/(1024*1024*1024);
 		$index = 3;
@@ -6098,7 +6098,7 @@ my $color = $u->{'over_quota'} ? "#ff0000" :
 	    $u->{'spam_quota'} ? "#aaaaaa" : undef;
 if (&can_mailbox_quota()) {
 	# Show inputs for editing quotas
-	local $quota = $_[1];
+	my $quota = $_[1];
 	$quota = undef if ($quota eq "none");
 	$rv .= &opt_quota_input($_[0], $quota, $_[3]);
 	$rv .= "\n";
@@ -6119,20 +6119,20 @@ my ($d, $file) = @_;
 
 # Record parent's domain name, which can be used when restoring
 if ($d->{'parent'}) {
-	local $parent = &get_domain($d->{'parent'});
+	my $parent = &get_domain($d->{'parent'});
 	$d->{'backup_parent_dom'} = $parent->{'dom'};
 	if ($d->{'alias'}) {
-		local $alias = &get_domain($d->{'alias'});
+		my $alias = &get_domain($d->{'alias'});
 		$d->{'backup_alias_dom'} = $alias->{'dom'};
 		}
 	if ($d->{'subdom'}) {
-		local $subdom = &get_domain($d->{'subdom'});
+		my $subdom = &get_domain($d->{'subdom'});
 		$d->{'backup_subdom_dom'} = $subdom->{'dom'};
 		}
 	}
 
 # Record sub-directory for mail folders, used during mail restores
-local %mconfig = &foreign_config("mailboxes");
+my %mconfig = &foreign_config("mailboxes");
 if ($mconfig{'mail_usermin'}) {
 	$d->{'backup_mail_folders'} = $mconfig{'mail_usermin'};
 	}
@@ -6143,8 +6143,8 @@ else {
 # Record encrypted Unix password
 delete($d->{'backup_encpass'});
 if ($d->{'unix'} && !$d->{'parent'} && !$d->{'disabled'}) {
-	local @users = &list_all_users();
-	local ($user) = grep { $_->{'user'} eq $d->{'user'} } @users;
+	my @users = &list_all_users();
+	my ($user) = grep { $_->{'user'} eq $d->{'user'} } @users;
 	if ($user) {
 		$d->{'backup_encpass'} = $user->{'pass'};
 		}
@@ -6209,13 +6209,13 @@ else {
 	}
 
 # Include template, in case the restore target doesn't have it
-local ($tmpl) = grep { $_->{'id'} == $d->{'template'} } &list_templates();
+my ($tmpl) = grep { $_->{'id'} == $d->{'template'} } &list_templates();
 if (!$tmpl->{'standard'}) {
 	&copy_source_dest($tmpl->{'file'}, $file."_template");
 	}
 
 # Include plan too
-local $plan = &get_plan($d->{'plan'});
+my $plan = &get_plan($d->{'plan'});
 if ($plan) {
 	&copy_source_dest($plan->{'file'}, $file."_plan");
 	}
@@ -6241,7 +6241,7 @@ return 1;
 # Save the current module config to the specified file
 sub virtualmin_backup_config
 {
-local ($file, $vbs) = @_;
+my ($file, $vbs) = @_;
 &$first_print($text{'backup_vconfig_doing'});
 &copy_source_dest($module_config_file, $file);
 &$second_print($text{'setup_done'});
@@ -6253,10 +6253,10 @@ return 1;
 # template settings
 sub virtualmin_restore_config
 {
-local ($file, $vbs) = @_;
+my ($file, $vbs) = @_;
 &$first_print($text{'restore_vconfig_doing'});
-local %oldconfig = %config;
-local @tmpls = &list_templates();
+my %oldconfig = %config;
+my @tmpls = &list_templates();
 &lock_file($module_config_file);
 &copy_source_dest($file, $module_config_file);
 &read_file($module_config_file, \%config);
@@ -6312,9 +6312,9 @@ return 1;
 # Write a tar file of all templates (including scripts) to the given file
 sub virtualmin_backup_templates
 {
-local ($file, $vbs) = @_;
+my ($file, $vbs) = @_;
 &$first_print($text{'backup_vtemplates_doing'});
-local $temp = &transname();
+my $temp = &transname();
 mkdir($temp, 0700);
 foreach my $tmpl (&list_templates()) {
 	my %tmplquoted = %$tmpl;
@@ -6341,12 +6341,12 @@ else {
 	}
 
 # Save skeleton directories for all templates
-local %done;
+my %done;
 foreach my $tmpl (&list_templates()) {
 	if ($tmpl->{'skel'} && $tmpl->{'skel'} ne 'none' &&
 	    !$done{$tmpl->{'skel'}}++ &&
 	    -d $tmpl->{'skel'}) {
-		local $skelfile = $file.'_skel_'.$tmpl->{'id'};
+		my $skelfile = $file.'_skel_'.$tmpl->{'id'};
 		&execute_command(
 		    "cd ".quotemeta($tmpl->{'skel'}).
 		    " && ".&make_tar_command("cf", $skelfile, "."));
@@ -6375,11 +6375,11 @@ return 1;
 # Extract all templates from a backup. Those that already exist are not deleted.
 sub virtualmin_restore_templates
 {
-local ($file, $vbs) = @_;
+my ($file, $vbs) = @_;
 &$first_print($text{'restore_vtemplates_doing'});
 
 # Extract backup file
-local $temp = &transname();
+my $temp = &transname();
 mkdir($temp, 0700);
 &execute_command("cd ".quotemeta($temp)." && ".
 		 &make_tar_command("xf", $file));
@@ -6397,7 +6397,7 @@ foreach my $t (readdir(DIR)) {
 		}
 	else {
 		# A template file
-		local %tmpl;
+		my %tmpl;
 		&read_file("$temp/$t", \%tmpl);
 		foreach my $k (keys %tmpl) {
 			$tmpl{$k} =~ s/\\n/\n/g;
@@ -6419,11 +6419,11 @@ if (-r $file."_global") {
 	}
 
 # Restore skeleton directories
-local %done;
+my %done;
 foreach my $tmpl (&list_templates()) {
 	if ($tmpl->{'skel'} && $tmpl->{'skel'} ne 'none' &&
 	    !$done{$tmpl->{'skel'}}++) {
-		local $skelfile = $file.'_skel_'.$tmpl->{'id'};
+		my $skelfile = $file.'_skel_'.$tmpl->{'id'};
 		if (-r $skelfile) {
 			# Delete and re-create skel directory
 			&unlink_file($tmpl->{'skel'});
@@ -6460,13 +6460,13 @@ return 1;
 # Create a tar file of all scheduled backups and keys
 sub virtualmin_backup_scheds
 {
-local ($file, $vbs) = @_;
-local $dokeys = defined(&list_backup_keys) && scalar(&list_backup_keys());
+my ($file, $vbs) = @_;
+my $dokeys = defined(&list_backup_keys) && scalar(&list_backup_keys());
 &$first_print($dokeys ? $text{'backup_vscheds_doing2'}
 		      : $text{'backup_vscheds_doing'});
 
 # Tar up scheduled backups dir
-local $temp = &transname();
+my $temp = &transname();
 mkdir($temp, 0700);
 foreach my $sched (&list_scheduled_backups()) {
 	&write_file("$temp/$sched->{'id'}", $sched);
@@ -6495,13 +6495,13 @@ return 1;
 # Re-create all scheduled backups
 sub virtualmin_restore_scheds
 {
-local ($file, $vbs) = @_;
-local $dokeys = -r $file."_keys" && defined(&list_backup_keys);
+my ($file, $vbs) = @_;
+my $dokeys = -r $file."_keys" && defined(&list_backup_keys);
 &$first_print($dokeys ? $text{'restore_vscheds_doing'}
 		      : $text{'restore_vscheds_doing2'});
 
 # Extract backup file
-local $temp = &transname();
+my $temp = &transname();
 mkdir($temp, 0700);
 &execute_command("cd ".quotemeta($temp)." && ".
 		 &make_tar_command("xf", $file));
@@ -6517,7 +6517,7 @@ foreach my $sched (&list_scheduled_backups()) {
 opendir(BACKUPDIR, $temp);
 foreach my $t (readdir(BACKUPDIR)) {
         next if ($t eq "." || $t eq "..");
-	local %sched;
+	my %sched;
 	&read_file("$temp/$t", \%sched);
 	delete($sched{'file'});
 	&save_scheduled_backup(\%sched);
@@ -6526,7 +6526,7 @@ closedir(BACKUPDIR);
 
 # Extract dir of backup keys, then re-save each to re-import to root
 if ($dokeys) {
-	local %oldkeys = map { $_->{'id'}, 1 } &list_backup_keys();
+	my %oldkeys = map { $_->{'id'}, 1 } &list_backup_keys();
 	&make_dir($backup_keys_dir, 0700) if (!-d $backup_keys_dir);
 	&execute_command("cd ".quotemeta($backup_keys_dir)." && ".
 			 &make_tar_command("xf", $file."_keys"));
@@ -6557,19 +6557,19 @@ return 1;
 # user information, plus all ACL files
 sub virtualmin_backup_resellers
 {
-local ($file, $vbs) = @_;
+my ($file, $vbs) = @_;
 return 0 if (!defined(&list_resellers));
 &$first_print($text{'backup_vresellers_doing'});
-local $temp = &transname();
+my $temp = &transname();
 mkdir($temp, 0700);
 foreach my $resel (&list_resellers()) {
 	&open_tempfile(RESEL, ">$temp/$resel->{'name'}.webmin");
 	&print_tempfile(RESEL, &serialise_variable($resel));
 	&close_tempfile(RESEL);
-	local $acldir = "$temp/$resel->{'name'}.acls";
+	my $acldir = "$temp/$resel->{'name'}.acls";
 	mkdir($acldir, 0700);
 	foreach my $m (@{$resel->{'modules'}}) {
-		local %acl = &get_module_acl($resel->{'name'}, $m, 1, 1);
+		my %acl = &get_module_acl($resel->{'name'}, $m, 1, 1);
 		&write_file("$acldir/$m", \%acl);
 		}
 	}
@@ -6584,10 +6584,10 @@ return 1;
 # Delete all resellers and re-create them from the backup
 sub virtualmin_restore_resellers
 {
-local ($file, $vbs) = @_;
+my ($file, $vbs) = @_;
 return undef if (!defined(&list_resellers));
 &$first_print($text{'restore_vresellers_doing'});
-local $temp = &transname();
+my $temp = &transname();
 mkdir($temp, 0700);
 &require_acl();
 &execute_command("cd ".quotemeta($temp)." && ".
@@ -6596,7 +6596,7 @@ foreach my $resel (&list_resellers()) {
 	&acl::delete_user($resel->{'name'});
 	&delete_reseller_unix_user($resel);
 	}
-local %miniserv;
+my %miniserv;
 &get_miniserv_config(\%miniserv);
 if (&check_pid_file($miniserv{'pidfile'})) {
 	&reload_miniserv();
@@ -6604,14 +6604,14 @@ if (&check_pid_file($miniserv{'pidfile'})) {
 opendir(DIR, $temp);
 foreach my $f (readdir(DIR)) {
 	if ($f =~ /^(.*)\.webmin$/) {
-		local $acldir = "$temp/$1";
-		local $ser = &read_file_contents("$temp/$f");
-		local $resel = &unserialise_variable($ser);
+		my $acldir = "$temp/$1";
+		my $ser = &read_file_contents("$temp/$f");
+		my $resel = &unserialise_variable($ser);
 		&create_reseller($resel);
 		opendir(ACL, $acldir);
 		foreach my $a (readdir(ACL)) {
 			next if ($a eq "." || $a eq "..");
-			local %acl;
+			my %acl;
 			&read_file("$acldir/$a", \%acl);
 			&save_module_acl(\%acl, $resel->{'name'}, $a);
 			}
@@ -6627,7 +6627,7 @@ return 1;
 # Creates a tar file of all email templates
 sub virtualmin_backup_email
 {
-local ($file, $vbs) = @_;
+my ($file, $vbs) = @_;
 &$first_print($text{'backup_vemail_doing'});
 &execute_command(
 	"cd $module_config_directory && ".
@@ -6640,7 +6640,7 @@ return 1;
 # Extract a tar file of all email templates
 sub virtualmin_restore_email
 {
-local ($file, $vbs) = @_;
+my ($file, $vbs) = @_;
 &$first_print($text{'restore_vemail_doing'});
 &execute_command("cd $module_config_directory && ".
 		 &make_tar_command("xf", $file));
@@ -6652,7 +6652,7 @@ return 1;
 # Copies the custom fields, links and shells files
 sub virtualmin_backup_custom
 {
-local ($file, $vbs) = @_;
+my ($file, $vbs) = @_;
 &$first_print($text{'backup_vcustom_doing'});
 foreach my $fm ([ $custom_fields_file, $file ],
 		[ $custom_links_file, $file."_links" ],
@@ -6673,7 +6673,7 @@ return 1;
 # Restores the custom fields, links and shells files
 sub virtualmin_restore_custom
 {
-local ($file, $vbs) = @_;
+my ($file, $vbs) = @_;
 &$first_print($text{'restore_vcustom_doing'});
 foreach my $fm ([ $custom_fields_file, $file ],
 		[ $custom_links_file, $file."_links" ],
@@ -6700,7 +6700,7 @@ return 1;
 # Create a tar file of the scripts directory, and of the unavailable scripts
 sub virtualmin_backup_scripts
 {
-local ($file, $vbs) = @_;
+my ($file, $vbs) = @_;
 &$first_print($text{'backup_vscripts_doing'});
 &make_dir("$module_config_directory/scripts", 0755);
 &execute_command("cd $module_config_directory/scripts && ".
@@ -6714,7 +6714,7 @@ return 1;
 # Extract a tar file of all third-party scripts
 sub virtualmin_restore_scripts
 {
-local ($file, $vbs) = @_;
+my ($file, $vbs) = @_;
 &$first_print($text{'restore_vscripts_doing'});
 &make_dir("$module_config_directory/scripts", 0755);
 &execute_command("cd $module_config_directory/scripts && ".
@@ -6730,13 +6730,13 @@ return 1;
 # Create a file of FTP directory restrictions
 sub virtualmin_backup_chroot
 {
-local ($file, $vbs) = @_;
+my ($file, $vbs) = @_;
 &$first_print($text{'backup_vchroot_doing'});
 if (!&has_ftp_chroot()) {
 	&$second_print($text{'backup_vchroot_none'});
 	return 0;
 	}
-local @chroots = &list_ftp_chroots();
+my @chroots = &list_ftp_chroots();
 &open_tempfile(CHROOT, ">$file");
 foreach my $c (@chroots) {
 	&print_tempfile(CHROOT,
@@ -6752,18 +6752,18 @@ return 1;
 # Restore all chroot'd directories from a backup file
 sub virtualmin_restore_chroot
 {
-local ($file, $vbs) = @_;
+my ($file, $vbs) = @_;
 &$first_print($text{'restore_vchroot_doing'});
 if (!&has_ftp_chroot()) {
 	&$second_print($text{'restore_vchroot_none'});
 	return 1;
 	}
 &obtain_lock_ftp();
-local @chroots;
+my @chroots;
 open(CHROOT, "<".$file);
 while(<CHROOT>) {
 	s/\r|\n//g;
-	local %c = map { my ($n, $v) = split(/=/, $_, 2);
+	my %c = map { my ($n, $v) = split(/=/, $_, 2);
 			 ($n, &un_urlize($v)) }
 		       split(/\s+/, $_);
 	push(@chroots, \%c);
@@ -6779,18 +6779,18 @@ return 1;
 # Save DKIM and Postgrey settings to a file
 sub virtualmin_backup_mailserver
 {
-local ($file, $vbs) = @_;
+my ($file, $vbs) = @_;
 my $donecount = 0;
 
 &require_mail();
 
 # Save DKIM settings
 &$first_print($text{'backup_vmailserver_dkim'});
-local %dkim;
+my %dkim;
 if (!&check_dkim()) {
 	# DKIM can be used .. check if enabled
 	$dkim{'support'} = 1;
-	local $conf = &get_dkim_config();
+	my $conf = &get_dkim_config();
 	$dkim{'enabled'} = $conf->{'enabled'};
 	$dkim{'selector'} = $conf->{'selector'};
 	$dkim{'extra'} = join(" ", @{$conf->{'extra'}});
@@ -6811,16 +6811,16 @@ else {
 
 # Save Postgrey settings
 &$first_print($text{'backup_vmailserver_postgrey'});
-local %grey;
+my %grey;
 if (!&check_postgrey()) {
 	# Postgrey can be used .. check if enabled, and with what opts
 	$grey{'support'} = 1;
 	$grey{'enabled'} = &is_postgrey_enabled();
-	local $cfile = &get_postgrey_data_file("clients");
+	my $cfile = &get_postgrey_data_file("clients");
 	if ($cfile) {
 		&copy_source_dest($cfile, $file."_greyclients");
 		}
-	local $rfile = &get_postgrey_data_file("recipients");
+	my $rfile = &get_postgrey_data_file("recipients");
 	if ($rfile) {
 		&copy_source_dest($rfile, $file."_greyrecipients");
 		}
@@ -6835,7 +6835,7 @@ else {
 
 # Save rate limiting settings
 &$first_print($text{'backup_vmailserver_ratelimit'});
-local %ratelimit;
+my %ratelimit;
 if (!&check_ratelimit()) {
 	# Rate limiting can be used .. check if enabled, and save config
 	$ratelimit{'support'} = 1;
@@ -6900,7 +6900,7 @@ return $donecount;
 # Apply DKIM and Postgrey settings from the backup
 sub virtualmin_restore_mailserver
 {
-local ($file, $vbs) = @_;
+my ($file, $vbs) = @_;
 &require_mail();
 
 # Restore DKIM config
@@ -6908,13 +6908,13 @@ local ($file, $vbs) = @_;
 &obtain_lock_mail();
 if (!&check_dkim()) {
 	# DKIM supported .. see what state was in the backup
-	local %dkim;
+	my %dkim;
 	&read_file($file."_dkim", \%dkim);
 	if (!$dkim{'support'}) {
 		&$second_print($text{'restore_vmailserver_none'});
 		}
 	else {
-		local $conf = &get_dkim_config();
+		my $conf = &get_dkim_config();
 		if ($dkim{'enabled'}) {
 			# Setup on this system, same as source
 			&$indent_print();
@@ -6923,7 +6923,7 @@ if (!&check_dkim()) {
 			$conf->{'extra'} = [ split(/\s+/, $dkim{'extra'}) ];
 			$conf->{'sign'} = $dkim{'sign'};
 			$conf->{'verify'} = $dkim{'verify'};
-			local $copiedkey = 0;
+			my $copiedkey = 0;
 			if ($conf->{'keyfile'} && -r $file."_dkimkey") {
 				# Can copy key now
 				&copy_source_dest($file."_dkimkey",
@@ -6961,7 +6961,7 @@ else {
 
 # Restore Postgrey config
 &$first_print($text{'restore_vmailserver_grey'});
-local %grey;
+my %grey;
 &read_file($file."_grey", \%grey);
 if (&check_postgrey() ne '' && &can_install_postgrey() && $grey{'enabled'}) {
 	# Postgrey is not installed on this system yet, but it was enabled
@@ -6973,17 +6973,17 @@ if (&check_postgrey() eq '') {
 		&$second_print($text{'restore_vmailserver_none'});
 		}
 	else {
-		local $enabled = &is_postgrey_enabled();
+		my $enabled = &is_postgrey_enabled();
 		if ($grey{'enabled'}) {
 			# Enable on this system, and copy client files
 			&$indent_print();
 			&enable_postgrey();
-			local $cfile = &get_postgrey_data_file("clients");
+			my $cfile = &get_postgrey_data_file("clients");
 			if ($cfile && -r $file."_greyclients") {
 				&copy_source_dest($file."_greyclients",
 						  $cfile);
 				}
-			local $rfile = &get_postgrey_data_file("recipients");
+			my $rfile = &get_postgrey_data_file("recipients");
 			if ($rfile && -r $file."_greyrecipients") {
 				&copy_source_dest($file."_greyrecipients",
 						  $rfile);
@@ -7011,7 +7011,7 @@ else {
 
 # Restore rate limiting config
 &$first_print($text{'restore_vmailserver_ratelimit'});
-local %ratelimit;
+my %ratelimit;
 &read_file($file."_ratelimit", \%ratelimit);
 if (&check_ratelimit() ne '' && &can_install_ratelimit() &&
     $ratelimit{'enabled'}) {
@@ -7024,7 +7024,7 @@ if (&check_ratelimit() eq '') {
 		&$second_print($text{'restore_vmailserver_none'});
 		}
 	else {
-		local $enabled = &is_ratelimit_enabled();
+		my $enabled = &is_ratelimit_enabled();
 		# XXX put back socket
 		if ($ratelimit{'enabled'}) {
 			# Enable on this system, and copy config file
@@ -7068,7 +7068,7 @@ else {
 &release_lock_mail();
 
 # Get mail server type from the backup
-local $bms = &read_file_contents($file);
+my $bms = &read_file_contents($file);
 $bms =~ s/\n//g;
 
 # Restore mail server type, if matching. This is done last because DKIM or
@@ -7155,7 +7155,7 @@ my ($d, $file, $opts, $allopts) = @_;
 if (!$allopts->{'fix'}) {
 	# Merge current and backup configs
 	&$first_print($text{'restore_virtualmincp'});
-	local %oldd;
+	my %oldd;
 	&read_file($file, \%oldd);
 	$d->{'quota'} = $oldd{'quota'};
 	$d->{'uquota'} = $oldd{'uquota'};
@@ -7246,8 +7246,8 @@ if (!$allopts->{'fix'}) {
 
 		# Fix up home dir on scripts
 		if ($_[5]->{'home'} && $_[5]->{'home'} ne $d->{'home'}) {
-			local $olddir = $_[5]->{'home'};
-			local $newdir = $d->{'home'};
+			my $olddir = $_[5]->{'home'};
+			my $newdir = $d->{'home'};
 			foreach my $sinfo (&list_domain_scripts($d)) {
 				$sinfo->{'opts'}->{'dir'} =~
 				       s/^\Q$olddir\E\//$newdir\//;
@@ -7295,7 +7295,7 @@ return 1;
 # a server, like user@foo:/path/to/bar/
 sub scp_copy
 {
-local ($src, $dest, $pass, $err, $port, $asuser) = @_;
+my ($src, $dest, $pass, $err, $port, $asuser) = @_;
 if ($src =~ /\s|\(|\)/) {
 	my ($host, $path) = split(/:/, $src, 2);
 	if ($path) {
@@ -7308,7 +7308,7 @@ if ($dest =~ /\s|\(|\)/) {
 		$dest = $host.":".quotemeta($path);
 		}
 	}
-local $cmd = "scp -r ".($port ? "-P $port " : "").
+my $cmd = "scp -r ".($port ? "-P $port " : "").
 	     $config{'ssh_args'}." ".
 	     $config{'scp_args'}." ".
 	     quotemeta($src)." ".quotemeta($dest);
@@ -7420,19 +7420,19 @@ return $out;
 # Checks this system's configured interfaces, and does pings.
 sub free_ip_address
 {
-local ($tmpl) = @_;
-local %taken = &interface_ip_addresses();
+my ($tmpl) = @_;
+my %taken = &interface_ip_addresses();
 %taken = (%taken, &domain_ip_addresses(), &cloudmin_ip_addresses());
 foreach my $ip (&get_default_ip(), &list_shared_ips()) {
 	$taken{$ip}++;
 	}
-local @ranges = split(/\s+/, $tmpl->{'ranges'});
+my @ranges = split(/\s+/, $tmpl->{'ranges'});
 foreach my $rn (@ranges) {
 	my ($r, $n) = split(/\//, $rn);
 	$r =~ /^(\d+\.\d+\.\d+)\.(\d+)\-(\d+)$/ || next;
-	local ($base, $s, $e) = ($1, $2, $3);
+	my ($base, $s, $e) = ($1, $2, $3);
 	for(my $j=$s; $j<=$e; $j++) {
-		local $try = "$base.$j";
+		my $try = "$base.$j";
 		if (!$taken{$try} && !&ping_ip_address($try)) {
 			return wantarray ? ( $try, $n ) : $try;
 			}
@@ -7446,16 +7446,16 @@ return wantarray ? ( ) : undef;
 # used. Checks this system's configured interfaces, and does pings.
 sub free_ip6_address
 {
-local ($tmpl) = @_;
-local %taken = &interface_ip_addresses();
+my ($tmpl) = @_;
+my %taken = &interface_ip_addresses();
 %taken = (%taken, &domain_ip_addresses());
-local @ranges = split(/\s+/, $tmpl->{'ranges6'});
+my @ranges = split(/\s+/, $tmpl->{'ranges6'});
 foreach my $rn (@ranges) {
 	my ($r, $n) = split(/\//, lc($rn));
 	$r =~ /^([0-9a-f:]+):([0-9a-f]+)\-([0-9a-f]+)$/ || next;
-	local ($base, $s, $e) = ($1, $2, $3);
+	my ($base, $s, $e) = ($1, $2, $3);
 	for(my $j=hex($s); $j<=hex($e); $j++) {
-		local $try = sprintf "%s:%x", $base, $j;
+		my $try = sprintf "%s:%x", $base, $j;
 		if (!$taken{$try} && !&ping_ip_address($try)) {
 			return wantarray ? ( $try, $n ) : $try;
 			}
@@ -7469,7 +7469,7 @@ return wantarray ? ( ) : undef;
 # active and boot-time
 sub interface_ip_addresses
 {
-local %taken;
+my %taken;
 foreach my $ip (&active_ip_addresses(), &bootup_ip_addresses()) {
 	$taken{$ip} = 1;
 	}
@@ -7480,7 +7480,7 @@ return %taken;
 # Returns a hash of IPs that are assigned to any domains as virtual IPs
 sub domain_ip_addresses
 {
-local %taken;
+my %taken;
 foreach my $d (&list_domains()) {
 	$taken{$d->{'ip'}} = 1 if ($d->{'virt'});
 	$taken{$d->{'ip6'}} = 1 if ($d->{'virt6'});
@@ -7492,7 +7492,7 @@ return %taken;
 # Returns a hash of IPs that are assigned to any Cloudmin servers (if installed)
 sub cloudmin_ip_addresses
 {
-local %taken;
+my %taken;
 if (&foreign_installed("server-manager")) {
 	&foreign_require("server-manager");
 	foreach my $s (&server_manager::list_managed_servers()) {
@@ -7513,7 +7513,7 @@ return %taken;
 sub active_ip_addresses
 {
 &foreign_require("net");
-local @rv;
+my @rv;
 push(@rv, map { $_->{'address'} } &net::active_interfaces());
 if (&supports_ip6()) {
 	push(@rv, map { $_->{'address'} } &active_ip6_interfaces());
@@ -7521,7 +7521,7 @@ if (&supports_ip6()) {
 if (&has_command("ip")) {
 	# On Linux, the 'ip' command sometimes includes IPs that are not
 	# shown by ifconfig -a
-	local $out = &backquote_command("ip addr </dev/null 2>/dev/null");
+	my $out = &backquote_command("ip addr </dev/null 2>/dev/null");
 	foreach my $l (split(/\r?\n/, $out)) {
 		if ($l =~ /inet\s+([0-9\.]+)/) {
 			push(@rv, $1);
@@ -7539,11 +7539,11 @@ return grep { $_ ne '' } &unique(@rv);
 sub bootup_ip_addresses
 {
 &foreign_require("net");
-local @rv;
+my @rv;
 foreach my $i (&net::boot_interfaces()) {
 	if ($i->{'range'} && $i->{'start'} && $i->{'end'}) {
-		local $start = &net::ip_to_integer($i->{'start'});
-		local $end = &net::ip_to_integer($i->{'end'});
+		my $start = &net::ip_to_integer($i->{'start'});
+		my $end = &net::ip_to_integer($i->{'end'});
 		for(my $j=$start; $j<=$end; $j++) {
 			push(@rv, &net::integer_to_ip($j));
 			}
@@ -7562,11 +7562,11 @@ return grep { $_ ne '' } &unique(@rv);
 # Returns 1 if some host responds to a ping in 1 second
 sub ping_ip_address
 {
-local ($host) = @_;
-local $pinger = &check_ip6address($host) ? "ping6" : "ping";
-local $pingcmd = $gconfig{'os_type'} =~ /-linux$/ ? "$pinger -c 1 -t 1"
+my ($host) = @_;
+my $pinger = &check_ip6address($host) ? "ping6" : "ping";
+my $pingcmd = $gconfig{'os_type'} =~ /-linux$/ ? "$pinger -c 1 -t 1"
 						  : $pinger;
-local ($out, $timed_out) = &backquote_with_timeout(
+my ($out, $timed_out) = &backquote_with_timeout(
 	$pingcmd." ".$host." 2>&1", 1, 1);
 return !$timed_out && !$?;
 }
@@ -7576,8 +7576,8 @@ return !$timed_out && !$?;
 # array of starting IP, ending IP and optional netmask
 sub parse_ip_ranges
 {
-local @rv;
-local @ranges = split(/\s+/, $_[0]);
+my @rv;
+my @ranges = split(/\s+/, $_[0]);
 foreach my $rn (@ranges) {
 	my ($r, $n) = split(/\//, $rn);
 	if ($r =~ /^(\d+\.\d+\.\d+)\.(\d+)\-(\d+)$/) {
@@ -7596,18 +7596,18 @@ return @rv;
 # Converts a list of ranges into a string
 sub join_ip_ranges
 {
-local @ranges;
+my @ranges;
 foreach my $r (@{$_[0]}) {
 	if (&check_ipaddress($r->[0])) {
 		# IPv4 range
-		local @start = split(/\./, $r->[0]);
-		local @end = split(/\./, $r->[1]);
+		my @start = split(/\./, $r->[0]);
+		my @end = split(/\./, $r->[1]);
 		push(@ranges, join(".", @start)."-".$end[3].
 			      ($r->[2] ? "/".$r->[2] : ""));
 		}
 	elsif (&check_ip6address($r->[0])) {
 		# IPv6 range
-		local @end = split(/:/, $r->[1]);
+		my @end = split(/:/, $r->[1]);
 		push(@ranges, $r->[0]."-".$end[$#end].
 			      ($r->[2] ? "/".$r->[2] : ""));
 		}
@@ -7634,7 +7634,7 @@ foreach my $r (&parse_ip_ranges($ranges)) {
 		# IPv6 range
 		my ($p, $n) = split(/\//, lc($r));
 		$p =~ /^([0-9a-f:]+):([0-9a-f]+)\-([0-9a-f]+)$/ || next;
-		local ($base, $s, $e) = ($1, $2, $3);
+		my ($base, $s, $e) = ($1, $2, $3);
 		$ip =~ /^([0-9a-f:]+):([0-9a-f]+)$/ || next;
 		if (lc($1) eq lc($base) &&
 		    hex($2) >= hex($s) && hex($2) <= hex($e)) {
@@ -7649,7 +7649,7 @@ return 0;
 # Ensures that this virtual server can host sub-servers
 sub setup_for_subdomain
 {
-local ($d, $subuser, $subd) = @_;
+my ($d, $subuser, $subd) = @_;
 if (!-d "$d->{'home'}/domains") {
 	&make_dir_as_domain_user($d, "$d->{'home'}/domains", 0755);
 	}
@@ -7663,15 +7663,15 @@ if (!-d "$d->{'home'}/domains") {
 # May exclude alias domains if they don't count towards the max.
 sub count_domains
 {
-local ($type) = @_;
+my ($type) = @_;
 $type ||= "doms";
-local ($left, $reason, $max, $hide) = &count_feature($type);
+my ($left, $reason, $max, $hide) = &count_feature($type);
 if ($left != 0 && $type ne "aliasdoms") {
 	# If no limit has been hit, check the licence
-	local ($lstatus, $lexpiry, $lerr, $ldoms) = &check_licence_expired();
+	my ($lstatus, $lexpiry, $lerr, $ldoms) = &check_licence_expired();
 	if ($ldoms) {
-		local $donedef = 0;
-		local @doms = grep { !$_->{'alias'} &&
+		my $donedef = 0;
+		my @doms = grep { !$_->{'alias'} &&
 				     (!$_->{'defaultdomain'} || $donedef++) }
 				   &list_domains();
 		if (@doms > $ldoms) {
@@ -7680,7 +7680,7 @@ if ($left != 0 && $type ne "aliasdoms") {
 		else {
 			# Haven't reached .. check if the licence limit is
 			# less than the current limit
-			local $dleft = $ldoms - @doms;
+			my $dleft = $ldoms - @doms;
 			if ($left == -1 || $dleft < $left) {
 				# Will hit licensed domains limit
 				return ($dleft, 3,
@@ -7701,12 +7701,12 @@ return ($left, $reason, $max, $hide);
 # max allowed for the current user
 sub count_mailboxes
 {
-local $count = 0;
-local $doms = 0;
-local $parent = $_[0]->{'parent'} ? &get_domain($_[0]->{'parent'}) : $_[0];
-local $d;
+my $count = 0;
+my $doms = 0;
+my $parent = $_[0]->{'parent'} ? &get_domain($_[0]->{'parent'}) : $_[0];
+my $d;
 foreach $d ($parent, &get_domain_by("parent", $parent->{'id'})) {
-	local @users = &list_domain_users($d, 0, 1, 1, 1);
+	my @users = &list_domain_users($d, 0, 1, 1, 1);
 	$count += @users;
 	$doms++;
 	}
@@ -7723,20 +7723,20 @@ return ( $count, $parent->{'mailboxlimit'} ? $parent->{'mailboxlimit'} : 0,
 # "aliases", "quota", "uquota", "dbs", "bw" or a feature
 sub count_feature
 {
-local ($f) = @_;
-local $user = $_[1] || $base_remote_user;
+my ($f) = @_;
+my $user = $_[1] || $base_remote_user;
 local %access = &get_module_acl($user);
 
 # Master admin has no limit
 return (-1, 0) if (&master_admin());
 
-local $userleft = -1;
-local $usermax;
+my $userleft = -1;
+my $usermax;
 if (!$access{'reseller'}) {
 	# Count the number that this user has
-	local @doms = &get_domain_by("user", $user);
-	local ($parent) = grep { !$_->{'parent'} } @doms;
-	local $limit = $f eq "doms" ? $parent->{'domslimit'} :
+	my @doms = &get_domain_by("user", $user);
+	my ($parent) = grep { !$_->{'parent'} } @doms;
+	my $limit = $f eq "doms" ? $parent->{'domslimit'} :
 		       $f eq "aliasdoms" ? $parent->{'aliasdomslimit'} :
 		       $f eq "realdoms" ? $parent->{'realdomslimit'} :
 		       $f eq "mailboxes" ? $parent->{'mailboxlimit'} :
@@ -7745,7 +7745,7 @@ if (!$access{'reseller'}) {
 	$limit = undef if ($limit eq "*");
 	if ($limit ne "") {
 		# A server-owner-level limit is in force .. check it
-		local $got = &count_domain_feature($f, @doms);
+		my $got = &count_domain_feature($f, @doms);
 		if ($got >= $limit) {
 			return (0, 0, $limit);
 			}
@@ -7755,7 +7755,7 @@ if (!$access{'reseller'}) {
 	if (($f eq "aliasdoms" || $f eq "realdoms") &&
 	    $parent->{'domslimit'} && $parent->{'domslimit'} ne '*') {
 		# See if the owner is over the limit for all domains types too
-		local $got = &count_domain_feature("doms", @doms);
+		my $got = &count_domain_feature("doms", @doms);
 		if ($got >= $parent->{'domslimit'}) {
 			return (0, 0, $parent->{'domslimit'});
 			}
@@ -7772,21 +7772,21 @@ else {
 
 if ($reseller && defined(&get_reseller_domains)) {
 	# Either this user is owned by a reseller, or he is a reseller.
-	local @rdoms = &get_reseller_domains($reseller);
-	local %racl = &get_reseller_acl($reseller);
-	local $reason = $access{'reseller'} ? 2 : 1;
-	local $hide = $base_remote_user ne $reseller && $racl{'hide'};
-	local $limit = $racl{"max_".$f};
+	my @rdoms = &get_reseller_domains($reseller);
+	my %racl = &get_reseller_acl($reseller);
+	my $reason = $access{'reseller'} ? 2 : 1;
+	my $hide = $base_remote_user ne $reseller && $racl{'hide'};
+	my $limit = $racl{"max_".$f};
 	if ($limit ne "") {
 		# Reseller has a limit ..
-		local $got = &count_domain_feature($f, @rdoms);
+		my $got = &count_domain_feature($f, @rdoms);
 		if ($got > $limit || $got < 0) {
 			# Reseller has reached his limit
 			return (0, $reason, $limit, $hide);
 			}
 		else {
 			# Check if reseller limit is less than the user limit
-			local $reselleft = $limit - $got;
+			my $reselleft = $limit - $got;
 			if ($userleft == -1 || $reselleft < $userleft) {
 				# Yes .. reseller limit applies
 				return ($reselleft, $reason, $limit, $hide);
@@ -7796,14 +7796,14 @@ if ($reseller && defined(&get_reseller_domains)) {
 	if (($f eq "aliasdoms" || $f eq "realdoms" || $f eq "topdoms") &&
 	    $racl{'max_doms'}) {
 		# See if the reseller is over the limit for all domains types
-		local $got = &count_domain_feature("doms", @rdoms);
+		my $got = &count_domain_feature("doms", @rdoms);
 		if ($got >= $racl{'max_doms'}) {
 			return (0, $reason, $racl{'max_doms'}, $hide);
 			}
 		}
 	if ($f eq "topdoms" && $racl{'max_realdoms'}) {
 		# See if the reseller is over the limit for all real domains
-		local $got = &count_domain_feature("realdoms", @rdoms);
+		my $got = &count_domain_feature("realdoms", @rdoms);
 		if ($got >= $racl{'max_realdoms'}) {
 			return (0, $reason, $racl{'max_realdoms'}, $hide);
 			}
@@ -7817,20 +7817,20 @@ return ($userleft, 0, $usermax);
 # any are set to unlimited (ie. quotas)
 sub count_domain_feature
 {
-local ($f, @doms) = @_;
-local $rv = 0;
-local $d;
+my ($f, @doms) = @_;
+my $rv = 0;
+my $d;
 foreach $d (@doms) {
 	if ($f eq "dbs") {
-		local @dbs = &domain_databases($d);
+		my @dbs = &domain_databases($d);
 		$rv += scalar(@dbs);
 		}
 	elsif ($f eq "mailboxes") {
-		local @users = &list_domain_users($d, 0, 1, 1, 1);
+		my @users = &list_domain_users($d, 0, 1, 1, 1);
 		$rv += scalar(@users);
 		}
 	elsif ($f eq "aliases") {
-		local @aliases = &list_domain_aliases($d, 1);
+		my @aliases = &list_domain_aliases($d, 1);
 		$rv += scalar(@aliases);
 		}
 	elsif ($f eq "quota" || $f eq "uquota") {
@@ -7869,22 +7869,22 @@ return $rv;
 # Returns a suitable database name for a domain
 sub database_name
 {
-local ($d) = @_;
-local $tmpl = &get_template($d->{'template'});
-local %hash = %$d;
+my ($d) = @_;
+my $tmpl = &get_template($d->{'template'});
+my %hash = %$d;
 if (!$hash{'uid'}) {
 	# Fake UID allocation now, in case the template uses it
-	local %taken;
+	my %taken;
         &build_taken(\%taken);
         $hash{'uid'} = &allocate_uid(\%taken);
 	}
 if (!$hash{'gid'}) {
 	# Fake GID allocation
-	local %gtaken;
+	my %gtaken;
 	&build_group_taken(\%gtaken);
 	$hash{'gid'} = &allocate_gid(\%gtaken);
 	}
-local $db = &substitute_domain_template($tmpl->{'mysql'}, \%hash);
+my $db = &substitute_domain_template($tmpl->{'mysql'}, \%hash);
 $db = lc($db);
 $db ||= $d->{'prefix'};
 $db = &fix_database_name($db, $d->{'mysql'} && $d->{'postgres'} ? undef :
@@ -7898,7 +7898,7 @@ return $db;
 # and handles reserved DB names.
 sub fix_database_name
 {
-local ($db, $dbtype) = @_;
+my ($db, $dbtype) = @_;
 if (!$dbtype) {
 	# Guess DB type
 	my @dbtypes = grep { $config{$_} } @database_features;
@@ -7944,8 +7944,8 @@ return $db;
 # Returns an error message if a name is invalid, undef if OK
 sub validate_database_name
 {
-local ($d, $dbtype, $dbname) = @_;
-local $vfunc = "validate_database_name_".$dbtype;
+my ($d, $dbtype, $dbname) = @_;
+my $vfunc = "validate_database_name_".$dbtype;
 if (defined(&$vfunc)) {
 	return &$vfunc($d, $dbname);
 	}
@@ -8110,20 +8110,20 @@ return undef;
 # missing features
 sub virtual_server_depends
 {
-local ($d, $feat, $oldd) = @_;
-local $f;
+my ($d, $feat, $oldd) = @_;
+my $f;
 
 # Check features that are enabled
 foreach $f (grep { $d->{$_} } @features) {
 	next if ($feat && $f ne $feat);
-	local $dfunc = "check_depends_$f";
+	my $dfunc = "check_depends_$f";
 	if (defined(&$dfunc)) {
 		# Call dependecy function
-		local $derr = &$dfunc($d, $oldd);
+		my $derr = &$dfunc($d, $oldd);
 		return $derr if ($derr);
 		}
 	# Check fixed dependency list
-	local $fd;
+	my $fd;
 	foreach $fd (@{$feature_depends{$f}}) {
 		return &text('setup_edep'.$f) if (!$d->{$fd});
 		}
@@ -8132,7 +8132,7 @@ foreach $f (grep { $d->{$_} } @features) {
 # Check plugins that are enabled
 foreach $f (grep { $d->{$_} } &list_feature_plugins()) {
 	next if ($feat && $f ne $feat);
-	local $derr = &plugin_call($f, "feature_depends", $d, $oldd);
+	my $derr = &plugin_call($f, "feature_depends", $d, $oldd);
 	return $derr if ($derr);
 	}
 
@@ -8140,10 +8140,10 @@ foreach $f (grep { $d->{$_} } &list_feature_plugins()) {
 # not missing. ie. mysql missing from parent but on children
 foreach $f (grep { !$d->{$_} } @features) {
 	next if ($feat && $f ne $feat);
-	local $dfunc = "check_anti_depends_$f";
+	my $dfunc = "check_anti_depends_$f";
 	if (defined(&$dfunc)) {
 		# Call dependecy function
-		local $derr = &$dfunc($d);
+		my $derr = &$dfunc($d);
 		return $derr if ($derr);
 		}
 	}
@@ -8155,12 +8155,12 @@ return undef;
 # Checks if the addition of a feature would exceed any limit for the user
 sub virtual_server_limits
 {
-local ($d, $oldd) = @_;
-local ($left, $reason, $max);
-local $tmpl = &get_template($d->{'template'});
+my ($d, $oldd) = @_;
+my ($left, $reason, $max);
+my $tmpl = &get_template($d->{'template'});
 
 # Check database limit
-local $newdbs = 0;
+my $newdbs = 0;
 $newdbs++ if ($d->{'mysql'} && (!$oldd || !$oldd->{'mysql'}) &&
 	      $tmpl->{'mysql_mkdb'} && !$d->{'no_mysql_db'});
 $newdbs++ if ($d->{'postgres'} && (!$oldd || !$oldd->{'postgres'}) &&
@@ -8178,7 +8178,7 @@ if (!$d->{'parent'} && $d->{'quota'} eq "" && $left != -1) {
 	# Unlimited quota chosen, but not allowed!
 	return &text('setup_noquotainf'.$reason, &quota_show($max, "home"));
 	}
-local $newquota = $d->{'quota'} - ($oldd ? $oldd->{'quota'} : 0);
+my $newquota = $d->{'quota'} - ($oldd ? $oldd->{'quota'} : 0);
 if ($left != -1 && $left-$newquota < 0) {
 	return &text('setup_noquotaadd'.$reason,
 		     &quota_show($left+($oldd ? $oldd->{'quota'} : 0),
@@ -8191,7 +8191,7 @@ if (!$d->{'parent'} && $d->{'bw_limit'} eq "" && $left != -1) {
 	# Unlimited bandwidth chosen, but not allowed!
 	return &text('setup_nobwinf'.$reason, &nice_size($max));
 	}
-local $newquota = $d->{'bw_limit'} - ($oldd ? $oldd->{'bw_limit'} : 0);
+my $newquota = $d->{'bw_limit'} - ($oldd ? $oldd->{'bw_limit'} : 0);
 if ($left != -1 && $left-$newquota < 0) {
 	return &text('setup_nobwadd'.$reason,
 		     &nice_size($left+($oldd ? $oldd->{'bw_limit'} : 0)));
@@ -8215,21 +8215,21 @@ return undef;
 # of some virtual server.
 sub virtual_server_warnings
 {
-local ($d, $oldd, $repl) = @_;
-local @rv;
+my ($d, $oldd, $repl) = @_;
+my @rv;
 
 # Check core features
 foreach my $f (grep { $d->{$_} } @features) {
-	local $wfunc = "check_warnings_$f";
+	my $wfunc = "check_warnings_$f";
 	if (defined(&$wfunc)) {
-		local $err = &$wfunc($d, $oldd, $repl);
+		my $err = &$wfunc($d, $oldd, $repl);
 		push(@rv, $err) if ($err);
 		}
 	}
 
 # Check plugins that are enabled
 foreach $f (grep { $d->{$_} } &list_feature_plugins()) {
-	local $err = &plugin_call($f, "feature_warnings", $d, $oldd);
+	my $err = &plugin_call($f, "feature_warnings", $d, $oldd);
 	push(@rv, $err) if ($err);
 	}
 return @rv;
@@ -8241,9 +8241,9 @@ return @rv;
 # is set. Returns 1 if the warning form was shown, 0 if not.
 sub show_virtual_server_warnings
 {
-local ($d, $oldd, $in) = @_;
+my ($d, $oldd, $in) = @_;
 return 0 if ($in->{'confirm_warnings'});
-local @warns = &virtual_server_warnings($d, $oldd);
+my @warns = &virtual_server_warnings($d, $oldd);
 return 0 if (!@warns);
 
 my @hids;
@@ -8280,7 +8280,7 @@ return 0;
 # Given a complete domain object, setup all it's features
 sub create_virtual_server
 {
-local ($dom, $parentdom, $parentuser, $noscripts, $nopost,
+my ($dom, $parentdom, $parentuser, $noscripts, $nopost,
        $pass, $content) = @_;
 
 # Sanity checks
@@ -8288,7 +8288,7 @@ $dom->{'ip'} || $dom->{'ip6'} || return $text{'setup_edefip'};
 
 # Run the before command
 &set_domain_envs($dom, "CREATE_DOMAIN");
-local $merr = &making_changes();
+my $merr = &making_changes();
 &reset_domain_envs($dom);
 return &text('setup_emaking', "<tt>$merr</tt>") if (defined($merr));
 
@@ -8304,10 +8304,10 @@ if ($dom->{'ip'} eq &get_default_ip() &&
 	}
 
 # Work out the auto-alias domain name
-local $tmpl = &get_template($dom->{'template'});
-local $aliasname;
+my $tmpl = &get_template($dom->{'template'});
+my $aliasname;
 if ($tmpl->{'domalias'} ne 'none' && $tmpl->{'domalias'} && !$dom->{'alias'}) {
-	local $aliasprefix = $dom->{'dom'};
+	my $aliasprefix = $dom->{'dom'};
 	if ($tmpl->{'domalias_type'} eq '1') {
 		# Shorten to first part of domain
 		$aliasprefix =~ s/\..*$//;
@@ -8379,9 +8379,9 @@ if (!defined($dom->{'defaultdomain'})) {
 
 # Set up all the selected features (except Webmin login)
 my $f;
-local @dof = grep { $_ ne "webmin" } @features;
-local $p = &domain_has_website($dom);
-local $s = &domain_has_ssl($dom);
+my @dof = grep { $_ ne "webmin" } @features;
+my $p = &domain_has_website($dom);
+my $s = &domain_has_ssl($dom);
 $dom->{'creating'} = 1;	# Tell features that they are being called for creation
 foreach $f (@dof) {
 	my $err;
@@ -8409,8 +8409,8 @@ foreach $f (&list_feature_plugins()) {
 
 # Setup Webmin login last, once all plugins are done
 if ($dom->{'webmin'}) {
-	local $sfunc = "setup_webmin";
-	local ($ok, $fok) = &try_function($f, $sfunc, $dom);
+	my $sfunc = "setup_webmin";
+	my ($ok, $fok) = &try_function($f, $sfunc, $dom);
 	if (!$ok || !$fok) {
 		$dom->{$f} = 0;
 		}
@@ -8418,13 +8418,13 @@ if ($dom->{'webmin'}) {
 
 # Add virtual IP address, if needed
 if ($dom->{'virt'}) {
-	local ($ok, $fok) = &try_function("virt", "setup_virt", $dom);
+	my ($ok, $fok) = &try_function("virt", "setup_virt", $dom);
 	if (!$ok || !$fok) {
 		$dom->{'virt'} = 0;
 		}
 	}
 if ($dom->{'virt6'}) {
-	local ($ok, $fok) = &try_function("virt6", "setup_virt6", $dom);
+	my ($ok, $fok) = &try_function("virt6", "setup_virt6", $dom);
 	if (!$ok || !$fok) {
 		$dom->{'virt6'} = 0;
 		}
@@ -8481,9 +8481,9 @@ if ($aliasname && $aliasname ne $dom->{'dom'}) {
 		}
 	else {
 		&$indent_print();
-		local $parentdom = $dom->{'parent'} ?
+		my $parentdom = $dom->{'parent'} ?
 			&get_domain($dom->{'parent'}) : $dom;
-		local %alias = ( 'id', &domain_id(),
+		my %alias = ( 'id', &domain_id(),
 				 'dom', $aliasname,
 				 'user', $dom->{'user'},
 				 'group', $dom->{'group'},
@@ -8535,7 +8535,7 @@ if ($aliasname && $aliasname ne $dom->{'dom'}) {
 &setup_web_for_php($dom, undef, undef);
 
 # Install any scripts specified in the template
-local @scripts = &get_template_scripts($tmpl);
+my @scripts = &get_template_scripts($tmpl);
 if (@scripts && !$dom->{'alias'} && !$noscripts &&
     &domain_has_website($dom) && $dom->{'dir'} &&
     !$dom->{'nocreationscripts'}) {
@@ -8543,29 +8543,29 @@ if (@scripts && !$dom->{'alias'} && !$noscripts &&
 	&$indent_print();
 	foreach my $sinfo (@scripts) {
 		# Work out install options
-		local ($name, $ver) = split(/\s+/, $sinfo->{'name'});
-		local $script = &get_script($name);
+		my ($name, $ver) = split(/\s+/, $sinfo->{'name'});
+		my $script = &get_script($name);
 		if (!$script) {
 			&$first_print(&text('setup_scriptgone', $name));
 			next;
 			}
 
 		# Work out actual version
-		local @allvers = @{$script->{'install_versions'}};
+		my @allvers = @{$script->{'install_versions'}};
 		if ($ver eq "latest") {
 			$ver = $allvers[0];
 			}
 
 		&$first_print(&text('setup_scriptinstall',
 				    $script->{'name'}, $ver));
-		local $opts = { 'path' => &substitute_scriptname_template(
+		my $opts = { 'path' => &substitute_scriptname_template(
 						$sinfo->{'path'}, $d) };
 		if ($sinfo->{'sopts'}) {
 			$opts->{$_->[0]} = $_->[1]
 				for map { [split(/=/, $_)] }
 					split(/,/, $sinfo->{'sopts'});
 			}
-		local $perr = &validate_script_path($opts, $script, $dom);
+		my $perr = &validate_script_path($opts, $script, $dom);
 		if ($perr) {
 			&$second_print(&text('setup_scriptpath', $perr));
 			next;
@@ -8575,7 +8575,7 @@ if (@scripts && !$dom->{'alias'} && !$noscripts &&
 		&setup_script_packages($script, $d, $ver);
 
 		# Check PHP version
-		local ($phpver, $phperr);
+		my ($phpver, $phperr);
 		if (&indexof("php", @{$script->{'uses'}}) >= 0) {
 			($phpver, $phperr) = &setup_php_version(
 				$dom, $script, $ver, $opts->{'path'});
@@ -8588,7 +8588,7 @@ if (@scripts && !$dom->{'alias'} && !$noscripts &&
 			}
 
 		# Check Python version
-		local ($pyver, $pyerr);
+		my ($pyver, $pyerr);
 		if (&indexof("python", @{$script->{'uses'}}) >= 0) {
 			($pyver, $pyerr) = &setup_python_version(
 				$dom, $script, $ver, $opts->{'path'});
@@ -8600,7 +8600,7 @@ if (@scripts && !$dom->{'alias'} && !$noscripts &&
 			}
 
 		# Check dependencies
-		local $derr = &check_script_depends($script, $dom, $ver,
+		my $derr = &check_script_depends($script, $dom, $ver,
 						    $sinfo, $phpver);
 		if ($derr) {
 			&$second_print(&text('setup_scriptdeps', $derr));
@@ -8615,7 +8615,7 @@ if (@scripts && !$dom->{'alias'} && !$noscripts &&
 
 		# Find the database, if requested
 		if ($sinfo->{'db'}) {
-			local $dbname = &substitute_domain_template(
+			my $dbname = &substitute_domain_template(
 						$sinfo->{'db'}, $dom);
 			if (!$dom->{$sinfo->{'dbtype'}}) {
 				# DB type isn't enabled for this domain
@@ -8624,8 +8624,8 @@ if (@scripts && !$dom->{'alias'} && !$noscripts &&
 				next;
 				}
 			$opts->{'db'} = $sinfo->{'dbtype'}."_".$dbname;
-			local @dbs = &domain_databases($dom);
-			local ($db) = grep {
+			my @dbs = &domain_databases($dom);
+			my ($db) = grep {
 				$_->{'type'} eq $sinfo->{'dbtype'} &&
 				$_->{'name'} eq $dbname } @dbs;
 			if (!$db) {
@@ -8655,8 +8655,8 @@ if (@scripts && !$dom->{'alias'} && !$noscripts &&
 			}
 
 		# Fetch needed files
-		local %gotfiles;
-		local $ferr = &fetch_script_files($script, $dom, $ver, $opts,
+		my %gotfiles;
+		my $ferr = &fetch_script_files($script, $dom, $ver, $opts,
 						  undef, \%gotfiles, 1);
 		if ($derr) {
 			&$second_print(&text('setup_scriptfetch', $ferr));
@@ -8664,11 +8664,11 @@ if (@scripts && !$dom->{'alias'} && !$noscripts &&
 			}
 
 		# Disable PHP timeouts
-		local $t = &disable_script_php_timeout($dom);
+		my $t = &disable_script_php_timeout($dom);
 
 		# Call the install function
-		local $dompass = $dom->{'pass'} || &random_password(8);
-		local ($ok, $msg, $desc, $url, $suser, $spass) =
+		my $dompass = $dom->{'pass'} || &random_password(8);
+		my ($ok, $msg, $desc, $url, $suser, $spass) =
 			&{$script->{'install_func'}}(
 				$dom, $ver, $opts, \%gotfiles, undef,
 				$dom->{'user'}, $dompass);
@@ -8739,9 +8739,9 @@ if (@redirs && !$dom->{'alias'} &&  &domain_has_website($dom) &&
 # is useful for things like awstats, which need to add the alias domain to those
 # supported for the main site.
 if ($dom->{'alias'}) {
-	local $aliasdom = &get_domain($dom->{'alias'});
+	my $aliasdom = &get_domain($dom->{'alias'});
 	foreach my $f (@features) {
-		local $safunc = "setup_alias_$f";
+		my $safunc = "setup_alias_$f";
 		if ($aliasdom->{$f} && defined(&$safunc)) {
 			&try_function($f, $safunc, $aliasdom, $dom);
 			}
@@ -8762,7 +8762,7 @@ if ($dom->{'alias'}) {
 
 # Refresh Unix group membership for reseller
 if ($dom->{'reseller'} && defined(&update_reseller_unix_groups)) {
-	local $rinfo = &get_reseller($dom->{'reseller'});
+	my $rinfo = &get_reseller($dom->{'reseller'});
 	if ($rinfo) {
 		&update_reseller_unix_groups($rinfo, 1);
 		}
@@ -8826,8 +8826,8 @@ if ($generated == 2) {
 # For a new alias domain, if the target has a Let's Encrypt cert for all
 # possible hostnames, re-request it to include the alias
 if ($dom->{'alias'} && &domain_has_website($dom) && !$acme_never) {
-	local $target = &get_domain($dom->{'alias'});
-	local $tinfo;
+	my $target = &get_domain($dom->{'alias'});
+	my $tinfo;
 	if ($target &&
 	    &domain_has_website($target) &&
 	    $target->{'letsencrypt_renew'} &&
@@ -8893,7 +8893,7 @@ if (!$nopost) {
 	}
 &unlock_domain($dom);
 &set_domain_envs($dom, "CREATE_DOMAIN");
-local $merr = &made_changes();
+my $merr = &made_changes();
 &$second_print(&text('setup_emade', "<tt>$merr</tt>")) if (defined($merr));
 &reset_domain_envs($dom);
 
@@ -8905,7 +8905,7 @@ return wantarray ? ($dom) : undef;
 # had SSL enabled. May print stuff.
 sub create_initial_letsencrypt_cert
 {
-local ($d, $valid, $showerrors) = @_;
+my ($d, $valid, $showerrors) = @_;
 &foreign_require("webmin");
 my $tmpl = &get_template($d->{'template'});
 my @dnames;
@@ -9059,11 +9059,11 @@ else {
 # a non-vital failure.
 sub call_feature_setup
 {
-local ($f, $dom, @args) = @_;
-local %vital = map { $_, 1 } @vital_features;
+my ($f, $dom, @args) = @_;
+my %vital = map { $_, 1 } @vital_features;
 if (&indexof($f, @features) >= 0) {
 	# Core feature
-	local $sfunc = "setup_$f";
+	my $sfunc = "setup_$f";
 	if ($vital{$f}) {
 		# Failure of this feature should halt the entire setup
 		if (!&$sfunc($dom, @args)) {
@@ -9073,7 +9073,7 @@ if (&indexof($f, @features) >= 0) {
 		}
 	else {
 		# Failure can be ignored
-		local ($ok, $fok) = &try_function($f, $sfunc, $dom);
+		my ($ok, $fok) = &try_function($f, $sfunc, $dom);
 		if (!$ok || !$fok) {
 			$dom->{$f} = 0;
 			}
@@ -9084,7 +9084,7 @@ else {
 	local $main::error_must_die = 1;
 	eval { &plugin_call($f, "feature_setup", $dom, @args) };
 	if ($@) {
-		local $err = $@;
+		my $err = $@;
 		&$second_print(&text('setup_failure',
 			&plugin_call($f, "feature_name"), $err));
 		$dom->{$f} = 0;
@@ -9098,13 +9098,13 @@ return undef;
 # on succes, or an error message on failure.
 sub delete_virtual_server
 {
-local ($d, $only, $nopost, $preserve) = @_;
+my ($d, $only, $nopost, $preserve) = @_;
 
 # Get domain details
-local @subs = &get_domain_by("parent", $d->{'id'});
-local @aliasdoms = &get_domain_by("alias", $d->{'id'});
-local @aliasdoms = grep { $_->{'parent'} ne $d->{'id'} } @aliasdoms;
-local @alldoms = (@aliasdoms, @subs, $d);
+my @subs = &get_domain_by("parent", $d->{'id'});
+my @aliasdoms = &get_domain_by("alias", $d->{'id'});
+my @aliasdoms = grep { $_->{'parent'} ne $d->{'id'} } @aliasdoms;
+my @alldoms = (@aliasdoms, @subs, $d);
 
 # Check for DNS dependencies
 foreach my $dd (@alldoms) {
@@ -9152,24 +9152,24 @@ foreach my $dd (@alldoms) {
 
 	# Run the before command
 	&set_domain_envs($dd, "DELETE_DOMAIN");
-	local $merr = &making_changes();
+	my $merr = &making_changes();
 	&reset_domain_envs($dd);
 	return &text('delete_emaking', "<tt>$merr</tt>")
 		if (defined($merr));
 
 	if (!$only) {
-		local @users = $dd->{'alias'} && !$dd->{'aliasmail'} ||
+		my @users = $dd->{'alias'} && !$dd->{'aliasmail'} ||
 			       !$dd->{'group'} ? ( )
 					       : &list_domain_users($dd, 1, 0, 0, 0, 1);
-		local @aliases = &list_domain_aliases($dd);
+		my @aliases = &list_domain_aliases($dd);
 
 		# Stop any processes belonging to installed scripts, such
 		# as Ruby on Rails mongrels
-		local $done_stopscripts;
+		my $done_stopscripts;
 		if (!$dd->{'alias'}) {
 			foreach my $sinfo (&list_domain_scripts($dd)) {
-				local $script = &get_script($sinfo->{'name'});
-				local $sfunc = $script->{'stop_func'};
+				my $script = &get_script($sinfo->{'name'});
+				my $sfunc = $script->{'stop_func'};
 				if (defined(&$sfunc)) {
 					&$first_print(
 					    $text{'delete_stopscripts'})
@@ -9232,9 +9232,9 @@ foreach my $dd (@alldoms) {
 	# deleted. This allows things like extra awstats symlinks to be removed
 	$dd->{'deleting'} = 1;		# so that features know about delete
 	if (!$only && $dd->{'alias'}) {
-		local $aliasdom = &get_domain($dd->{'alias'});
+		my $aliasdom = &get_domain($dd->{'alias'});
 		foreach my $f (@features) {
-			local $dafunc = "delete_alias_$f";
+			my $dafunc = "delete_alias_$f";
 			if ($aliasdom->{$f} && defined(&$dafunc)) {
 				&try_function($f, $dafunc, $aliasdom, $dd);
 				}
@@ -9269,7 +9269,7 @@ foreach my $dd (@alldoms) {
 	# Delete all features (or just 'webmin' if un-importing). Any
 	# failures are ignored!
 	my $f;
-	local $p = &domain_has_website($dd);
+	my $p = &domain_has_website($dd);
 
 	# Always try to delete plugin-managed features before core features are
 	# torn down, so plugins can still access the domain home, web config and
@@ -9279,7 +9279,7 @@ foreach my $dd (@alldoms) {
 		&plugin_call($plugin, 'features_always_delete', $dd, $only);
 		}
 
-	local @of;
+	my @of;
 	if ($only) {
 		@of = ( "webmin" );
 		}
@@ -9290,7 +9290,7 @@ foreach my $dd (@alldoms) {
 		if (($config{$f} || &indexof($f, @plugins) >= 0) &&
 		    $dd->{$f} || $f eq 'unix') {
 			# Delete core feature
-			local @args = ( $preserve );
+			my @args = ( $preserve );
 			if ($f eq "mail") {
 				# Don't delete mail aliases, because we have
 				# already done so above
@@ -9341,7 +9341,7 @@ foreach my $dd (@alldoms) {
 
 	# Call post script
 	&set_domain_envs($dd, "DELETE_DOMAIN");
-	local $merr = &made_changes();
+	my $merr = &made_changes();
 	&reset_domain_envs($dd);
 	&$second_print(&text('setup_emade', "<tt>$merr</tt>"))
 		if (defined($merr));
@@ -9381,11 +9381,11 @@ return undef;
 # stuff.
 sub call_feature_delete
 {
-local ($f, $dom, @args) = @_;
+my ($f, $dom, @args) = @_;
 if (&indexof($f, @features) >= 0) {
 	# Call core delete function
-	local $dfunc = "delete_$f";
-	local ($ok, $fok) = &try_function($f, $dfunc, $dom, @args);
+	my $dfunc = "delete_$f";
+	my ($ok, $fok) = &try_function($f, $dfunc, $dom, @args);
 	if (!$ok || !$fok) {
 		$dom->{$f} = 1;
 		}
@@ -9395,7 +9395,7 @@ else {
 	local $main::error_must_die = 1;
 	eval { &plugin_call($f, "feature_delete", $dom, @args) };
 	if ($@) {
-		local $err = $@;
+		my $err = $@;
 		&$second_print(&text('delete_failure',
 			    &plugin_call($f, "feature_name"), $err));
 		}
@@ -9460,7 +9460,7 @@ my @disabled;
 foreach my $f (@features) {
 	if ($d->{$f} && $disable{$f}) {
 		my $dfunc = "disable_$f";
-		local ($ok, $fok) = &try_function($f, $dfunc, $d);
+		my ($ok, $fok) = &try_function($f, $dfunc, $d);
 		if ($ok && $fok) {
 			push(@disabled, $f);
 			}
@@ -9560,9 +9560,9 @@ push(@main::post_actions, [ @_ ]);
 # Run all registered post-modification actions
 sub run_post_actions
 {
-local @only = @_;
-local %only = map { $_, 1 } @only;
-local $a;
+my @only = @_;
+my %only = map { $_, 1 } @only;
+my $a;
 
 # Check if we are restarting Apache or Webmin, and if so don't reload it
 my ($apache, $webmin);
@@ -9585,8 +9585,8 @@ if ($webmin) {
 	}
 
 # Run unique actions
-local %done;
-local @newpost;
+my %done;
+my @newpost;
 foreach my $a (@main::post_actions) {
 	# Don't run multiple times
 	my $key;
@@ -9613,7 +9613,7 @@ foreach my $a (@main::post_actions) {
 	next if ($done{$key}++);
 
 	# Skip if the caller requested specific actions
-	local ($afunc, @aargs) = @$a;
+	my ($afunc, @aargs) = @$a;
 	if (@only && !$only{$afunc}) {
 		push(@newpost, $a);
 		next;
@@ -9643,7 +9643,7 @@ sub run_post_actions_silently
 # Returns the cron job used for bandwidth monitoring
 sub find_bandwidth_job
 {
-local $job = &find_cron_script($bw_cron_cmd);
+my $job = &find_cron_script($bw_cron_cmd);
 return $job;
 }
 
@@ -9653,7 +9653,7 @@ sub get_bandwidth
 {
 my ($d) = @_;
 if (!defined($get_bandwidth_cache{$d->{'id'}})) {
-	local %bwinfo;
+	my %bwinfo;
 	&read_file("$bandwidth_dir/$d->{'id'}", \%bwinfo);
 	foreach my $k (keys %bwinfo) {
 		if ($k =~ /^\d+$/) {
@@ -9681,11 +9681,11 @@ $get_bandwidth_cache{$d->{'id'}} ||= $info;
 # Returns HTML for a bandwidth input field, with an 'unlimited' option
 sub bandwidth_input
 {
-local ($name, $value, $nounlimited, $dontchange) = @_;
-local $rv;
-local $dis1 = &js_disable_inputs([ $name, $name."_units" ], [ ]);
-local $dis2 = &js_disable_inputs([ ], [ $name, $name."_units" ]);
-local $dis;
+my ($name, $value, $nounlimited, $dontchange) = @_;
+my $rv;
+my $dis1 = &js_disable_inputs([ $name, $name."_units" ], [ ]);
+my $dis2 = &js_disable_inputs([ ], [ $name, $name."_units" ]);
+my $dis;
 if (!$nounlimited) {
 	if ($dontchange) {
 		# Show don't change option
@@ -9703,7 +9703,7 @@ if (!$nounlimited) {
 		$dis = 1 if (!$value);
 		}
 	}
-local ($val, $u);
+my ($val, $u);
 my $unit = 1024;
 if ($value eq "") {
 	# Default to GB, since bytes are rarely useful
@@ -9729,7 +9729,7 @@ else {
 	$val = $value;
 	$u = $text{"nice_size_b"};
 	}
-local $sel = &ui_select($name."_units", $u,
+my $sel = &ui_select($name."_units", $u,
 		[ [$text{"nice_size_b"}], [$text{"nice_size_kiB"}], [$text{"nice_size_MiB"}], [$text{"nice_size_GiB"}], [$text{"nice_size_TiB"}] ], 1, 0, 0, $dis);
 $rv .= &text('edit_bwpast_'.$config{'bw_past'},
 	     &ui_textbox($name, $val, 10, $dis)." ".$sel,
@@ -9746,7 +9746,7 @@ if ($in{"$_[0]_def"} && !$_[2]) {
 else {
 	my $unit = 1024;
 	$in{$_[0]} =~ /^\d+$/ && $in{$_[0]} > 0 || &error($_[1]);
-	local $m = $in{"$_[0]_units"} eq $text{"nice_size_TiB"} ? $unit*$unit*$unit*$unit :
+	my $m = $in{"$_[0]_units"} eq $text{"nice_size_TiB"} ? $unit*$unit*$unit*$unit :
 		   $in{"$_[0]_units"} eq $text{"nice_size_GiB"} ? $unit*$unit*$unit :
 		   $in{"$_[0]_units"} eq $text{"nice_size_MiB"} ? $unit*$unit :
 		   $in{"$_[0]_units"} eq $text{"nice_size_kiB"} ? $unit : 1;
@@ -9759,9 +9759,9 @@ else {
 # Returns HTML for fields for editing an email template
 sub email_template_input
 {
-local ($file, $subject, $cc, $bcc, $mailbox, $owner, $reseller, $header,
+my ($file, $subject, $cc, $bcc, $mailbox, $owner, $reseller, $header,
        $filemode) = @_;
-local $rv;
+my $rv;
 $rv .= &ui_table_start($header, undef, 2);
 if ($filemode eq "none" || $filemode eq "default") {
 	# Show input for selecting if enabled
@@ -9797,7 +9797,7 @@ return $rv;
 #		       [filemode-config])
 sub parse_email_template
 {
-local ($file, $subject_config, $cc_config, $bcc_config,
+my ($file, $subject_config, $cc_config, $bcc_config,
        $mailbox_config, $owner_config, $reseller_config, $filemode_config) = @_;
 $in{'template'} =~ s/\r//g;
 &open_lock_tempfile(FILE, ">$file", 1) ||
@@ -9829,7 +9829,7 @@ $config{'last_check'} = time()+1;	# no need for check.cgi to be run
 # destination (like @) escaped
 sub escape_user
 {
-local $escuser = $_[0];
+my $escuser = $_[0];
 $escuser =~ s/\@/\\\@/g;
 return $escuser;
 }
@@ -9838,7 +9838,7 @@ return $escuser;
 # The reverse of escape_user
 sub unescape_user
 {
-local $escuser = $_[0];
+my $escuser = $_[0];
 $escuser =~ s/\\\@/\@/g;
 return $escuser;
 }
@@ -9896,7 +9896,7 @@ return $user;
 # Given a username like foo-bar.com, return foo@bar.com
 sub add_atsign
 {
-local ($rv) = @_;
+my ($rv) = @_;
 $rv =~ s/\-/\@/;
 return $rv;
 }
@@ -9911,7 +9911,7 @@ return "$_[0]->{'home'}/.qmail";
 sub get_dotqmail
 {
 $_[0] =~ /\.qmail(-(\S+))?$/;
-local $alias = { 'file' => $_[0],
+my $alias = { 'file' => $_[0],
 		 'name' => $2 };
 local $_;
 open(AFILE, "<".$_[0]) || return undef;
@@ -9931,7 +9931,7 @@ sub save_dotqmail
 {
 if (@{$_[0]->{'values'}}) {
 	&open_lock_tempfile(AFILE, ">$_[1]");
-	local $v;
+	my $v;
 	foreach $v (@{$_[0]->{'values'}}) {
 		if ($v eq "\\$_[2]" || $v eq "\\NEWUSER") {
 			# Delivery to this user means to his maildir
@@ -9957,7 +9957,7 @@ if (scalar(@list_templates_cache)) {
 	# Use cached copy
 	return @list_templates_cache;
 	}
-local @rv;
+my @rv;
 &ensure_template("domain-template");
 &ensure_template("subdomain-template");
 &ensure_template("user-template");
@@ -10246,11 +10246,11 @@ push(@rv, { 'id' => 1,
 	    'for_alias' => 0,
 	    'for_users' => !$config{'subtmpl_nousers'},
 	  } );
-local $f;
+my $f;
 opendir(DIR, $templates_dir);
 while(defined($f = readdir(DIR))) {
 	if ($f ne "." && $f ne "..") {
-		local %tmpl;
+		my %tmpl;
 		&read_file("$templates_dir/$f", \%tmpl);
 		$tmpl{'file'} = "$templates_dir/$f";
 		$tmpl{'mail'} =~ s/\t/\n/g;
@@ -10299,8 +10299,8 @@ return @list_templates_cache;
 # and alias target domains
 sub list_available_templates
 {
-local ($parentdom, $aliasdom) = @_;
-local @rv;
+my ($parentdom, $aliasdom) = @_;
+my @rv;
 foreach my $t (&list_templates()) {
 	next if ($t->{'deleted'});
 	next if (($parentdom && !$aliasdom) && !$t->{'for_sub'});
@@ -10318,8 +10318,8 @@ return @rv;
 # appropriate config options instead of the template file.
 sub save_template
 {
-local ($tmpl) = @_;
-local $save_config = 0;
+my ($tmpl) = @_;
+my $save_config = 0;
 if (!defined($tmpl->{'id'})) {
 	$tmpl->{'id'} = &domain_id();
 	}
@@ -10672,7 +10672,7 @@ else {
 	&make_dir($templates_dir, 0700);
 	&lock_file("$templates_dir/$tmpl->{'id'}");
 	&read_file("$templates_dir/$tmpl->{'id'}", \%ptmpl);
-	local %ptmpl;
+	my %ptmpl;
 	foreach my $p (@plugins) {
 		foreach my $k (keys %$tmpl) {
 			if ($k =~ /^\Q$p\E/) {
@@ -10697,13 +10697,13 @@ undef(@list_templates_cache);
 sub get_template
 {
 my ($tmplid) = @_;
-local @tmpls = &list_templates();
-local ($tmpl) = grep { $_->{'id'} == $tmplid } @tmpls;
+my @tmpls = &list_templates();
+my ($tmpl) = grep { $_->{'id'} == $tmplid } @tmpls;
 return undef if (!$tmpl);	# not found
 if (!$tmpl->{'default'}) {
-	local $def = $tmpls[0];
-	local $p;
-	local %done;
+	my $def = $tmpls[0];
+	my $p;
+	my %done;
 	foreach $p ("dns_spf", "dns_sub", "dns_master", "dns_mx", "dns_dmarc",
 		    "dns_cloud", "dns_slaves", "dns_prins", "dns_alias",
 		    "web_acme", "web_webmail", "web_admin", "web_http2",
@@ -10744,7 +10744,7 @@ if (!$tmpl->{'default'}) {
 		my $psel = $p eq "web_php" ? "web_php_suexec" :
 			   $p eq "mail" ? "mail_on" : $p;
 		if ($tmpl->{$psel} eq "") {
-			local $k;
+			my $k;
 			foreach $k (keys %$def) {
 				next if ($p eq "dns" &&
 					 $k =~ /^dns_(spf|cloud|slaves|prins|alias)/);
@@ -10787,9 +10787,9 @@ return $tmpl;
 # Otherwise, really delete it.
 sub delete_template
 {
-local %tmpl;
+my %tmpl;
 &lock_file("$templates_dir/$_[0]->{'id'}");
-local @users = &get_domain_by("template", $_[0]->{'id'});
+my @users = &get_domain_by("template", $_[0]->{'id'});
 if (@users) {
 	&read_file("$templates_dir/$_[0]->{'id'}", \%tmpl);
 	$tmpl{'deleted'} = 1;
@@ -10806,13 +10806,13 @@ else {
 # if there are none.
 sub list_template_scripts
 {
-local ($tmpl) = @_;
+my ($tmpl) = @_;
 return "none" if ($tmpl->{'noscripts'});
-local @rv;
+my @rv;
 opendir(DIR, $template_scripts_dir);
 foreach my $f (readdir(DIR)) {
 	if ($f =~ /^(\d+)_(\d+)$/ && $1 == $tmpl->{'id'}) {
-		local %script;
+		my %script;
 		&read_file("$template_scripts_dir/$f", \%script);
 		$script{'id'} = $2;
 		$script{'file'} = "$template_scripts_dir/$f";
@@ -10827,7 +10827,7 @@ return \@rv;
 # Updates the scripts for some template
 sub save_template_scripts
 {
-local ($tmpl, $scripts) = @_;
+my ($tmpl, $scripts) = @_;
 
 # Delete old scripts
 opendir(DIR, $template_scripts_dir);
@@ -10858,8 +10858,8 @@ else {
 # using this template, taking defaults into account
 sub get_template_scripts
 {
-local ($tmpl) = @_;
-local $scripts = &list_template_scripts($tmpl);
+my ($tmpl) = @_;
+my $scripts = &list_template_scripts($tmpl);
 if ($scripts eq "none") {
 	return ( );
 	}
@@ -10868,8 +10868,8 @@ elsif (@$scripts || $tmpl->{'default'}) {
 	}
 else {
 	# Fall back to default
-	local @tmpls = &list_templates();
-	local $def = $tmpls[0];
+	my @tmpls = &list_templates();
+	my $def = $tmpls[0];
 	return &get_template_scripts($def);
 	}
 }
@@ -10878,9 +10878,9 @@ else {
 # Returns the contents of some file
 sub cat_file
 {
-local ($file, $tabs) = @_;
-local $path = $file =~ /^\// ? $file : "$module_config_directory/$file";
-local $rv = &read_file_contents($path);
+my ($file, $tabs) = @_;
+my $path = $file =~ /^\// ? $file : "$module_config_directory/$file";
+my $rv = &read_file_contents($path);
 if ($tabs) {
 	$rv =~ s/\r//g;
 	$rv =~ s/\n/\t/g;
@@ -10892,11 +10892,11 @@ return $rv;
 # Writes to some file
 sub uncat_file
 {
-local ($file, $data, $tabs) = @_;
+my ($file, $data, $tabs) = @_;
 if ($tabs) {
 	$data =~ s/\t/\n/g;
 	}
-local $path = $file =~ /^\// ? $file : "$module_config_directory/$file";
+my $path = $file =~ /^\// ? $file : "$module_config_directory/$file";
 &open_lock_tempfile(FILE, ">$path");
 &print_tempfile(FILE, $data);
 &close_tempfile(FILE);
@@ -10906,8 +10906,8 @@ local $path = $file =~ /^\// ? $file : "$module_config_directory/$file";
 # Creates a temp file and writes some data to it
 sub uncat_transname
 {
-local ($data, $tabs) = @_;
-local $temp = &transname();
+my ($data, $tabs) = @_;
+my $temp = &transname();
 &uncat_file($temp, $data, $tabs);
 return $temp;
 }
@@ -10917,7 +10917,7 @@ return $temp;
 # otherwise return undef
 sub plugin_call
 {
-local ($mod, $func, @args) = @_;
+my ($mod, $func, @args) = @_;
 &load_plugin_libraries($mod);
 if (&plugin_defined($mod, $func)) {
 	if ($main::module_name ne "virtual_server") {
@@ -10939,7 +10939,7 @@ else {
 # Like plugin_call, but catches and prints errors
 sub try_plugin_call
 {
-local ($mod, $func, @args) = @_;
+my ($mod, $func, @args) = @_;
 local $main::error_must_die = 1;
 eval { &plugin_call($mod, $func, @args) };
 if ($@) {
@@ -10954,10 +10954,10 @@ return 1;
 # Returns 1 if some function is defined in a plugin
 sub plugin_defined
 {
-local ($mod, $func) = @_;
+my ($mod, $func) = @_;
 &load_plugin_libraries($mod);
 $mod =~ s/[^A-Za-z0-9]/_/g;
-local $func = "${mod}::$func";
+my $func = "${mod}::$func";
 return defined(&$func);
 }
 
@@ -10965,7 +10965,7 @@ return defined(&$func);
 # Returns 1 if any feature that uses a database is enabled (perhaps in a domain)
 sub database_feature
 {
-local ($d) = @_;
+my ($d) = @_;
 foreach my $f ('mysql', 'postgres') {
 	return 1 if ($config{$f} && (!$d || $d->{$f}));
 	}
@@ -10989,12 +10989,12 @@ return 0;
 #   	      2=only root can see
 sub list_custom_fields
 {
-local @rv;
+my @rv;
 local $_;
 open(FIELDS, "<".$custom_fields_file);
 while(<FIELDS>) {
 	s/\r|\n//g;
-	local @a = split(/:/, $_, 6);
+	my @a = split(/:/, $_, 6);
 	push(@rv, { 'name' => $a[0],
 		    'type' => $a[1],
 		    'opts' => $a[2],
@@ -11023,12 +11023,12 @@ foreach my $a (@{$_[0]}) {
 # Returns a list of structures containing custom link details
 sub list_custom_links
 {
-local @rv;
+my @rv;
 local $_;
 open(LINKS, "<".$custom_links_file);
 while(<LINKS>) {
 	s/\r|\n//g;
-	local @a = split(/\t/, $_);
+	my @a = split(/\t/, $_);
 	push(@rv, { 'desc' => $a[0],
 		    'url' => $a[1],
 		    'who' => { map { $_ => 1 } split(/:/, $a[2]) },
@@ -11063,11 +11063,11 @@ foreach my $a (@{$_[0]}) {
 # Returns a list of all custom link category hash refs
 sub list_custom_link_categories
 {
-local @rv;
+my @rv;
 open(LINKCATS, "<".$custom_link_categories_file);
 while(<LINKCATS>) {
 	s/\r|\n//g;
-	local @a = split(/\t/, $_);
+	my @a = split(/\t/, $_);
 	push(@rv, { 'id' => $a[0], 'desc' => $a[1] });
 	}
 close(LINKCATS);
@@ -11090,11 +11090,11 @@ foreach my $a (@{$_[0]}) {
 # for the current user type. Category names are also include.
 sub list_visible_custom_links
 {
-local ($d) = @_;
-local @rv;
-local $me = &master_admin() ? 'master' :
+my ($d) = @_;
+my @rv;
+my $me = &master_admin() ? 'master' :
 	    &reseller_admin() ? 'reseller' : 'domain';
-local %cats = map { $_->{'id'}, $_->{'desc'} } &list_custom_link_categories();
+my %cats = map { $_->{'id'}, $_->{'desc'} } &list_custom_link_categories();
 foreach my $l (&list_custom_links()) {
 	if (!$l->{'who'}->{$me}) {
 		# Not for you
@@ -11108,7 +11108,7 @@ foreach my $l (&list_custom_links()) {
 		# Not for this domain feature
 		next;
 		}
-	local $nl = {
+	my $nl = {
 		'desc' => &substitute_domain_template($l->{'desc'}, $d),
 		'url' => &substitute_domain_template($l->{'url'}, $d),
 		'open' => $l->{'open'},
@@ -11126,24 +11126,24 @@ return @rv;
 # Returns HTML for custom field inputs, for inclusion in a table
 sub show_custom_fields
 {
-local ($d, $tds) = @_;
-local $rv;
-local $col = 0;
+my ($d, $tds) = @_;
+my $rv;
+my $col = 0;
 foreach my $f (&list_custom_fields()) {
-	local ($desc, $tip) = split(/;/, $f->{'desc'}, 2);
+	my ($desc, $tip) = split(/;/, $f->{'desc'}, 2);
 	$desc = &html_escape($desc);
 	if ($tip) {
 		$desc = "<div title='".&quote_escape($tip)."'>$desc</div>";
 		}
 	if ($f->{'visible'} == 0 || &master_admin()) {
 		# Can edit
-		local $n = "field_".$f->{'name'};
-		local $v = $d ? $d->{"field_".$f->{'name'}} :
+		my $n = "field_".$f->{'name'};
+		my $v = $d ? $d->{"field_".$f->{'name'}} :
 			   $f->{'type'} == 7 ? 1 :
 			   $f->{'type'} == 11 ? 0 : undef;
-		local $fv;
+		my $fv;
 		if ($f->{'type'} == 0) {
-			local $sz = $f->{'opts'} || 30;
+			my $sz = $f->{'opts'} || 30;
 			$fv = &ui_textbox($n, $v, $sz);
 			}
 		elsif ($f->{'type'} == 1 || $f->{'type'} == 2) {
@@ -11161,17 +11161,17 @@ foreach my $f (&list_custom_fields()) {
 							  [ 0, $text{'no'} ] ]);
 			}
 		elsif ($f->{'type'} == 8) {
-			local $sz = $f->{'opts'} || 30;
+			my $sz = $f->{'opts'} || 30;
 			$fv = &ui_password($n, $v, $sz);
 			}
 		elsif ($f->{'type'} == 9) {
-			local @opts = &read_opts_file($f->{'opts'});
-			local ($found) = grep { $_->[0] eq $v } @opts;
+			my @opts = &read_opts_file($f->{'opts'});
+			my ($found) = grep { $_->[0] eq $v } @opts;
 			push(@opts, [ $v, $v ]) if (!$found && $v ne '');
 			$fv = &ui_select($n, $v, \@opts);
 			}
 		elsif ($f->{'type'} == 10) {
-			local ($w, $h) = split(/\s+/, $f->{'opts'});
+			my ($w, $h) = split(/\s+/, $f->{'opts'});
 			$h ||= 4;
 			$w ||= 30;
 			$v =~ s/\t/\n/g;
@@ -11181,7 +11181,7 @@ foreach my $f (&list_custom_fields()) {
 		}
 	elsif ($f->{'visible'} == 1 && $d) {
 		# Can only see
-		local $fv = $d->{"field_".$f->{'name'}};
+		my $fv = $d->{"field_".$f->{'name'}};
 		$rv .= &ui_table_row($desc, $fv, 1, $tds);
 		}
 	}
@@ -11192,11 +11192,11 @@ return $rv;
 # Updates a domain with custom fields
 sub parse_custom_fields
 {
-local %in = %{$_[1]};
+my %in = %{$_[1]};
 foreach my $f (&list_custom_fields()) {
 	next if ($f->{'visible'} != 0 && !&master_admin());
-	local $n = "field_".$f->{'name'};
-	local $rv;
+	my $n = "field_".$f->{'name'};
+	my $rv;
 	if ($f->{'type'} == 0 || $f->{'type'} == 5 ||
 	    $f->{'type'} == 6 || $f->{'type'} == 8) {
 		$rv = $in{$n};
@@ -11207,11 +11207,11 @@ foreach my $f (&list_custom_fields()) {
 		$rv =~ s/\n/\t/g;
 		}
 	elsif ($f->{'type'} == 1 || $f->{'type'} == 2) {
-		local @u = getpwnam($in{$n});
+		my @u = getpwnam($in{$n});
 		$rv = $f->{'type'} == 1 ? $in{$n} : $u[2];
 		}
 	elsif ($f->{'type'} == 3 || $f->{'type'} == 4) {
-		local @g = getgrnam($in{$n});
+		my @g = getgrnam($in{$n});
 		$rv = $f->{'type'} == 3 ? $in{$n} : $g[2];
 		}
 	elsif ($f->{'type'} == 7 || $f->{'type'} == 11) {
@@ -11227,10 +11227,10 @@ foreach my $f (&list_custom_fields()) {
 # read_opts_file(file)
 sub read_opts_file
 {
-local @rv;
-local $file = $_[0];
+my @rv;
+my $file = $_[0];
 if ($file !~ /^\//) {
-	local @uinfo = getpwnam($remote_user);
+	my @uinfo = getpwnam($remote_user);
 	if (@uinfo) {
 		$file = "$uinfo[7]/$file";
 		}
@@ -11264,7 +11264,7 @@ my ($d, $notmpl, $forweb) = @_;
 my $user = { 'unix' => 1 };
 if ($d && !$notmpl) {
 	# Initial aliases and quota come from template
-	local $tmpl = &get_template($d->{'template'});
+	my $tmpl = &get_template($d->{'template'});
 	if ($tmpl->{'user_aliases'} ne 'none') {
 		$user->{'to'} = [ map { &substitute_domain_template($_, $d) }
 				      split(/\t+/, $tmpl->{'user_aliases'}) ];
@@ -11282,7 +11282,7 @@ $user->{'shell'} = &default_available_shell('mailbox');
 
 # Merge in configurable initial user settings
 if ($d) {
-	local %init;
+	my %init;
 	&read_file("$initial_users_dir/$d->{'id'}", \%init);
 	foreach my $a ("email", "quota", "shell") {
 		$user->{$a} = $init{$a} if (defined($init{$a}) &&
@@ -11294,9 +11294,9 @@ if ($d) {
 			}
 		}
 	if (defined($init{'dbs'})) {
-		local ($db, @dbs);
+		my ($db, @dbs);
 		foreach $db (split(/\t+/, $init{'dbs'})) {
-			local ($type, $name) = split(/_/, $db, 2);
+			my ($type, $name) = split(/_/, $db, 2);
 			push(@dbs, { 'type' => $type,
 				     'name' => $name,
 				     'desc' => $text{'databases_'.$type} });
@@ -11307,7 +11307,7 @@ if ($d) {
 
 if ($forweb) {
 	# This is a website management user
-	local (undef, $ftp_shell, undef, $def_shell) =
+	my (undef, $ftp_shell, undef, $def_shell) =
 		&get_common_available_shells();
 	$user->{'webowner'} = 1;
 	$user->{'fixedhome'} = 0;
@@ -11326,9 +11326,9 @@ if ($forweb) {
 # For a unix user, apply default password expiry restrictions
 if ($gconfig{'os_type'} =~ /-linux$/) {
 	&require_useradmin();
-	local %uconfig = &foreign_config("useradmin");
+	my %uconfig = &foreign_config("useradmin");
 	if ($usermodule eq "ldap-useradmin") {
-		local %lconfig = &foreign_config($usermodule);
+		my %lconfig = &foreign_config($usermodule);
 		foreach my $k (keys %lconfig) {
 			if ($lconfig{$k} ne "") {
 				$uconfig{$k} = $lconfig{$k};
@@ -11347,12 +11347,12 @@ return $user;
 # Saves default settings for new users in a virtual server
 sub save_initial_user
 {
-local ($user, $dom) = @_;
+my ($user, $dom) = @_;
 if (!-d $initial_users_dir) {
 	mkdir($initial_users_dir, 0700);
 	}
 &lock_file("$initial_users_dir/$dom->{'id'}");
-local %init;
+my %init;
 foreach my $a ("email", "quota", "shell") {
 	$init{$a} = $user->{$a} if (defined($user->{$a}));
 	}
@@ -11374,13 +11374,13 @@ if (defined($user->{'dbs'})) {
 # Checks domain-owner subdomain and reseller subdomain limits.
 sub allowed_domain_name
 {
-local ($parent, $newdom) = @_;
+my ($parent, $newdom) = @_;
 
 # Check if forced to be under one of the domains he already owns
 if ($parent && $access{'forceunder'}) {
-	local $ok = 0;
+	my $ok = 0;
 	foreach my $pdom ($parent, &get_domain_by("parent", $parent->{'id'})) {
-		local $pd = $pdom->{'dom'};
+		my $pd = $pdom->{'dom'};
 		if ($newdom =~ /\.\Q$pd\E$/i) {
 			$ok = 1;
 			last;
@@ -11392,7 +11392,7 @@ if ($parent && $access{'forceunder'}) {
 # Check if under someone else's domain
 if ($parent && $access{'safeunder'}) {
 	foreach my $d (&list_domains()) {
-		local $od = $d->{'dom'};
+		my $od = $d->{'dom'};
 		if ($d->{'id'} ne $parent->{'id'} &&
 		    $d->{'parent'} ne $parent->{'id'} &&
 		    $newdom =~ /\.\Q$od\E$/i) {
@@ -11423,13 +11423,13 @@ return undef;
 # Returns a list of structures for databases in a domain
 sub domain_databases
 {
-local ($d, $types) = @_;
-local @dbs;
+my ($d, $types) = @_;
+my @dbs;
 if ($d->{'mysql'} && (!$types || &indexof("mysql", @$types) >= 0)) {
-	local %done;
-	local $mymod = &require_dom_mysql($d);
-	local $av = &foreign_available($mymod);
-	local $myhost = &get_database_host_mysql($d);
+	my %done;
+	my $mymod = &require_dom_mysql($d);
+	my $av = &foreign_available($mymod);
+	my $myhost = &get_database_host_mysql($d);
 	$myhost = undef if ($myhost eq 'localhost');
 	foreach my $db (split(/\s+/, $d->{'db_mysql'})) {
 		next if ($done{$db}++);
@@ -11443,11 +11443,11 @@ if ($d->{'mysql'} && (!$types || &indexof("mysql", @$types) >= 0)) {
 		}
 	}
 if ($d->{'postgres'} && (!$types || &indexof("postgres", @$types) >= 0)) {
-	local %done;
-	local $pgmod = &require_dom_postgres($d);
-	local $av = &foreign_available("postgresql");
+	my %done;
+	my $pgmod = &require_dom_postgres($d);
+	my $av = &foreign_available("postgresql");
 	&require_postgres();
-	local $pghost = &get_database_host_postgres($d);
+	my $pghost = &get_database_host_postgres($d);
 	$pghost = undef if ($pghost eq 'localhost');
 	foreach my $db (split(/\s+/, $d->{'db_postgres'})) {
 		next if ($done{$db}++);
@@ -11462,7 +11462,7 @@ if ($d->{'postgres'} && (!$types || &indexof("postgres", @$types) >= 0)) {
 	}
 
 # Only check plugins if some non-core DB types were requested
-local @nctypes = $types ? grep { $_ ne "mysql" && $_ ne "postgres" } @$types
+my @nctypes = $types ? grep { $_ ne "mysql" && $_ ne "postgres" } @$types
 			: ( );
 if (!$types || @nctypes) {
 	foreach my $f (&list_database_plugins()) {
@@ -11479,8 +11479,8 @@ return @dbs;
 # those relevant for some domain.
 sub all_databases
 {
-local ($d) = @_;
-local @rv;
+my ($d) = @_;
+my @rv;
 if ($config{'mysql'} && (!$d || $d->{'mysql'})) {
 	&require_mysql();
 	push(@rv, map { { 'name' => $_,
@@ -11519,17 +11519,17 @@ return ( $config{'mysql'} ? ("mysql") : ( ),
 # perhaps to change the 'db' field to the first actual database
 sub resync_all_databases
 {
-local ($d, $all) = @_;
+my ($d, $all) = @_;
 return if (!@$all);		# If no DBs were found on the system, do nothing
 				# to avoid mass dis-association
-local %all = map { ("$_->{'type'} $_->{'name'}", $_) } @$all;
-local $removed = 0;
+my %all = map { ("$_->{'type'} $_->{'name'}", $_) } @$all;
+my $removed = 0;
 &lock_domain($d);
 foreach my $k (keys %$d) {
 	if ($k =~ /^db_(\S+)$/) {
-		local $t = $1;
-		local @names = split(/\s+/, $d->{$k});
-		local @newnames = grep { $all{"$t $_"} } @names;
+		my $t = $1;
+		my @names = split(/\s+/, $d->{$k});
+		my @newnames = grep { $all{"$t $_"} } @names;
 		if (@names != @newnames) {
 			$d->{$k} = join(" ", @newnames);
 			$removed = 1;
@@ -11541,8 +11541,8 @@ if ($removed) {
 	}
 
 # Fix 'db' field if it is currently set to a missing DB
-local @domdbs = &domain_databases($d);
-local ($defdb) = grep { $_->{'name'} eq $d->{'db'} } @domdbs;
+my @domdbs = &domain_databases($d);
+my ($defdb) = grep { $_->{'name'} eq $d->{'db'} } @domdbs;
 if (!$defdb && @domdbs) {
 	$d->{'db'} = $domdbs[0]->{'name'};
 	&save_domain($d);
@@ -11555,11 +11555,11 @@ if (!$defdb && @domdbs) {
 # DB is on the same server, returns localhost
 sub get_database_host
 {
-local ($type, $d) = @_;
-local $rv;
+my ($type, $d) = @_;
+my $rv;
 if (&indexof($type, @features) >= 0) {
 	# Built-in DB
-	local $hfunc = "get_database_host_".$type;
+	my $hfunc = "get_database_host_".$type;
 	$rv = &$hfunc($d);
 	}
 elsif (&indexof($type, &list_database_plugins()) >= 0) {
@@ -11634,7 +11634,7 @@ if ($mode) {
 # passwords synced with the admin login
 sub get_password_synced_types
 {
-local ($d) = @_;
+my ($d) = @_;
 my @rv;
 foreach my $t (&all_database_types()) {
 	my $sfunc = $t."_password_synced";
@@ -11655,8 +11655,8 @@ return @rv;
 # total bytes and time of last log entry.
 sub count_ftp_bandwidth
 {
-local $max_ltime = $_[1];
-local $f;
+my $max_ltime = $_[1];
+my $f;
 foreach $f ($_[5] ? &all_log_files($_[0], $max_ltime) : ( $_[0] )) {
 	local $_;
 	if ($f =~ /\.gz$/i) {
@@ -11671,24 +11671,24 @@ foreach $f ($_[5] ? &all_log_files($_[0], $max_ltime) : ( $_[0] )) {
 	while(<LOG>) {
 		if (/^(\S+)\s+(\S+)\s+(\S+)\s+\[(\d+)\/(\S+)\/(\d+):(\d+):(\d+):(\d+)\s+(\S+)\]\s+"([^"]*)"\s+(\S+)\s+(\S+)/) {
 			# ProFTPD extended log format line
-			local $ltime = timelocal($9, $8, $7, $4, $apache_mmap{lc($5)}, $6);
+			my $ltime = timelocal($9, $8, $7, $4, $apache_mmap{lc($5)}, $6);
 			$max_ltime = $ltime if ($ltime > $max_ltime);
 			next if ($_[3] && &indexof($3, @{$_[3]}) < 0);	# user
 			next if (substr($11, 0, 4) ne "RETR" &&
 				 substr($11, 0, 4) ne "STOR");
 			if ($ltime > $_[1]) {
-				local $day = int($ltime / (24*60*60));
+				my $day = int($ltime / (24*60*60));
 				$_[2]->{$_[4]."_".$day} += $13;
 				}
 			}
 		elsif (/^\S+\s+(\S+)\s+(\d+)\s+(\d+):(\d+):(\d+)\s+(\d+)\s+\d+\s+\S+\s+(\d+)\s+\S+\s+\S+\s+\S+\s+(\S+)\s+\S+\s+(\S+)/) {
 			# xferlog format line
-			local $ltime = timelocal($5, $4, $3, $2, $apache_mmap{lc($1)}, $6);
+			my $ltime = timelocal($5, $4, $3, $2, $apache_mmap{lc($1)}, $6);
 			$max_ltime = $ltime if ($ltime > $max_ltime);
 			next if ($_[3] && &indexof($9, @{$_[3]}) < 0);	# user
 			next if ($8 ne "o" && $8 ne "i");
 			if ($ltime > $_[1]) {
-				local $day = int($ltime / (24*60*60));
+				my $day = int($ltime / (24*60*60));
 				$_[2]->{$_[4]."_".$day} += $7;
 				}
 			}
@@ -11760,10 +11760,10 @@ return 1;
 # Returns a crypt-format salt of the given length (default 2 chars)
 sub random_salt
 {
-local $len = $_[0] || 2;
+my $len = $_[0] || 2;
 &seed_random();
-local $rv;
-local @saltchars = ( 'a' .. 'z', 'A' .. 'Z', 0 .. 9, '.', '/' );
+my $rv;
+my @saltchars = ( 'a' .. 'z', 'A' .. 'Z', 0 .. 9, '.', '/' );
 for(my $i=0; $i<$len; $i++) {
 	$rv .= $saltchars[int(rand()*scalar(@saltchars))];
 	}
@@ -11776,9 +11776,9 @@ return $rv;
 # returns this flag plus the function's actual return value.
 sub try_function
 {
-local ($f, $func, @args) = @_;
+my ($f, $func, @args) = @_;
 local $main::error_must_die = 1;
-local $rv;
+my $rv;
 eval { $rv = &$func(@args) };
 if ($@) {
 	&$second_print(&text('setup_failure',
@@ -11793,11 +11793,11 @@ return wantarray ? ( 1, $rv ) : 1;
 # bandwidth period started
 sub bandwidth_period_start
 {
-local ($ago) = @_;
-local $now = time();
-local $day = int($now / (24*60*60));
-local @tm = localtime(time());
-local $rv;
+my ($ago) = @_;
+my $now = time();
+my $day = int($now / (24*60*60));
+my @tm = localtime(time());
+my $rv;
 if ($config{'bw_past'} eq 'week') {
 	# Start on last sunday
 	$rv = $day - $tm[6];
@@ -11831,13 +11831,13 @@ return $rv;
 # Returns the day number on which some bandwidth period ends (inclusive)
 sub bandwidth_period_end
 {
-local ($ago) = @_;
-local $now = time();
-local $day = int($now / (24*60*60));
+my ($ago) = @_;
+my $now = time();
+my $day = int($now / (24*60*60));
 if ($ago == 0) {
 	return $day;
 	}
-local $sday = &bandwidth_period_start($ago);
+my $sday = &bandwidth_period_start($ago);
 if ($config{'bw_past'} eq 'week') {
 	# 6 days after start
 	return $sday + 6;
@@ -11885,7 +11885,7 @@ else {
 # Returns HTML for a single-server selection field
 sub one_server_input
 {
-local ($name, $id, $doms, $dis) = @_;
+my ($name, $id, $doms, $dis) = @_;
 return &ui_select($name, $id,
 		  [ map { [ $_->{'id'}, &show_domain_name($_) ] }
 			sort { $a->{'dom'} cmp $b->{'dom'} } @$doms ],
@@ -11901,12 +11901,12 @@ if ($config{'bw_servers'} eq "") {
 	}
 elsif ($config{'bw_servers'} =~ /^\!(.*)$/) {
 	# List of servers not to check
-	local @ids = split(/\s+/, $1);
+	my @ids = split(/\s+/, $1);
 	return &indexof($_[0]->{'id'}, @ids) == -1;
 	}
 else {
 	# List of servers to check
-	local @ids = split(/\s+/, $config{'bw_servers'});
+	my @ids = split(/\s+/, $config{'bw_servers'});
 	return &indexof($_[0]->{'id'}, @ids) != -1;
 	}
 }
@@ -11996,7 +11996,7 @@ return &can_edit_templates() || $access{'createresellers'};
 # proxying to a single URL, 0 if neither.
 sub has_proxy_balancer
 {
-local ($d) = @_;
+my ($d) = @_;
 if ($config{'web'} && !$d->{'alias'}) {
 	# From Apache
 	&require_apache();
@@ -12010,7 +12010,7 @@ if ($config{'web'} && !$d->{'alias'}) {
 	}
 else {
 	# From plugin, maybe
-	local $p = &domain_has_website($d);
+	my $p = &domain_has_website($d);
 	return &plugin_defined($p, "feature_supports_web_balancers") ?
 		&plugin_call($p, "feature_supports_web_balancers", $d) : 0;
 	}
@@ -12020,8 +12020,8 @@ else {
 # Returns 1 if the system supports disabling proxying for some URL
 sub has_proxy_none
 {
-local ($d) = @_;
-local $p = &domain_has_website($d);
+my ($d) = @_;
+my $p = &domain_has_website($d);
 if ($p eq 'web') {
 	&require_apache();
 	return $apache::httpd_modules{'mod_proxy'} >= 2.0;
@@ -12036,8 +12036,8 @@ else {
 # to port 20000
 sub has_webmail_rewrite
 {
-local ($d) = @_;
-local $p = &domain_has_website($d);
+my ($d) = @_;
+my $p = &domain_has_website($d);
 if ($p eq 'web') {
 	# Check Apache modules
 	&require_apache();
@@ -12054,13 +12054,13 @@ else {
 # Returns 1 if the webserver supports SNI for SSL cert selection
 sub has_sni_support
 {
-local ($d) = @_;
-local $p = &domain_has_website($d);
+my ($d) = @_;
+my $p = &domain_has_website($d);
 if ($p eq 'web') {
 	# Check Apache modules
 	&require_apache();
-	local @dirs = &list_apache_directives();
-	local ($sni) = grep { lc($_->[0]) eq lc("SSLStrictSNIVHostCheck") }
+	my @dirs = &list_apache_directives();
+	my ($sni) = grep { lc($_->[0]) eq lc("SSLStrictSNIVHostCheck") }
 			    @dirs;
 	return 1 if ($sni);
 	if ($apache::httpd_modules{'mod_ssl'} >= 2.3 ||
@@ -12261,7 +12261,7 @@ if (&require_licence()) {
 	return if (time() - $licence{'last'} < 24*60*60); # checked recently, so no worries
 
 	# Hasn't been checked from cron for 3 days .. do it now
-	local $job = &find_cron_script($licence_cmd);
+	my $job = &find_cron_script($licence_cmd);
 	if (!$job) {
 		# Create
 		$job = { 'mins' => int(rand()*60),
@@ -12353,7 +12353,7 @@ if ($virtualmin_pro && -r $licence_status) {
 sub check_licence_expired
 {
 return 0 if (!&require_licence());
-local %licence;
+my %licence;
 &read_file_cached($licence_status, \%licence);
 if (time() - $licence{'last'} > 3*24*60*60) {
 	# Hasn't been checked from cron for 3 days .. do it now
@@ -12426,7 +12426,7 @@ my ($status, $expiry, $err, $doms, $max_servers, $servers, $autorenew,
 		$hostid, $serial{'SerialNumber'}, $serial{'LicenseKey'});
 if (defined($status) && $status == 0 && $doms) {
 	# A domains limit exists .. check if we have exceeded it
-	local @doms = grep { !$_->{'alias'} &&
+	my @doms = grep { !$_->{'alias'} &&
 			     !$_->{'defaultdomain'} } &list_domains();
 	if (@doms > $doms) {
 		$status = 1;
@@ -12469,7 +12469,7 @@ if (&has_command("hostid")) {
 	}
 if (!$id || $id =~ /^0+$/ || $id eq '7f0100') {
 	&foreign_require("net");
-	local ($iface) = grep { $_->{'fullname'} eq $config{'iface'} }
+	my ($iface) = grep { $_->{'fullname'} eq $config{'iface'} }
 			      &net::active_interfaces();
 	$id = $iface->{'ether'} if ($iface);
 	}
@@ -12500,9 +12500,9 @@ return () if (!&master_admin());
 my @rv;
 my $wp = &get_webprefix_safe();
 # Get licence expiry date
-local ($status, $expiry, $err, undef, undef, $autorenew, $state, $bind) =
+my ($status, $expiry, $err, undef, undef, $autorenew, $state, $bind) =
 	&check_licence_expired();
-local $expirytime;
+my $expirytime;
 if ($expiry =~ /^(\d+)\-(\d+)\-(\d+)$/) {
 	# Make Unix time
 	eval {
@@ -12553,8 +12553,8 @@ if ($status != 0 && !$state) {
 	}
 elsif ($expirytime && $expirytime - time() < 7*24*60*60 && !$autorenew) {
 	# One week to expiry .. tell the user
-	local $days = int(($expirytime - time()) / (24*60*60));
-	local $hours = int(($expirytime - time()) / (60*60));
+	my $days = int(($expirytime - time()) / (24*60*60));
+	my $hours = int(($expirytime - time()) / (60*60));
 	if ($days) {
 		$alert_text .= "<b>".&text('licence_soon', $days)."</b><br>\n";
 		}
@@ -12573,7 +12573,7 @@ elsif ($expirytime && $expirytime - time() < 7*24*60*60 && !$autorenew) {
 	}
 
 # Check if default IP has changed
-local $defip = &get_default_ip();
+my $defip = &get_default_ip();
 if ($config{'old_defip'} && $defip && $config{'old_defip'} ne $defip) {
 	my $alert_text;
 	$alert_text .= "<b>".&text('licence_ipchanged',
@@ -12590,13 +12590,13 @@ if ($config{'old_defip'} && $defip && $config{'old_defip'} ne $defip) {
 	}
 
 # Check if in SSL mode, and SSL cert is < 2048 bits
-local $small;
+my $small;
 if ($ENV{'HTTPS'} eq 'ON') {
-	local %miniserv;
+	my %miniserv;
 	&get_miniserv_config(\%miniserv);
-	local $certfile = $miniserv{'certfile'} || $miniserv{'keyfile'};
+	my $certfile = $miniserv{'certfile'} || $miniserv{'keyfile'};
 	if ($certfile) {
-		local $cert = &cert_file_info($certfile);
+		my $cert = &cert_file_info($certfile);
 		if ($cert->{'algo'} eq 'rsa' && $cert->{'size'} && $cert->{'size'} < 2048) {
 			# Too small!
 			$small = $cert;
@@ -12605,7 +12605,7 @@ if ($ENV{'HTTPS'} eq 'ON') {
 	}
 if ($small) {
 	my $alert_text;
-	local $msg = $small->{'issuer_c'} eq $small->{'c'} &&
+	my $msg = $small->{'issuer_c'} eq $small->{'c'} &&
 		     $small->{'issuer_o'} eq $small->{'o'} ?
 			'licence_smallself' : 'licence_smallcert';
 	$alert_text .= &text($msg,
@@ -12635,7 +12635,7 @@ if ($small) {
 if ($config{'allow_symlinks'} eq '') {
 	my $alert_text;
 	# Do any domains have unsafe settings?
-	local @fixdoms = &fix_symlink_security(undef, 1);
+	my @fixdoms = &fix_symlink_security(undef, 1);
 	if (@fixdoms) {
 		$alert_text .= "<b>".&text('licence_fixlinks', scalar(@fixdoms))."<p>".
 		             $text{'licence_fixlinks2'}."</b><p>\n";
@@ -12887,8 +12887,8 @@ return join(" ", map { &ui_link("@{[&get_webprefix_safe()]}/$module_name/cert_fo
 # Given a username, returns it's virtual server details
 sub get_user_domain
 {
-local @uinfo = getpwnam($_[0]);
-local @doms;
+my @uinfo = getpwnam($_[0]);
+my @doms;
 if (@uinfo) {
 	# Is a Unix user .. find the domains for his GID (which could include
 	# sub-servers), and then check the home for each
@@ -12901,10 +12901,10 @@ if (@uinfo) {
 	}
 
 # Need to check all domains :( This is unlikely to happen though
-local @doms = &list_domains();
+my @doms = &list_domains();
 foreach my $d (@doms) {
-	local @users = &list_domain_users($d, 0, 1, 1, 1);
-	local $u;
+	my @users = &list_domain_users($d, 0, 1, 1, 1);
+	my $u;
 	foreach $u (@users) {
 		if ($u->{'user'} eq $_[0] ||
 		    &replace_atsign($u->{'user'}) eq $_[0]) {
@@ -12962,7 +12962,7 @@ if (&has_group_quotas()) {
 	if ($dbtoo) {
 		$db = 0;
 		foreach my $sd ($d, &get_domain_by("parent", $d->{'id'})) {
-			local @dbu = &get_database_usage($sd);
+			my @dbu = &get_database_usage($sd);
 			$db += $dbu[0];
 			$dbq += $dbu[1];
 			}
@@ -13015,7 +13015,7 @@ return undef;
 # Given a domain name, returns the prefix for usernames
 sub compute_prefix
 {
-local ($name, $group, $parent, $creating) = @_;
+my ($name, $group, $parent, $creating) = @_;
 if ($config{'longname'} != 1) {
 	$name =~ s/^xn(-+)//;	# Strip IDN part
 	}
@@ -13039,8 +13039,8 @@ elsif ($group && !$parent && !$config{'longname'}) {
 else {
 	# Otherwise, prefix comes from first part of domain. If this clashes,
 	# use the second part too and so on
-	local @p = split(/\./, $name);
-	local $prefix;
+	my @p = split(/\./, $name);
+	my $prefix;
 	if ($creating) {
 		# Extract prefix based on the user pattern
 		if ($config{'longname'} && $config{'longname'} !~ /^[0-9]$/) {
@@ -13049,8 +13049,8 @@ else {
 		else {
 			# First try foo, then foo.com, then foo.com.au
 			for(my $i=0; $i<@p; $i++) {
-				local $testp = join("-", @p[0..$i]);
-				local $pclash = &get_domain_by("prefix", $testp);
+				my $testp = join("-", @p[0..$i]);
+				my $pclash = &get_domain_by("prefix", $testp);
 				if (!$pclash) {
 					$prefix = $testp;
 					last;
@@ -13060,8 +13060,8 @@ else {
 			if (!$prefix) {
 				my $i = 1;
 				while(1) {
-					local $testp = $p[0].$i;
-					local $pclash = &get_domain_by("prefix",$testp);
+					my $testp = $p[0].$i;
+					my $pclash = &get_domain_by("prefix",$testp);
 					if (!$pclash) {
 						$prefix = $testp;
 						last;
@@ -13080,19 +13080,19 @@ else {
 # details will be omitted if the skip flag is set.
 sub get_domain_owner
 {
-local ($d, $novirts, $noquotas, $nodbs) = @_;
+my ($d, $novirts, $noquotas, $nodbs) = @_;
 $noquotas = $novirts if (!defined($noquotas));
 $nodbs = $novirts if (!defined($nodbs));
 if ($d->{'parent'}) {
-	local $parent = &get_domain($d->{'parent'});
+	my $parent = &get_domain($d->{'parent'});
 	if ($parent) {
 		return &get_domain_owner($parent, $novirts, $noquotas, $nodbs);
 		}
 	return undef;
 	}
 else {
-	local @users = &list_domain_users($d, 0, $novirts, $noquotas, $nodbs);
-	local ($user) = grep { $_->{'user'} eq $_[0]->{'user'} } @users;
+	my @users = &list_domain_users($d, 0, $novirts, $noquotas, $nodbs);
+	my ($user) = grep { $_->{'user'} eq $_[0]->{'user'} } @users;
 	return $user;
 	}
 }
@@ -13140,7 +13140,7 @@ return $shell && $shell->{'id'} eq 'ssh';
 # Returns HTML for a password selection field
 sub new_password_input
 {
-local ($name) = @_;
+my ($name) = @_;
 if ($config{'passwd_mode'} == 1) {
 	# Random but editable password
 	return &vui_noauto_textbox($name, &random_password(), 21);
@@ -13163,7 +13163,7 @@ elsif ($config{'passwd_mode'} == 2) {
 # Returns the entered or randomly generated password
 sub parse_new_password
 {
-local ($name, $empty) = @_;
+my ($name, $empty) = @_;
 $empty || $in{$name} =~ /\S/ || &error($text{'setup_epass'});
 if (defined($in{$name."_again"}) && $in{$name} ne $in{$name."_again"}) {
 	&error($text{'setup_epassagain'});
@@ -13175,8 +13175,8 @@ return $in{$name};
 # Given a domain, returns a list of features that can be disabled for it
 sub get_disable_features
 {
-local ($d) = @_;
-local @disable;
+my ($d) = @_;
+my @disable;
 my %core = map { $_, 1 } @features;
 @disable = grep { $core{$_} && $d->{$_} && $config{$_} }
 	   split(/,/, $config{'disable'});
@@ -13192,10 +13192,10 @@ return &unique(@disable);
 # Given a domain, returns a list of features that should be enabled for it
 sub get_enable_features
 {
-local ($d) = @_;
-local @enable;
-local @disabled = split(/,/, $d->{'disabled'});
-local %disabled = map { $_, 1 } @disabled;
+my ($d) = @_;
+my @enable;
+my @disabled = split(/,/, $d->{'disabled'});
+my %disabled = map { $_, 1 } @disabled;
 my %core = map { $_, 1 } @features;
 @enable = grep { $core{$_} && $d->{$_} && ($config{$_} || $_ eq 'unix') } @disabled;
 push(@enable, "ssl") if (&indexof("web", @enable) >= 0 && $d->{'ssl'});
@@ -13324,11 +13324,11 @@ return 0;
 # is also returned.
 sub get_database_usage
 {
-local ($d) = @_;
-local $rv = 0;
-local $qrv = 0;
+my ($d) = @_;
+my $rv = 0;
+my $qrv = 0;
 foreach my $db (&domain_databases($d, [ 'mysql', 'postgres' ])) {
-	local ($size, undef, $qsize) = &get_one_database_usage($d, $db);
+	my ($size, undef, $qsize) = &get_one_database_usage($d, $db);
 	$rv += $size;
 	$qrv += $qsize;
 	}
@@ -13340,16 +13340,16 @@ return wantarray ? ($rv, $qrv) : $rv;
 # space that is already counted by the quota system, and the file count.
 sub get_one_database_usage
 {
-local ($d, $db) = @_;
+my ($d, $db) = @_;
 if ($db->{'type'} eq 'mysql' || $db->{'type'} eq 'postgres') {
 	# Get size from core database
-	local $szfunc = $db->{'type'}."_size";
-	local ($size, $tables, $qsize, $count) = &$szfunc($d, $db->{'name'}, 0);
+	my $szfunc = $db->{'type'}."_size";
+	my ($size, $tables, $qsize, $count) = &$szfunc($d, $db->{'name'}, 0);
 	return ($size, $tables, $qsize, $count);
 	}
 else {
 	# Get size from plugin
-	local ($size, $tables, $qsize, $count) = &plugin_call($db->{'type'},
+	my ($size, $tables, $qsize, $count) = &plugin_call($db->{'type'},
 		      "database_size", $d, $db->{'name'}, 0);
 	return ($size, $tables, $qsize, $count);
 	}
@@ -13360,10 +13360,10 @@ else {
 # needed due to any checked option changing.
 sub need_config_check
 {
-local @cst = stat($module_config_file);
+my @cst = stat($module_config_file);
 return 0 if ($cst[9] <= $config{'last_check'});
 return 1 if ($mail_system == 5 || $mail_system == 6);
-local %lastconfig;
+my %lastconfig;
 &read_file("$module_config_directory/last-config", \%lastconfig) || return 1;
 foreach my $f (@features) {
 	# A feature was enabled or disabled
@@ -13400,34 +13400,34 @@ return 0;
 # specified in it's template with the appropriate users.
 sub update_secondary_groups
 {
-local ($dom, $users) = @_;
-local $tmpl = &get_template($dom->{'template'});
+my ($dom, $users) = @_;
+my $tmpl = &get_template($dom->{'template'});
 
 # See if this feature is actually configured
 my $any = 0;
 foreach my $g ("mailgroup", "ftpgroup", "dbgroup") {
-	local $gn = $tmpl->{$g};
+	my $gn = $tmpl->{$g};
 	$any++ if ($gn && $gn ne "none");
 	}
 return 0 if (!$any);
 
 # Get the current user and group lists
 $users ||= [ &list_domain_users($dom) ];
-local %indom = map { $_->{'user'}, 1 } @$users;
+my %indom = map { $_->{'user'}, 1 } @$users;
 &require_useradmin();
-local @groups = &list_all_groups();
-local %gtaken;
+my @groups = &list_all_groups();
+my %gtaken;
 &build_group_taken(\%gtaken, undef, \@groups);
-local %taken;
+my %taken;
 &build_taken(undef, \%taken);
 
 # Find FTP-capable shells
-local %shellmap = map { $_->{'shell'}, $_->{'id'} } &list_available_shells();
+my %shellmap = map { $_->{'shell'}, $_->{'id'} } &list_available_shells();
 
 foreach my $g ("mailgroup", "ftpgroup", "dbgroup") {
-	local $gn = $tmpl->{$g};
+	my $gn = $tmpl->{$g};
 	next if (!$gn || $gn eq "none");
-	local @inusers;
+	my @inusers;
 
 	# Work out who is in the group
 	if ($g eq "mailgroup") {
@@ -13442,15 +13442,15 @@ foreach my $g ("mailgroup", "ftpgroup", "dbgroup") {
 		@inusers = grep { @{$_->{'dbs'}} > 0 ||
 			  $_->{'domainowner'} && $dom->{'mysql'} } @$users;
 		}
-	local @innames = map { $_->{'user'} } @inusers;
-	local %innames = map { $_, 1 } @innames;
+	my @innames = map { $_->{'user'} } @inusers;
+	my %innames = map { $_, 1 } @innames;
 
 	# Get the group
-	local ($group) = grep { $_->{'group'} eq $gn } @groups;
+	my ($group) = grep { $_->{'group'} eq $gn } @groups;
 	if ($group) {
 		# Update the secondary members, removing any users who don't
 		# exist or are in this domain but shouldn't be there.
-		local @mems = split(/,/, $group->{'members'});
+		my @mems = split(/,/, $group->{'members'});
 		@mems = grep { !($indom{$_} && !$innames{$_}) } @mems;
 		@mems = &unique(@mems, @innames);
 		@mems = grep { $taken{$_} } @mems;
@@ -13485,7 +13485,7 @@ return ( );
 # 4 for zip, 5 for tar, 6 for zstd
 sub compression_format
 {
-local ($file, $key) = @_;
+my ($file, $key) = @_;
 if ($key) {
 	open(BACKUP, &backup_decryption_command($key)." ".
 		     quotemeta($file)." 2>/dev/null |");
@@ -13493,10 +13493,10 @@ if ($key) {
 else {
 	open(BACKUP, "<".$file);
 	}
-local $two;
+my $two;
 read(BACKUP, $two, 2);
 close(BACKUP);
-local $rv = $two eq "\037\213" ? 1 :
+my $rv = $two eq "\037\213" ? 1 :
 	    $two eq "\037\235" ? 2 :
 	    $two eq chr(0x28).chr(0xB5) ? 6 :
 	    $two eq "P*" ? 6 :
@@ -13504,7 +13504,7 @@ local $rv = $two eq "\037\213" ? 1 :
 	    $two eq "BZ" ? 3 : 0;
 if (!$rv) {
 	# Fall back to 'file' command for tar
-	local $out = &backquote_command("file ".quotemeta($_[0]));
+	my $out = &backquote_command("file ".quotemeta($_[0]));
 	if ($out =~ /tar\s+archive/i) {
 		$rv = 5;
 		}
@@ -13589,7 +13589,7 @@ return $? ? &text('addstyle_ecmdfailed',
 # be determined
 sub get_compressed_file_size
 {
-local ($file, $key) = @_;
+my ($file, $key) = @_;
 return undef if ($key);	# Too expensive to decrypt and check
 my $fmt = &compression_format($file, $key);
 my @st = stat($file);
@@ -13720,16 +13720,16 @@ my @ordered_combined = (@ordered, @unordered);
 # as the DNS zone, apache config and so on. Includes plugins.
 sub feature_links
 {
-local ($d) = @_;
-local @rv;
+my ($d) = @_;
+my @rv;
 
 # Check cache for feature links
-local $v = [ 'time' => $d->{'lastsave'},
+my $v = [ 'time' => $d->{'lastsave'},
 	     'last_check' => $config{'last_check'},
 	     'plugins' => \@plugins,
 	     'features' => \@config_features ];
-local $ckey = $d->{'id'}."-links-".$base_remote_user;
-local $crv = &get_links_cache($ckey, $v);
+my $ckey = $d->{'id'}."-links-".$base_remote_user;
+my $crv = &get_links_cache($ckey, $v);
 my $modify_plugin_category = sub {
 	my ($l) = @_;
 	if ($l->{'mod'} =~ /virtualmin-(init|oracle|svn|git)/ ||
@@ -13801,7 +13801,7 @@ foreach my $f (@plugins) {
 
 # Links to other Webmin modules, for domain owners
 if (!&master_admin() && !&reseller_admin()) {
-	local @ot;
+	my @ot;
 	foreach my $k (keys %config) {
 		if ($k =~ /^avail_(\S+)$/ &&
 		    &indexof($1, @features) < 0 &&
@@ -13809,7 +13809,7 @@ if (!&master_admin() && !&reseller_admin()) {
 		    $1 !~ /(phpini|webminlog|filemin)/) {
 			my $mod = $1;
 			if (&foreign_available($mod)) {
-				local %minfo = &get_module_info($mod);
+				my %minfo = &get_module_info($mod);
 				next if ($minfo{'plugin_feature'});
 				push(@ot, { 'mod' => $mod,
 					    'page' => 'index.cgi',
@@ -13832,17 +13832,17 @@ return @rv;
 # Print all the buttons for actions that can be taken on a server
 sub show_domain_buttons
 {
-local ($d) = @_;
-local ($anyrow1, $anyrow2, $anyrow3);
+my ($d) = @_;
+my ($anyrow1, $anyrow2, $anyrow3);
 print &ui_buttons_start();
 
 # Get the actions and work out categories
-local @buts = &get_domain_actions($d);
-local @cats = &unique(map { $_->{'cat'} } @buts);
+my @buts = &get_domain_actions($d);
+my @cats = &unique(map { $_->{'cat'} } @buts);
 
 # Show by category
 foreach my $c (@cats) {
-	local @incat = grep { $_->{'cat'} eq $c } @buts;
+	my @incat = grep { $_->{'cat'} eq $c } @buts;
 	print &ui_buttons_hr($text{'cat_'.$c});
 	foreach my $b (@incat) {
 		print &ui_buttons_row($b->{'page'},
@@ -13860,16 +13860,16 @@ print &ui_buttons_end();
 # Returns a list of actions that can be taken for some virtual server
 sub get_domain_actions
 {
-local ($d) = @_;
-local @rv;
+my ($d) = @_;
+my @rv;
 
 # Check cache for domain actions
-local $v = [ 'time' => $d->{'lastsave'},
+my $v = [ 'time' => $d->{'lastsave'},
 	     'last_check' => $config{'last_check'},
 	     'plugins' => \@plugins,
 	     'features' => \@config_features ];
-local $ckey = $d->{'id'}."-actions-".$base_remote_user;
-local $crv = &get_links_cache($ckey, $v);
+my $ckey = $d->{'id'}."-actions-".$base_remote_user;
+my $crv = &get_links_cache($ckey, $v);
 if ($crv) {
 	return @$crv;
 	}
@@ -13986,12 +13986,12 @@ if (&can_change_ip($d) && !$d->{'alias'}) {
 		  });
 	}
 
-local $parentdom = $d->{'parent'} ? &get_domain($d->{'parent'}) : undef;
-local $unixer = $parentdom || $d;
+my $parentdom = $d->{'parent'} ? &get_domain($d->{'parent'}) : undef;
+my $unixer = $parentdom || $d;
 if (&can_create_sub_servers() && !$d->{'alias'} && $unixer->{'unix'}) {
 	# Domain alias and sub-domain buttons
-	local ($dleft, $dreason, $dmax) = &count_domains("realdoms");
-	local ($aleft, $areason, $amax) = &count_domains("aliasdoms");
+	my ($dleft, $dreason, $dmax) = &count_domains("realdoms");
+	my ($aleft, $areason, $amax) = &count_domains("aliasdoms");
 	if ($dleft != 0 && &can_create_sub_servers() &&
 	    !$d->{'parent'}) {
 		# Sub-server
@@ -14327,12 +14327,12 @@ return @rv;
 #  icon - Unique code for this link
 sub get_all_domain_links
 {
-local ($d) = @_;
-local @rv;
+my ($d) = @_;
+my @rv;
 
 # Always start with edit/view link
 my $canconfig = &can_config_domain($d);
-local $vm = "/$module_name";
+my $vm = "/$module_name";
 my $edit_title = $text{'edit_title'};
 my $view_title = $text{'view_title'};
 if ($d->{'parent'} && !$d->{'alias'}) {
@@ -14376,7 +14376,7 @@ my %catmap = map { $_->{'catname'}, $_->{'cat'} } @rv;
 
 # Add preview website link, proxied via Webmin
 if (&domain_has_website($d) && &can_use_preview()) {
-	local $pt = $d->{'web_port'} == 80 ? "" : ":$d->{'web_port'}";
+	my $pt = $d->{'web_port'} == 80 ? "" : ":$d->{'web_port'}";
 	push(@rv, { 'url' => "/$module_name/".
 		    	     "link.cgi/$d->{'ip'}/http://www.$d->{'dom'}$pt/",
 		    'title' => $text{'links_website'},
@@ -14421,7 +14421,7 @@ return @rv;
 # Returns a link and text suitable for the footer function
 sub domain_footer_link
 {
-local $base = "/".$module_name;
+my $base = "/".$module_name;
 return &can_config_domain($_[0]) ?
 	( "$base/edit_domain.cgi?dom=$_[0]->{'id'}", $text{'edit_return'} ) :
 	( "$base/view_domain.cgi?dom=$_[0]->{'id'}", $text{'view_return'} );
@@ -14431,7 +14431,7 @@ return &can_config_domain($_[0]) ?
 # Calls redirect to edit_domain.cgi or view_domain.cgi
 sub domain_redirect
 {
-local ($d, $refresh) = @_;
+my ($d, $refresh) = @_;
 &redirect("/$module_name/postsave.cgi?".
 	  "dom=$d->{'id'}&refresh=$refresh");
 }
@@ -14441,7 +14441,7 @@ local ($d, $refresh) = @_;
 # categories and codes
 sub get_template_pages
 {
-local @tmpls = ( 'features', 'tmpl', 'plan', 'bw',
+my @tmpls = ( 'features', 'tmpl', 'plan', 'bw',
    $virtualmin_pro ? ( 'fields', 'links', 'ips', 'sharedips', 'dynip', 'resels',
 		       'notify', 'scripts', )
 		   : ( 'fields', 'ips', 'sharedips', 'scripts', 'dynip' ),
@@ -14465,7 +14465,7 @@ local @tmpls = ( 'features', 'tmpl', 'plan', 'bw',
    $virtualmin_pro ? ( 'remotedns' ) : ( ),
    $virtualmin_pro ? ( 'acmes' ) : ( ),
    );
-local %tmplcat = (
+my %tmplcat = (
 	'features' => 'setting',
 	'notify' => 'email',
 	'sv' => 'email',
@@ -14501,7 +14501,7 @@ local %tmplcat = (
 	'remotedns' => 'ip',
 	'acmes' => 'ip',
 	);
-local %nonew = ( 'history', 1,
+my %nonew = ( 'history', 1,
 		 'postgrey', 1,
 		 'dkim', 1,
 		 'ratelimit', 1,
@@ -14510,18 +14510,18 @@ local %nonew = ( 'history', 1,
 		 'dnsclouds', 1,
 		 'remotedns', 1,
 	       );
-local %pro = ( 'resels', 1,
+my %pro = ( 'resels', 1,
 	       'reseller', 1,
 	       'smtpclouds', 1,
 	       'remotedns', 1,
 	       'acmes', 1 );
-local @tlinks = map { ($pro{$_} ? "pro/" : "").
+my @tlinks = map { ($pro{$_} ? "pro/" : "").
 		      ($nonew{$_} ? "${_}.cgi" : "edit_new${_}.cgi") } @tmpls;
-local @ttitles = map { $nonew{$_} ? $text{"${_}_title"}
+my @ttitles = map { $nonew{$_} ? $text{"${_}_title"}
 			          : $text{"new${_}_title"} } @tmpls;
-local @ticons = map { $nonew{$_} ? "images/${_}.gif"
+my @ticons = map { $nonew{$_} ? "images/${_}.gif"
 			         : "images/new${_}.gif" } @tmpls;
-local @tcats = map { $tmplcat{$_} } @tmpls;
+my @tcats = map { $tmplcat{$_} } @tmpls;
 
 # Get from plugins too
 foreach my $p (@plugins) {
@@ -14547,7 +14547,7 @@ sub get_all_global_links
 my @rv;
 my $vm = "/$module_name";
 
-local $v = [ 'plugins' => \@plugins,
+my $v = [ 'plugins' => \@plugins,
 	     'spam' => $config{'spam'},
 	     'virus' => $config{'virus'},
 	     'quotas' => &has_home_quotas(),
@@ -14556,7 +14556,7 @@ local $v = [ 'plugins' => \@plugins,
 
 # Add template pages
 if (&can_edit_templates()) {
-	local $crv = &get_links_cache("global", $v);
+	my $crv = &get_links_cache("global", $v);
 	if ($crv) {
 		# Use cache
 		@rv = @$crv;
@@ -14567,7 +14567,7 @@ if (&can_edit_templates()) {
 			&get_template_pages();
 		$tcats = [ map { "setting" } @$tlinks ] if (!$tcats);
 		for(my $i=0; $i<@$tlinks; $i++) {
-			local $url;
+			my $url;
 			if ($tcodes->[$i] eq 'upgrade' &&
 			    $config{'upgrade_link'}) {
 				# Special link for upgrading GPL to Pro
@@ -14737,10 +14737,10 @@ return @rv;
 # return undef.
 sub get_links_cache
 {
-local ($cachekey, $validator) = @_;
-local $cachedata = &read_file_contents("$links_cache_dir/$cachekey");
+my ($cachekey, $validator) = @_;
+my $cachedata = &read_file_contents("$links_cache_dir/$cachekey");
 return undef if (!$cachedata);
-local $cachestr = &unserialise_variable($cachedata);
+my $cachestr = &unserialise_variable($cachedata);
 return undef if (!$cachestr);
 return undef if (&serialise_variable($cachestr->{'validator'}) ne
 		 &serialise_variable($validator));
@@ -14752,7 +14752,7 @@ return $cachestr->{'data'};
 # be used to check suitability by get_links_cache.
 sub save_links_cache
 {
-local ($cachekey, $validator, $data) = @_;
+my ($cachekey, $validator, $data) = @_;
 if (!-d $links_cache_dir) {
 	&make_dir($links_cache_dir, 0700);
 	}
@@ -14795,12 +14795,12 @@ foreach my $d (@list) {
 # Returns a list of status objects for relevant features and plugins
 sub get_startstop_links
 {
-local ($live) = @_;
-local @rv;
-local %typestatus;
+my ($live) = @_;
+my @rv;
+my %typestatus;
 foreach my $f (@startstop_features) {
 	if ($config{$f}) {
-		local $sfunc = "startstop_".$f;
+		my $sfunc = "startstop_".$f;
 		if (defined(&$sfunc)) {
 			foreach my $status (&$sfunc(\%typestatus)) {
 				$status->{'feature'} ||= $f;
@@ -14810,7 +14810,7 @@ foreach my $f (@startstop_features) {
 		}
 	}
 foreach my $f (@startstop_always_features) {
-	local $sfunc = "startstop_".$f;
+	my $sfunc = "startstop_".$f;
 	if (defined(&$sfunc)) {
 		foreach my $status (&$sfunc()) {
 			$status->{'feature'} ||= $f;
@@ -14819,7 +14819,7 @@ foreach my $f (@startstop_always_features) {
 		}
 	}
 foreach my $f (&list_startstop_plugins()) {
-	local $status = &plugin_call($f, "feature_startstop");
+	my $status = &plugin_call($f, "feature_startstop");
 	$status->{'feature'} ||= $f;
 	$status->{'plugin'} = 1;
 	push(@rv, $status);
@@ -14831,7 +14831,7 @@ return @rv;
 # Returns 1 if the given domain can have mail/FTP/DB users
 sub can_domain_have_users
 {
-local ($d) = @_;
+my ($d) = @_;
 return 0 if ($d->{'alias'} && !$d->{'aliasmail'} ||
 	     $d->{'subdom'});		# never allowed for aliases
 if (!$d->{'dir'}) {
@@ -14844,7 +14844,7 @@ return 1;
 # Returns 1 if some domain can have scripts installed
 sub can_domain_have_scripts
 {
-local ($d) = @_;
+my ($d) = @_;
 return ($d->{'web'} && $config{'web'} ||
 	&domain_has_website($d)) && !$d->{'subdom'} && !$d->{'alias'};
 }
@@ -14880,22 +14880,22 @@ else {
 # Calls the appropriate function to enable or disable a feature for a domain
 sub call_feature_func
 {
-local ($f, $d, $oldd) = @_;
+my ($f, $d, $oldd) = @_;
 if (&indexof($f, @features) >= 0 && $config{$f}) {
 	# A core feature
-	local $sfunc = "setup_$f";
-	local $dfunc = "delete_$f";
-	local $mfunc = "modify_$f";
+	my $sfunc = "setup_$f";
+	my $dfunc = "delete_$f";
+	my $mfunc = "modify_$f";
 	if ($d->{$f} && !$oldd->{$f}) {
 		# Setup some feature
-		local ($ok, $fok) = &try_function($f, $sfunc, $d);
+		my ($ok, $fok) = &try_function($f, $sfunc, $d);
 		if (!$ok || !$fok) {
 			$d->{$f} = 0;
 			}
 		}
 	elsif (!$d->{$f} && $oldd->{$f}) {
 		# Delete some feature
-		local ($ok, $fok) = &try_function($f, $dfunc, $oldd);
+		my ($ok, $fok) = &try_function($f, $dfunc, $oldd);
 		if (!$ok || !$fok) {
 			$d->{$f} = 1;
 			}
@@ -14933,7 +14933,7 @@ return $text{'feature_'.$f} || &plugin_call($f, "feature_name") || $f;
 # Returns a list of possible core features for a domain
 sub domain_features
 {
-local ($d) = @_;
+my ($d) = @_;
 return $d->{'alias'} && $d->{'aliasmail'} ? @aliasmail_features :
        $d->{'alias'} ? @alias_features :
        $d->{'subdom'} ? @opt_subdom_features :
@@ -14947,11 +14947,11 @@ sub list_mx_servers
 {
 if (&foreign_check("servers") && $config{'mx_servers'}) {
 	&foreign_require("servers");
-	local %servers = map { $_->{'id'}, $_ } &servers::list_servers();
-	local @rv;
+	my %servers = map { $_->{'id'}, $_ } &servers::list_servers();
+	my @rv;
 	foreach my $idname (split(/\s+/, $config{'mx_servers'})) {
 		my ($id, $name) = split(/=/, $idname);
-		local $s = $servers{$id};
+		my $s = $servers{$id};
 		if ($s) {
 			$s->{'mxname'} = $name;
 			push(@rv, $s);
@@ -14966,7 +14966,7 @@ return ();
 # Update the list of servers to create secondary MXs on
 sub save_mx_servers
 {
-local ($servers) = @_;
+my ($servers) = @_;
 $config{'mx_servers'} =
     join(" ", map { $_->{'mxname'} ? $_->{'id'}."=".$_->{'mxname'}
 				   : $_->{'id'} } @$servers);
@@ -14979,8 +14979,8 @@ $config{'mx_servers'} =
 # Updates the home directory and anything that refers to it in a domain object
 sub change_home_directory
 {
-local ($d, $newhome) = @_;
-local $oldhome = $d->{'home'};
+my ($d, $newhome) = @_;
+my $oldhome = $d->{'home'};
 $d->{'home'} = $newhome;
 foreach my $k (keys %$d) {
 	if ($k ne "home") {
@@ -14993,15 +14993,15 @@ foreach my $k (keys %$d) {
 # Moves some virtual server so that it is now owned by the new parent domain
 sub move_virtual_server
 {
-local ($d, $parent) = @_;
-local $oldd = { %$d };
-local $oldparent;
+my ($d, $parent) = @_;
+my $oldd = { %$d };
+my $oldparent;
 if ($d->{'parent'}) {
 	$oldparent = &get_domain($d->{'parent'});
 	}
 
 # Update the domain object with new home directory and parent details
-local (@doms, @olddoms, @remove_feats);
+my (@doms, @olddoms, @remove_feats);
 &set_parent_attributes($d, $parent);
 &change_home_directory($d, &server_home_directory($d, $parent));
 if ($d->{'alias'}) {
@@ -15024,9 +15024,9 @@ if (!$oldd->{'parent'}) {
 	# re-parented too. This will also catch any aliases and sub-domains.
 	# These have to be moved BEFORE their old parent, so that move of the
 	# parent doesn't cause the home directory to disappear.
-	local @subs = &get_domain_by("parent", $d->{'id'});
+	my @subs = &get_domain_by("parent", $d->{'id'});
 	foreach my $sd (@subs) {
-		local $oldsd = { %$sd };
+		my $oldsd = { %$sd };
 		&set_parent_attributes($sd, $parent);
 		&change_home_directory($sd,
 				       &server_home_directory($sd, $parent));
@@ -15035,7 +15035,7 @@ if (!$oldd->{'parent'}) {
 		}
 
 	# The template may no longer be valid if it was for a top-level server
-	local $tmpl = &get_template($d->{'template'});
+	my $tmpl = &get_template($d->{'template'});
 	if (!$tmpl->{'for_sub'}) {
 		$d->{'template'} = &get_init_template(1);
 		}
@@ -15043,10 +15043,10 @@ if (!$oldd->{'parent'}) {
 else {
 	# Find any alias domains that also need to be re-parented. Also find
 	# any sub-domains
-	local @aliases = &get_domain_by("alias", $d->{'id'});
-	local @subdoms = &get_domain_by("subdoms", $d->{'id'});
+	my @aliases = &get_domain_by("alias", $d->{'id'});
+	my @subdoms = &get_domain_by("subdoms", $d->{'id'});
 	foreach my $ad (@aliases, @subdoms) {
-		local $oldad = { %$ad };
+		my $oldad = { %$ad };
 		&set_parent_attributes($ad, $parent);
 		&change_home_directory($ad,
 				       &server_home_directory($ad, $parent));
@@ -15057,7 +15057,7 @@ else {
 
 # Run the before command
 &set_domain_envs($oldd, "MODIFY_DOMAIN", $d);
-local $merr = &making_changes();
+my $merr = &making_changes();
 &reset_domain_envs($oldd);
 &error(&text('rename_emaking', "<tt>$merr</tt>")) if (defined($merr));
 &setup_for_subdomain($parent);
@@ -15089,9 +15089,9 @@ if (@doms > 1) {
 	}
 
 # Update all features in all domains
-local %vital = map { $_, 1 } @vital_features;
+my %vital = map { $_, 1 } @vital_features;
 foreach my $f (@features) {
-	local $mfunc = "modify_$f";
+	my $mfunc = "modify_$f";
 	for(my $i=0; $i<@doms; $i++) {
 		if (($doms[$i]->{$f} || ($f eq 'mail' && !$d->{'alias'})) &&
 		    ($config{$f} || $f eq "unix" || $f eq "mail")) {
@@ -15101,9 +15101,9 @@ foreach my $f (@features) {
 				if ($doms[$i]->{'alias'}) {
 					# Is an alias domain, so pass in old
 					# and new target domain objects
-					local $aliasdom = &get_domain(
+					my $aliasdom = &get_domain(
 						$doms[$i]->{'alias'});
-					local $idx = &indexof($aliasdom, @doms);
+					my $idx = &indexof($aliasdom, @doms);
 					if ($idx >= 0) {
 						&$mfunc(
 						   $doms[$i], $olddoms[$i],
@@ -15148,7 +15148,7 @@ foreach my $f (&list_feature_plugins(1)) {
 			eval { &plugin_call($f, "feature_modify",
 				     	    $doms[$i], $olddoms[$i]) };
 			if ($@) {
-				local $err = $@;
+				my $err = $@;
 				&$second_print(&text('setup_failure',
 					&plugin_call($f, "feature_name"),$err));
 				}
@@ -15164,7 +15164,7 @@ $first_print = $old_first_print if ($old_first_print);
 if (!$d->{'alias'}) {
 	&$first_print($text{'rename_scripts'});
 	for(my $i=0; $i<@doms; $i++) {
-		local ($olddir, $newdir) =
+		my ($olddir, $newdir) =
 		    ($olddoms[$i]->{'home'}, $doms[$i]->{'home'});
 		foreach $sinfo (&list_domain_scripts($doms[$i])) {
 			$changed = 0;
@@ -15212,7 +15212,7 @@ if ($oldparent) {
 
 # Re-apply the parent's resource limits, if any
 if (defined(&supports_resource_limits) && &supports_resource_limits()) {
-	local $rv = &get_domain_resource_limits($parent);
+	my $rv = &get_domain_resource_limits($parent);
 	&save_domain_resource_limits($parent, $rv);
 	}
 
@@ -15225,7 +15225,7 @@ if ($d->{'alias'} && $d->{'mail'} && $parent->{'mail'}) {
 
 # Run the after command
 &set_domain_envs($d, "MODIFY_DOMAIN", undef, $oldd);
-local $merr = &made_changes();
+my $merr = &made_changes();
 &$second_print(&text('setup_emade', "<tt>$merr</tt>")) if (defined($merr));
 &reset_domain_envs($d);
 
@@ -15236,19 +15236,19 @@ return 1;
 # Converts an existing sub-server into a new parent server
 sub reparent_virtual_server
 {
-local ($d, $newuser, $newpass) = @_;
-local $oldd = { %$d };
-local $oldparent = &get_domain($d->{'parent'});
+my ($d, $newuser, $newpass) = @_;
+my $oldd = { %$d };
+my $oldparent = &get_domain($d->{'parent'});
 
 # Run the before command
 &set_domain_envs($oldd, "MODIFY_DOMAIN");
-local $merr = &making_changes();
+my $merr = &making_changes();
 &reset_domain_envs($oldd);
 &error(&text('rename_emaking', "<tt>$merr</tt>")) if (defined($merr));
 
 # Update the domain object with a new top-level home directory and it's
 # own user and group
-local (@doms, @olddoms);
+my (@doms, @olddoms);
 $d->{'parent'} = undef;
 $d->{'user'} = $newuser;
 $d->{'group'} = $newuser;
@@ -15261,7 +15261,7 @@ if (!$d->{'mysql'}) {
 if (!$d->{'postgres'}) {
 	delete($d->{'postgres_user'});
 	}
-local (%gtaken, %taken);
+my (%gtaken, %taken);
 &build_group_taken(\%gtaken);
 &build_taken(\%taken);
 $d->{'uid'} = &allocate_uid(\%taken);
@@ -15272,13 +15272,13 @@ push(@doms, $d);
 push(@olddoms, $oldd);
 
 # The template may no longer be valid if it was for a sub-server
-local $tmpl = &get_template($d->{'template'});
-local $skelchanged;
+my $tmpl = &get_template($d->{'template'});
+my $skelchanged;
 if (!$tmpl->{'for_parent'}) {
-	local $deftmpl = &get_init_template(0);
+	my $deftmpl = &get_init_template(0);
 	if ($d->{'template'} ne $deftmpl) {
 		$d->{'template'} = $deftmpl;
-		local $newtmpl = &get_template($d->{'template'});
+		my $newtmpl = &get_template($d->{'template'});
 		if ($newtmpl->{'skel'} ne $tmpl->{'skel'}) {
 			$skelchanged = $newtmpl->{'skel'};
 			}
@@ -15307,10 +15307,10 @@ $d->{'plan'} = $oldparent->{'plan'};
 
 # Find any alias domains that also need to be re-parented. Also find
 # any sub-domains
-local @aliases = &get_domain_by("alias", $d->{'id'});
-local @subdoms = &get_domain_by("subdom", $d->{'id'});
+my @aliases = &get_domain_by("alias", $d->{'id'});
+my @subdoms = &get_domain_by("subdom", $d->{'id'});
 foreach my $ad (@aliases, @subdoms) {
-	local $oldad = { %$ad };
+	my $oldad = { %$ad };
 	&set_parent_attributes($ad, $d);
 	&change_home_directory($ad,
 			       &server_home_directory($ad, $d));
@@ -15332,9 +15332,9 @@ if (@doms > 1) {
 
 # Update all features in all domains
 my $f;
-local %vital = map { $_, 1 } @vital_features;
+my %vital = map { $_, 1 } @vital_features;
 foreach $f (@features) {
-	local $mfunc = "modify_$f";
+	my $mfunc = "modify_$f";
 	for(my $i=0; $i<@doms; $i++) {
 		$doing_dom = $doms[$i];
 		if ($doms[$i]->{$f} && ($config{$f} || $f eq "unix")) {
@@ -15343,9 +15343,9 @@ foreach $f (@features) {
 				if ($doms[$i]->{'alias'}) {
 					# Is an alias domain, so pass in old
 					# and new target domain objects
-					local $aliasdom = &get_domain(
+					my $aliasdom = &get_domain(
 						$doms[$i]->{'alias'});
-					local $idx = &indexof($aliasdom, @doms);
+					my $idx = &indexof($aliasdom, @doms);
 					if ($idx >= 0) {
 						&$mfunc(
 						   $doms[$i], $olddoms[$i],
@@ -15380,7 +15380,7 @@ foreach $f (@features) {
 		# Turn on the Unix and Webmin features
 		if ($doms[$i] eq $d && ($f eq "unix" || $f eq "webmin")) {
 			$doms[$i]->{$f} = 1;
-			local $sfunc = "setup_$f";
+			my $sfunc = "setup_$f";
 			&try_function($f, $sfunc, $doms[$i]);
 			}
 		}
@@ -15393,7 +15393,7 @@ foreach $f (&list_feature_plugins(1)) {
 			eval { &plugin_call($f, "feature_modify",
 					    $doms[$i], $olddoms[$i]) };
 			if ($@) {
-				local $err = $@;
+				my $err = $@;
 				&$second_print(&text('setup_failure',
 					&plugin_call($f, "feature_name"),$err));
 				}
@@ -15408,7 +15408,7 @@ $first_print = $old_first_print if ($old_first_print);
 # Fix script installer paths in all domains
 &$first_print($text{'rename_scripts'});
 for(my $i=0; $i<@doms; $i++) {
-	local ($olddir, $newdir) =
+	my ($olddir, $newdir) =
 	    ($olddoms[$i]->{'home'}, $doms[$i]->{'home'});
 	foreach $sinfo (&list_domain_scripts($doms[$i])) {
 		$changed = 0;
@@ -15444,13 +15444,13 @@ if ($d->{'webmin'}) {
 
 # Re-apply resource limits, to update Apache and PHP configs
 if (defined(&supports_resource_limits) && &supports_resource_limits()) {
-	local $rv = &get_domain_resource_limits($d);
+	my $rv = &get_domain_resource_limits($d);
 	&save_domain_resource_limits($d, $rv);
 	}
 
 # Copy skeleton files for top-level server
 if ($skelchanged && $skelchanged ne 'none') {
-	local $uinfo = &get_domain_owner($d, 1);
+	my $uinfo = &get_domain_owner($d, 1);
 	&copy_skel_files(&substitute_domain_template($skelchanged, $d),
 			 $uinfo, $d->{'home'},
 			 $d->{'group'} || $d->{'ugroup'}, $d);
@@ -15460,7 +15460,7 @@ if ($skelchanged && $skelchanged ne 'none') {
 
 # Run the after command
 &set_domain_envs($d, "MODIFY_DOMAIN", undef, $oldd);
-local $merr = &made_changes();
+my $merr = &made_changes();
 &$second_print(&text('setup_emade', "<tt>$merr</tt>")) if (defined($merr));
 &reset_domain_envs($d);
 
@@ -15471,13 +15471,13 @@ return 1;
 # Convert a virtual server from a sub-domain to a sub-server
 sub unsub_virtual_server
 {
-local ($d) = @_;
-local $oldd = { %$d };
-local $parent = &get_domain($d->{'parent'});
+my ($d) = @_;
+my $oldd = { %$d };
+my $parent = &get_domain($d->{'parent'});
 
 # Run the before command
 &set_domain_envs($oldd, "MODIFY_DOMAIN");
-local $merr = &making_changes();
+my $merr = &making_changes();
 &reset_domain_envs($oldd);
 &error(&text('rename_emaking', "<tt>$merr</tt>")) if (defined($merr));
 
@@ -15494,9 +15494,9 @@ $d->{'cgi_bin_path'} = &cgi_bin_dir($d, 0);
 &change_home_directory($d, &server_home_directory($d, $parent));
 
 # Update all features in the domain
-local %vital = map { $_, 1 } @vital_features;
+my %vital = map { $_, 1 } @vital_features;
 foreach my $f (@features) {
-	local $mfunc = "modify_$f";
+	my $mfunc = "modify_$f";
 	if ($d->{$f} && $config{$f}) {
 		local $main::error_must_die = 1;
 		eval { &$mfunc($d, $oldd); };
@@ -15514,7 +15514,7 @@ foreach my $f (&list_feature_plugins(1)) {
 	if ($d->{$f}) {
 		eval { &plugin_call($f, "feature_modify", $d, $oldd) };
 		if ($@) {
-			local $err = $@;
+			my $err = $@;
 			&$second_print(&text('setup_failure',
 				&plugin_call($f, "feature_name"), $err));
 			}
@@ -15536,7 +15536,7 @@ foreach my $f (&list_feature_plugins(1)) {
 
 # Run the after command
 &set_domain_envs($d, "MODIFY_DOMAIN", undef, $oldd);
-local $merr = &made_changes();
+my $merr = &made_changes();
 &$second_print(&text('setup_emade', "<tt>$merr</tt>")) if (defined($merr));
 &reset_domain_envs($d);
 
@@ -15547,13 +15547,13 @@ return 1;
 # Convert a virtual server from an alias to a sub-server
 sub unalias_virtual_server
 {
-local ($d) = @_;
-local $oldd = { %$d };
-local $parent = &get_domain($d->{'parent'});
+my ($d) = @_;
+my $oldd = { %$d };
+my $parent = &get_domain($d->{'parent'});
 
 # Run the before command
 &set_domain_envs($oldd, "MODIFY_DOMAIN");
-local $merr = &making_changes();
+my $merr = &making_changes();
 &reset_domain_envs($oldd);
 &error(&text('rename_emaking', "<tt>$merr</tt>")) if (defined($merr));
 
@@ -15583,9 +15583,9 @@ if (!$d->{'dir'}) {
 	}
 
 # Update all features in the domain
-local %vital = map { $_, 1 } @vital_features;
+my %vital = map { $_, 1 } @vital_features;
 foreach my $f (@features) {
-	local $mfunc = "modify_$f";
+	my $mfunc = "modify_$f";
 	if ($d->{$f} && $config{$f}) {
 		local $main::error_must_die = 1;
 		eval { &$mfunc($d, $oldd); };
@@ -15603,7 +15603,7 @@ foreach my $f (&list_feature_plugins(1)) {
 	if ($d->{$f}) {
 		eval { &plugin_call($f, "feature_modify", $d, $oldd) };
 		if ($@) {
-			local $err = $@;
+			my $err = $@;
 			&$second_print(&text('setup_failure',
 				&plugin_call($f, "feature_name"), $err));
 			}
@@ -15631,7 +15631,7 @@ delete($d->{'aliascopy'});
 
 # Run the after command
 &set_domain_envs($d, "MODIFY_DOMAIN", undef, $oldd);
-local $merr = &made_changes();
+my $merr = &made_changes();
 &$second_print(&text('setup_emade', "<tt>$merr</tt>")) if (defined($merr));
 &reset_domain_envs($d);
 
@@ -15642,7 +15642,7 @@ return 1;
 # Update a domain object with attributes inherited from the parent
 sub set_parent_attributes
 {
-local ($d, $parent) = @_;
+my ($d, $parent) = @_;
 $d->{'parent'} = $parent->{'id'};
 $d->{'user'} = $parent->{'user'};
 $d->{'group'} = $parent->{'group'};
@@ -15889,9 +15889,9 @@ foreach my $f (&unique(@features, 'mail')) {
 				if ($doms[$i]->{'alias'}) {
 					# Is an alias domain, so pass in old
 					# and new target domain objects
-					local $aliasdom = &get_domain(
+					my $aliasdom = &get_domain(
 						$doms[$i]->{'alias'});
-					local $idx = &indexof($aliasdom, @doms);
+					my $idx = &indexof($aliasdom, @doms);
 					if ($idx >= 0) {
 						&try_function($f, $mfunc,
 						   $doms[$i], $olddoms[$i],
@@ -16003,9 +16003,9 @@ return undef;
 # Returns undef on success, or an error message on failure.
 sub check_virtual_server_config
 {
-local ($lastconfig, $skip_dns_network) = @_;
-local $clink = "edit_newfeatures.cgi";
-local $mclink = "../config.cgi?$module_name";
+my ($lastconfig, $skip_dns_network) = @_;
+my $clink = "edit_newfeatures.cgi";
+my $mclink = "../config.cgi?$module_name";
 
 # Check for disabled features that were just turned off
 if ($lastconfig) {
@@ -16054,13 +16054,13 @@ if (!&foreign_check("net")) {
 # Check for sensible memory limits
 if (&foreign_check("proc")) {
 	&foreign_require("proc");
-	local $arch = &backquote_command("uname -m");
-	local $defmem = 1024;
+	my $arch = &backquote_command("uname -m");
+	my $defmem = 1024;
 	$defmem += 512 if ($config{'virus'});	# ClamAV eats RAM
-	local $rmem = ($config{'mem_low'} || $defmem)*1024*1024;
+	my $rmem = ($config{'mem_low'} || $defmem)*1024*1024;
 	if (defined(&proc::get_memory_info)) {
-		local @mem = &proc::get_memory_info();
-		local $beans = &get_beancounters();
+		my @mem = &proc::get_memory_info();
+		my $beans = &get_beancounters();
 		if ($mem[0]*1024 < $rmem) {
 			# Memory is less than 512 MB (768 on 64-bit)
 			&$second_print(&ui_text_color(&text('check_lowmemory',
@@ -16122,12 +16122,12 @@ if ($config{'dns'} && !$skip_dns_network) {
 
 		# Check that primary NS hostname is reasonable
 		&require_bind();
-		local $tmpl = &get_template(0);
-		local $master = $tmpl->{'dns_master'} eq 'none' ? undef :
+		my $tmpl = &get_template(0);
+		my $master = $tmpl->{'dns_master'} eq 'none' ? undef :
 						$tmpl->{'dns_master'};
 		$master ||= $bind8::config{'default_prins'} ||
 			    &get_system_hostname();
-		local $mastermsg;
+		my $mastermsg;
 		if ($master !~ /\./) {
 			$mastermsg = &text('check_dnsmaster',
 					   "<tt>$master</tt>");
@@ -16180,7 +16180,7 @@ if ($config{'mail'}) {
 		&save_module_config();
 		&unlock_file($module_config_file);
 		}
-	local $expected_mailboxes;
+	my $expected_mailboxes;
 	if ($mail_system == 1) {
 		# Make sure sendmail is installed
 		if (!&sendmail_installed()) {
@@ -16203,15 +16203,15 @@ if ($config{'mail'}) {
 			}
 
 		# Check for external interface
-		local @addrs;
-		local $conf = &sendmail::get_sendmailcf();
+		my @addrs;
+		my $conf = &sendmail::get_sendmailcf();
 		foreach my $dpo (&sendmail::find_options("DaemonPortOptions",
 							 $conf)) {
-			local $addr = "*";
+			my $addr = "*";
 			if ($dpo->[1] =~ /(Addr|Address|A)=([^ ,]+)/i) {
 				$addr = $2;
 				}
-			local $port = 25;
+			my $port = 25;
 			if ($dpo->[1] =~ /(Port|P)=([^ ,]+)/i) {
 				$port = $2;
 				}
@@ -16219,7 +16219,7 @@ if ($config{'mail'}) {
 			}
 		if (@addrs) {
 			# Need at least one non-localhost port 25
-			local @adescs;
+			my @adescs;
 			foreach my $a (@addrs) {
 				if ($a->[0] eq '*') {
 					push(@adescs, "port $a->[1]");
@@ -16270,14 +16270,14 @@ if ($config{'mail'}) {
 
 		# Make sure virtual_alias_domains is not set, as it overrides
 		# virtual_alias_maps
-		local $vad = &postfix::get_real_value("virtual_alias_domains");
-		local $vam = &postfix::get_real_value($virtual_type);
+		my $vad = &postfix::get_real_value("virtual_alias_domains");
+		my $vam = &postfix::get_real_value($virtual_type);
 		if ($vad && $vad ne $vam) {
 			return &text('check_evad', $vad);
 			}
 
 		# Make sure mydestination contains hostname or origin
-		local $myhost = &postfix::get_real_value("myorigin") ||
+		my $myhost = &postfix::get_real_value("myorigin") ||
 			        &postfix::get_real_value("myhostname") ||
 				&get_system_hostname(0, 1);
 		if ($myhost =~ /^\//) {
@@ -16286,7 +16286,7 @@ if ($config{'mail'}) {
 			}
 		$myhost =~ s/^\s+//;
 		$myhost =~ s/\s+$//;
-		local @mydest = split(/[, ]+/,
+		my @mydest = split(/[, ]+/,
 				   &postfix::get_real_value("mydestination"));
 		if ($myhost &&
 		    &indexoflc($myhost, @mydest) < 0 &&
@@ -16313,7 +16313,7 @@ if ($config{'mail'}) {
 			&$second_print($text{'check_dependentever'});
 			}
 		else {
-			local $l = '../postfix/dependent.cgi';
+			my $l = '../postfix/dependent.cgi';
 			&$second_print(&text('check_dependentesupport', $l));
 			}
 		}
@@ -16329,7 +16329,7 @@ if ($config{'mail'}) {
 		if ($config{'bccs'}) {
 			return &text('check_eqmailbccs', $mclink);
 			}
-		local $tmpl = &get_template(0);
+		my $tmpl = &get_template(0);
 		if ($tmpl->{'append_style'} == 6) {
 			&$second_print($text{'check_qmailmode6'});
 			}
@@ -16340,7 +16340,7 @@ if ($config{'mail'}) {
 		}
 	# Check that Read User Mail module agrees
 	if (&foreign_check("mailboxes") && defined($expected_mailboxes)) {
-		local %mconfig = &foreign_config("mailboxes");
+		my %mconfig = &foreign_config("mailboxes");
 		$mconfig{'mail_system'} == 3 ||
 		    $mconfig{'mail_system'} == $expected_mailboxes ||
 			return &text('index_emailboxessystem',
@@ -16384,9 +16384,9 @@ if ($config{'web'}) {
 		}
 
 	# Run Apache config check
-	local $err = &apache::test_config();
+	my $err = &apache::test_config();
 	if ($err) {
-		local @elines = split(/\r?\n/, $err);
+		my @elines = split(/\r?\n/, $err);
 		@elines = grep { !/\[warn\]/ } @elines;
 		$err = join("\n", @elines) if (@elines);
 		return &text('check_ewebconfig',
@@ -16415,8 +16415,8 @@ if ($config{'web'}) {
 		}
 
 	# Check for breaking SetHandler lines
-	local $conf = &apache::get_config();
-	local $fixed = &recursive_fix_sethandler($conf, $conf);
+	my $conf = &apache::get_config();
+	my $fixed = &recursive_fix_sethandler($conf, $conf);
 	if ($fixed) {
 		&flush_file_lines();
 		}
@@ -16454,13 +16454,13 @@ if (&domain_has_website()) {
 		}
 
 	# Report on PHP versions (unless it's just FPM, which we cover later)
-	local @vers = &list_available_php_versions();
+	my @vers = &list_available_php_versions();
 	my @othersupp = grep { !/fpm|none/ } @supp;
 	if (@othersupp) {
-		local @msg;
+		my @msg;
 		foreach my $v (@vers) {
 			if ($v->[1]) {
-				local $realv = &get_php_version($v->[0]);
+				my $realv = &get_php_version($v->[0]);
 				push(@msg, ($realv ||$v->[0])." (".$v->[1].")");
 				}
 			else {
@@ -16638,8 +16638,8 @@ if (&domain_has_website()) {
 
 	# Check if any new PHP versions have shown up, and re-generate their
 	# cgi and fcgid wrappers and INI files
-	local @newvernums = sort { $a <=> $b } map { $_->[0] } &unique(@vers);
-	local @oldvernums = sort { $a <=> $b } split(/\s+/, $config{'last_check_php_vers'});
+	my @newvernums = sort { $a <=> $b } map { $_->[0] } &unique(@vers);
+	my @oldvernums = sort { $a <=> $b } split(/\s+/, $config{'last_check_php_vers'});
 	if (join(" ", @newvernums) ne join(" ", @oldvernums)) {
 		my $indented_print;
 		foreach my $d (grep { &domain_has_website($_) &&
@@ -16647,7 +16647,7 @@ if (&domain_has_website()) {
 				    &list_domains()) {
 			eval {
 				local $main::error_must_die = 1;
-				local $mode = $d->{'php_mode'} ||
+				my $mode = $d->{'php_mode'} ||
 					      &get_domain_php_mode($d);
 				if ($mode && $mode ne "mod_php" &&
 				    $mode ne "fpm" && $mode ne "none") {
@@ -16686,24 +16686,24 @@ if ($config{'ssl'}) {
 	    return &text('index_eopenssl', "<tt>openssl</tt>", $clink);
 
 	&require_apache();
-	local $conf = &apache::get_config();
-	local @loads = &apache::find_directive_struct("LoadModule", $conf);
-	local ($l, $hasmod);
+	my $conf = &apache::get_config();
+	my @loads = &apache::find_directive_struct("LoadModule", $conf);
+	my ($l, $hasmod);
 	foreach $l (@loads) {
 		$hasmod++ if ($l->{'words'}->[1] =~ /mod_ssl/);
 		}
-	local ($aver, $amods) = &apache::httpd_info(&apache::find_httpd());
+	my ($aver, $amods) = &apache::httpd_info(&apache::find_httpd());
 	$hasmod++ if (&indexof("mod_ssl", @$amods) >= 0);
 	$hasmod++ if ($apache::httpd_modules{'mod_ssl'});
 	$hasmod ||
 	    return &text('index_emodssl', "<tt>mod_ssl</tt>", $clink);
 
-	local @listens = &apache::find_directive_struct("Listen", $conf);
-	local $haslisten;
+	my @listens = &apache::find_directive_struct("Listen", $conf);
+	my $haslisten;
 	foreach $l (@listens) {
 		$haslisten++ if ($l->{'words'}->[0] =~ /^(\S+:)?$default_web_sslport$/);
 		}
-	local @ports = &apache::find_directive_struct("Port", $conf);
+	my @ports = &apache::find_directive_struct("Port", $conf);
 	foreach $l (@ports) {
 		$haslisten++ if ($l->{'words'}->[0] == $default_web_sslport);
 		}
@@ -16797,13 +16797,13 @@ if ($config{'logrotate'}) {
 	&foreign_installed("logrotate", 1) == 2 ||
 		return &text('index_elogrotate', "/logrotate/", $clink);
 	&foreign_require("logrotate");
-	local $ver = &logrotate::get_logrotate_version();
+	my $ver = &logrotate::get_logrotate_version();
 	&compare_versions($ver, 3.6) >= 0 ||
 		return &text('index_elogrotatever', "/logrotate/",
 				   $clink, $ver, 3.6);
 
 	# Make sure the current config is OK
-	local $out = &backquote_with_timeout(
+	my $out = &backquote_with_timeout(
 		"$logrotate::config{'logrotate'} -d -f ".
 		&quote_path($logrotate::config{'logrotate_conf'})." 2>&1",
 		60, 1, 1000);
@@ -16822,17 +16822,17 @@ if ($config{'spam'}) {
 		return &text('index_espam', "/spam/", $clink);
 	&foreign_installed("procmail", 1) == 2 ||
 		return &text('index_eprocmail', "/procmail/", $clink);
-	local $spamclient = &get_global_spam_client();
+	my $spamclient = &get_global_spam_client();
 	if ($spamclient =~ /^spamassassin/) {
 		# Make sure it supports --siteconfigpath
-		local $out = &backquote_command("$spamclient -h 2>&1 </dev/null");
+		my $out = &backquote_command("$spamclient -h 2>&1 </dev/null");
 		if ($out !~ /\-\-siteconfigpath/) {
 			&require_spam();
-			local $ver = &spam::get_spamassassin_version();
+			my $ver = &spam::get_spamassassin_version();
 			return &text('check_espamsiteconfig', $ver);
 			}
 		}
-	local $hasprocmail = &mail_system_has_procmail();
+	my $hasprocmail = &mail_system_has_procmail();
 	if ($hasprocmail) {
 		&$second_print($text{'check_spamok'});
 		}
@@ -16842,7 +16842,7 @@ if ($config{'spam'}) {
 
 	# Check for spamassassin call in /etc/procmailrc
 	&require_spam();
-	local @recipes = &procmail::get_procmailrc();
+	my @recipes = &procmail::get_procmailrc();
 	foreach my $r (@recipes) {
 		if ($r->{'action'} =~ /spamassassin|spamc/) {
 			return &text('check_spamglobal',
@@ -16852,7 +16852,7 @@ if ($config{'spam'}) {
 
 	# Check for spam_white conflict with spamc
 	if ($config{'spam_white'}) {
-		local ($client, $host, $size) = &get_global_spam_client();
+		my ($client, $host, $size) = &get_global_spam_client();
 		if ($client eq "spamc") {
 			return &text('check_spamwhite', $mclink,
 				     "edit_newsv.cgi");
@@ -16862,10 +16862,10 @@ if ($config{'spam'}) {
 	# If using Postfix, procmail-wrapper must be used and setuid root
 	if ($hasprocmail && $mail_system == 0) {
 		&require_mail();
-		local $mbc = &postfix::get_real_value("mailbox_command");
-		local @mbc = &split_quoted_string($mbc);
+		my $mbc = &postfix::get_real_value("mailbox_command");
+		my @mbc = &split_quoted_string($mbc);
 		$mbc[0] = &has_command($mbc[0]);
-		local @st = stat($mbc[0]);
+		my @st = stat($mbc[0]);
 		if (!&has_command($mbc[0])) {
 			# Procmail does not exist
 			return &text('check_spamwrappercmd', $mbc[0]);
@@ -16876,13 +16876,13 @@ if ($config{'spam'}) {
 			}
 		if ($st[4] != 0) {
 			# User is not root
-			local $user = getpwuid($st[4]);
+			my $user = getpwuid($st[4]);
 			return &text('check_spamwrapperuser', $mbc[0],
 				     $user || "UID $st[4]");
 			}
 		if ($st[5] != 0) {
 			# Group is not root
-			local $group = getgrgid($st[5]);
+			my $group = getgrgid($st[5]);
 			return &text('check_spamwrappergroup', $mbc[0],
 				     $group || "GID $st[5]");
 			}
@@ -16917,7 +16917,7 @@ if ($config{'virus'}) {
 		# Need clamd to be running
 		&find_byname("clamd") || return $text{'check_eclamd'};
 		}
-	local $err;
+	my $err;
 	if ($config{'clamscan_cmd_tested'} ne $config{'clamscan_cmd'}) {
 		$err = &test_virus_scanner($config{'clamscan_cmd'},
 					   $config{'clamscan_host'});
@@ -16925,13 +16925,13 @@ if ($config{'virus'}) {
 	if ($err) {
 		# Failed .. but this can often be due to the ClamAV database
 		# being out of date.
-		local $freshclam = &has_command("freshclam");
+		my $freshclam = &has_command("freshclam");
 		if (!$freshclam &&
 		    $config{'clamscan_cmd'} =~ /^(\/.*\/)[^\/]+$/) {
 			$freshclam = $1."freshclam";
 			}
 		if (-x $freshclam) {
-			local $cout = &backquote_with_timeout($freshclam, 180);
+			my $cout = &backquote_with_timeout($freshclam, 180);
 			$err = &test_virus_scanner($config{'clamscan_cmd'},
 						   $config{'clamscan_host'});
 			}
@@ -16954,7 +16954,7 @@ if ($config{'status'}) {
 	# Make sure scheduled status monitoring is enabled
 	&foreign_check("status") ||
 		return &text('index_estatus', "/status/", $clink);
-	local %sconfig = &foreign_config("status");
+	my %sconfig = &foreign_config("status");
 	if ($sconfig{'sched_mode'}) {
 		&$second_print($text{'check_statusok'});
 		}
@@ -16969,7 +16969,7 @@ foreach $p (@plugins) {
 	if ($p eq "virtualmin-mysqluser") {
 		return &text('check_emysqlplugin');
 		}
-	local $err = &plugin_call($p, "feature_check");
+	my $err = &plugin_call($p, "feature_check");
 	if ($err) {
 		return &text('check_eplugin', "<tt>$p</tt>", $err);
 		}
@@ -17145,12 +17145,12 @@ $config{'group_quotas'} = '';
 if ($config{'quotas'} && $config{'quota_commands'}) {
 	# External commands are being used for quotas - make sure they exist!
 	foreach my $c ("set_user", "set_group", "list_users", "list_groups") {
-		local ($cmd) = &split_quoted_string(
+		my ($cmd) = &split_quoted_string(
 			$config{"quota_".$c."_command"});
 		$cmd && &has_command($cmd) || return $text{'check_e'.$c};
 		}
 	foreach my $c ("get_user", "get_group") {
-		local ($cmd) = &split_quoted_string(
+		my ($cmd) = &split_quoted_string(
 			$config{"quota_".$c."_command"});
 		!$cmd || &has_command($cmd) || return $text{'check_e'.$c};
 		}
@@ -17158,7 +17158,7 @@ if ($config{'quotas'} && $config{'quota_commands'}) {
 	}
 elsif ($config{'quotas'}) {
 	# Make sure quotas are enabled, and work out where they are needed
-	local $qerr;
+	my $qerr;
 	&require_useradmin();
 	if (!$home_base) {
 		$qerr = &text('index_ehomebase');
@@ -17238,7 +17238,7 @@ while(<SHELLS>) {
 	$shells{$_}++;
 	}
 close(SHELLS);
-local ($nologin_shell, $ftp_shell) = &get_common_available_shells();
+my ($nologin_shell, $ftp_shell) = &get_common_available_shells();
 if ($nologin_shell && $shells{$nologin_shell->{'shell'}}) {
 	&$second_print(&text('check_eshell',
 		"<tt>$nologin_shell->{'shell'}</tt>", "<tt>/etc/shells</tt>"));
@@ -17251,7 +17251,7 @@ if ($ftp_shell && !$shells{$ftp_shell->{'shell'}}) {
 # Make sure LDAP module is set up, if selected
 if ($config{'ldap'}) {
 	&require_useradmin();
-	local $ldap = &ldap_useradmin::ldap_connect(1);
+	my $ldap = &ldap_useradmin::ldap_connect(1);
 	if (!ref($ldap)) {
 		return &text('check_eldap', $ldap, $clink,
 				   "../ldap-useradmin/");
@@ -17270,22 +17270,22 @@ if ($config{'ldap'}) {
 # Check for conflicting other-modules calls
 if ($config{'unix'} && $config{'other_users'}) {
 	# MySQL user creation
-	local %mconfig = &foreign_config('mysql');
+	my %mconfig = &foreign_config('mysql');
 	if ($mconfig{'sync_create'} || $mconfig{'sync_modify'} ||
 	    $mconfig{'sync_delete'}) {
 		return &text('check_emysqlsync', '../mysql/list_users.cgi');
 		}
 	# User and group default quotas
 	if ($config{'home_quotas'}) {
-		local %qconfig = &foreign_config('quota');
-		local @syncs = map { /^sync_(\S+)/; $1 }
+		my %qconfig = &foreign_config('quota');
+		my @syncs = map { /^sync_(\S+)/; $1 }
 				   grep { /^sync_/ } (keys %qconfig);
 		if (@syncs) {
 			return &text('check_equotasync',
 				     join(' , ', map { "<tt>$_</tt>" } @syncs),
 				     '../quota/');
 			}
-		local @gsyncs = map { /^gsync_(\S+)/; $1 }
+		my @gsyncs = map { /^gsync_(\S+)/; $1 }
 				   grep { /^gsync_/ } (keys %qconfig);
 		if (@gsyncs) {
 			return &text('check_egquotasync',
@@ -17299,7 +17299,7 @@ if ($config{'unix'} && $config{'other_users'}) {
 if (!&has_command("tar")) {
 	return &text('check_ebcmd', "<tt>tar</tt>");
 	}
-local @bcmds = $config{'compression'} == 0 ? ( "gzip", "gunzip" ) :
+my @bcmds = $config{'compression'} == 0 ? ( "gzip", "gunzip" ) :
 	       $config{'compression'} == 3 ? ( "zip", "unzip" ) :
 	       $config{'compression'} == 4 ? ( "zstd", "unzstd" ) :
 	       $config{'compression'} == 1 && $config{'pbzip2'} ? ( "pbzip2" ) :
@@ -17314,12 +17314,12 @@ foreach my $bcmd (@bcmds) {
 # If pbzip2 is being used, make sure it is a version that supports
 # compressing to stdout
 if ($config{'compression'} == 1 && $config{'pbzip2'}) {
-	local $out = &backquote_command("pbzip2 -V 2>&1");
+	my $out = &backquote_command("pbzip2 -V 2>&1");
 	if ($out !~ /Parallel\s+BZIP2\s+v([0-9\.]+)/i) {
 		return &text('check_epbzip2out',
 			     "<tt>".&html_escape($out)."</tt>");
 		}
-	local $ver = $1;
+	my $ver = $1;
 	if (&compare_versions($ver, "1.0.4") < 0) {
 		return &text('check_epbzip2ver', "1.0.4", $ver);
 		}
@@ -17329,7 +17329,7 @@ if ($config{'compression'} == 1 && $config{'pbzip2'}) {
 
 # Check if resource limits are supported
 if (defined(&supports_resource_limits)) {
-	local ($rok, $rmsg) = &supports_resource_limits(1);
+	my ($rok, $rmsg) = &supports_resource_limits(1);
 	&$second_print(!$rok ? &text('check_reserr', $rmsg) :
 		       $rmsg ? &text('check_reswarn', $rmsg) :
 			       $text{'check_resok'});
@@ -17339,8 +17339,8 @@ if (defined(&supports_resource_limits)) {
 if (&foreign_check("software")) {
 	&foreign_require("software");
 	if (defined(&software::check_package_system)) {
-		local $err = &software::check_package_system();
-		local $uerr = &software::check_update_system();
+		my $err = &software::check_package_system();
+		my $uerr = &software::check_update_system();
 		if ($err) {
 			&$second_print(&text('check_packageerr', $err));
 			}
@@ -17573,8 +17573,8 @@ return $rv;
 # Check if we need to Webmin users following a config re-check
 sub need_update_webmin_users_post_config
 {
-local ($lastconfig) = @_;
-local $webminchanged = 0;
+my ($lastconfig) = @_;
+my $webminchanged = 0;
 foreach my $k (keys %config) {
 	if ($k eq 'leave_acl' || $k eq 'webmin_modules' ||
 	    $k eq 'last_check_php_vers' ||
@@ -17589,8 +17589,8 @@ return $webminchanged;
 # Returns the contents of /proc/user_beancounters for this VM
 sub get_beancounters
 {
-local %beans;
-local $inctx = 0;
+my %beans;
+my $inctx = 0;
 open(BEANS, "</proc/user_beancounters") || return undef;
 while(<BEANS>) {
 	if (/^\s*(\d+):/) {
@@ -17614,7 +17614,7 @@ return \%beans;
 # May print stuff.
 sub run_post_config_actions
 {
-local %lastconfig = %{$_[0]};
+my %lastconfig = %{$_[0]};
 
 # Update the domain owner's group
 &update_domain_owners_group();
@@ -17666,7 +17666,7 @@ if ($config{'default_procmail'} != $lastconfig{'default_procmail'}) {
 if ($config{'api_helper'} ne $lastconfig{'api_helper'} ||
 	!&has_command(&get_api_helper_command())) {
 	&$first_print($text{'check_apicmd'});
-	local ($ok, $path) = &create_virtualmin_api_helper_command();
+	my ($ok, $path) = &create_virtualmin_api_helper_command();
 	&$second_print(&text($ok ? 'check_apicmdok' : 'check_apicmderr',
 			     $path));
 	}
@@ -17712,7 +17712,7 @@ if (defined(&setup_scriptlatest_job) && $config{'scriptlatest_enabled'}) {
 &setup_spamclear_cron_job();
 
 # Re-setup the validation cron job based on the saved config
-local ($oldjob, $job);
+my ($oldjob, $job);
 $oldjob = $job = &find_cron_script($validate_cron_cmd);
 $job ||= { 'user' => 'root',
 	   'active' => 1,
@@ -17753,16 +17753,16 @@ if ($config{'mail_autoconfig'} ne '') {
 # Returns both the mtab and fstab details for the parent mount for a directory
 sub mount_point
 {
-local $dir = &resolve_links($_[0]);
+my $dir = &resolve_links($_[0]);
 if ($mount_point_cache{$dir}) {
 	# Already found, so no need to re-lookup
 	return @{$mount_point_cache{$dir}};
 	}
 &foreign_require("mount");
-local @mounts = &mount::list_mounts();
-local @mounted = &mount::list_mounted();
+my @mounts = &mount::list_mounts();
+my @mounted = &mount::list_mounted();
 # Exclude swap mounts
-local @realmounts = grep { $_->[0] ne 'none' &&
+my @realmounts = grep { $_->[0] ne 'none' &&
 			   $_->[0] ne 'proc' &&
 			   $_->[0] ne '/proc' &&
 			   $_->[0] !~ /^swap/ &&
@@ -17776,7 +17776,7 @@ foreach my $m (sort { length($b->[0]) <=> length($a->[0]) } @mounted) {
 	if ($dir eq $m->[0] || $m->[0] eq "/" ||
 	    substr($dir, 0, length($m->[0])+1) eq "$m->[0]/") {
 		# Found currently mounted parent directory
-		local ($m2) = grep { $_->[0] eq $m->[0] } @mounts;
+		my ($m2) = grep { $_->[0] eq $m->[0] } @mounts;
 		if ($m2) {
 			if ($m2->[2] eq "bind" && $m2->[0] eq $m2->[1]) {
 				# Skip loopback mount onto same directory,
@@ -17817,10 +17817,10 @@ return $mount;
 # Returns the mtab entries for mounts at or under some directory
 sub sub_mount_points
 {
-local $dir = &resolve_links($_[0]);
+my $dir = &resolve_links($_[0]);
 &foreign_require("mount");
-local @mounted = &mount::list_mounted();
-local @rv;
+my @mounted = &mount::list_mounted();
+my @rv;
 foreach my $m (@mounted) {
 	if ($dir eq $m->[0] || &is_under_directory($dir, $m->[0])) {
 		push(@rv, $m);
@@ -17833,7 +17833,7 @@ return @rv;
 # Outputs HTML for editing basic template options (like the name)
 sub show_template_basic
 {
-local ($tmpl) = @_;
+my ($tmpl) = @_;
 
 # Name of this template - only editable for custom templates
 print &ui_table_row(&hlink($text{'tmpl_name'}, "template_name"),
@@ -17841,7 +17841,7 @@ print &ui_table_row(&hlink($text{'tmpl_name'}, "template_name"),
 			&ui_textbox("name", $tmpl->{'name'}, 40));
 
 # Who this template is suitable for
-local @fors = ( );
+my @fors = ( );
 foreach my $f ("parent", "sub", "alias", "users") {
 	if ($tmpl->{'standard'} && $f ne "users") {
 		if ($tmpl->{"for_".$f}) {
@@ -17858,7 +17858,7 @@ print &ui_table_row(&hlink($text{'tmpl_for'}, "template_for"),
 		    join("&nbsp;&nbsp;&nbsp;", @fors));
 
 # Which resellers can use this template?
-local @resels = $virtualmin_pro ? &list_resellers() : ( );
+my @resels = $virtualmin_pro ? &list_resellers() : ( );
 if (@resels) {
 	print &ui_table_row(
 		&hlink($text{'tmpl_resellers'}, "template_resellers"),
@@ -17876,7 +17876,7 @@ if (@resels) {
 	}
 
 # Which system owners can use this template
-local @owners = &unique(map { $_->{'user'} } &list_domains());
+my @owners = &unique(map { $_->{'user'} } &list_domains());
 print &ui_table_row(
 	&hlink($text{'tmpl_owners'}, "template_owners"),
 	&ui_radio("owners_def", $tmpl->{'owners'} eq "*" ? 1 :
@@ -17891,7 +17891,7 @@ print &ui_table_row(
 # parse_template_basic(&tmpl)
 sub parse_template_basic
 {
-local ($tmpl) = @_;
+my ($tmpl) = @_;
 
 if (!$tmpl->{'standard'}) {
 	$in{'name'} || &error($text{'tmpl_ename'});
@@ -17907,7 +17907,7 @@ foreach my $f ($tmpl->{'standard'} ? ( "users" )
 	$tmpl->{"for_".$f} = $in{"for_".$f};
 	}
 
-local @resels = $virtualmin_pro ? &list_resellers() : ( );
+my @resels = $virtualmin_pro ? &list_resellers() : ( );
 if (@resels) {
 	# Save list of allowed resellers
 	if ($in{'resellers_def'} == 1) {
@@ -17966,7 +17966,7 @@ foreach my $f (@plugins) {
 # Parse plugin options
 sub parse_template_plugins
 {
-local ($tmpl) = @_;
+my ($tmpl) = @_;
 foreach my $f (@plugins) {
         if (&plugin_defined($f, "template_parse") &&
 	    !&plugin_defined($f, "template_section")) {
@@ -17982,7 +17982,7 @@ sub list_domain_owner_modules
 {
 &require_mysql();
 my $mytype = $mysql::mysql_version =~ /mariadb/i ? "MariaDB" : "MySQL";
-local @rv = (
+my @rv = (
         [ 'dns', 'BIND DNS Server (for DNS domain)' ],
         [ 'mail', 'Virtual Email (for mailboxes and aliases)' ],
         [ 'web', 'Apache Webserver (for virtual host)' ],
@@ -18032,12 +18032,12 @@ return @rv;
 # Output HTML for selecting modules available to domain owners
 sub show_template_avail
 {
-local ($tmpl) = @_;
-local $field;
+my ($tmpl) = @_;
+my $field;
 if (!$tmpl->{'default'}) {
-	local @inames = map { "avail_".$_->[0] } &list_domain_owner_modules();
-	local $dis1 = &js_disable_inputs(\@inames, [ ], 'onClick');
-	local $dis2 = &js_disable_inputs([ ], \@inames, 'onClick');
+	my @inames = map { "avail_".$_->[0] } &list_domain_owner_modules();
+	my $dis1 = &js_disable_inputs(\@inames, [ ], 'onClick');
+	my $dis2 = &js_disable_inputs([ ], \@inames, 'onClick');
 	$field .= &ui_radio("avail_def", $tmpl->{'avail'} ? 0 : 1,
 			    [ [ 1, $text{'tmpl_avail1'}, $dis1 ],
 			      [ 0, $text{'tmpl_avail0'}, $dis2 ] ])."<br>\n";
@@ -18081,12 +18081,12 @@ print &ui_table_row(undef, $field, 2);
 # Update the list of modules available to domain owners
 sub parse_template_avail
 {
-local ($tmpl) = @_;
+my ($tmpl) = @_;
 if ($in{'avail_def'}) {
 	$tmpl->{'avail'} = undef;
 	}
 else {
-	local @avail;
+	my @avail;
 	foreach my $m (&list_domain_owner_modules()) {
 		push(@avail, $m->[0].'='.$in{'avail_'.$m->[0]});
 		}
@@ -18098,10 +18098,10 @@ else {
 # Outputs HTML for editing core Virtualmin template options
 sub show_template_virtualmin
 {
-local ($tmpl) = @_;
+my ($tmpl) = @_;
 
 # Automatic alias domain
-local @afields = ( "domalias", "domalias_type", "domalias_tmpl" );
+my @afields = ( "domalias", "domalias_type", "domalias_tmpl" );
 print &ui_table_row(&hlink($text{'tmpl_domalias'}, "template_domalias"),
 	&none_def_input("domalias", $tmpl->{'domalias'},
 			$text{'tmpl_aliasset'},
@@ -18135,7 +18135,7 @@ print &ui_table_row($text{'disable_autodisable'},
 # Updates core Virtualmin template options from %in
 sub parse_template_virtualmin
 {
-local ($tmpl) = @_;
+my ($tmpl) = @_;
 
 # Parse automatic alias domain mode
 $tmpl->{'domalias'} = &parse_none_def("domalias");
@@ -18169,10 +18169,10 @@ else {
 # Outputs HTML for mail client autoconfig XML
 sub show_template_autoconfig
 {
-local ($tmpl) = @_;
+my ($tmpl) = @_;
 
 # XML for Thunderbird
-local $xml;
+my $xml;
 if ($tmpl->{'autoconfig'} eq "" || $tmpl->{'autoconfig'} eq "none") {
 	$xml = &get_thunderbird_autoconfig_xml();
 	}
@@ -18206,7 +18206,7 @@ print &ui_table_row(
 # Updates core mail client autoconfig template options from %in
 sub parse_template_autoconfig
 {
-local ($tmpl) = @_;
+my ($tmpl) = @_;
 
 # Parse Thunderbird automatic alias domain mode
 $tmpl->{'autoconfig'} = &parse_none_def("autoconfig");
@@ -18227,9 +18227,9 @@ if ($in{'outlook_autoconfig_mode'} == 2) {
 # If mail autoconfig is active, update the template for all domains
 sub postsave_template_autoconfig
 {
-local ($tmpl) = @_;
+my ($tmpl) = @_;
 if ($config{'mail_autoconfig'}) {
-	local @doms = grep { $_->{'mail'} && &domain_has_website($_) &&
+	my @doms = grep { $_->{'mail'} && &domain_has_website($_) &&
 			     !$_->{'alias'} } &list_domains();
 	foreach my $d (@doms) {
 		&enable_email_autoconfig($d);
@@ -18283,8 +18283,8 @@ return @rvdesc;
 # PARENT_DOMAIN variables too
 sub substitute_domain_template
 {
-local ($str, $d, $extra, $escape) = @_;
-local %hash = &make_domain_substitions($d, 0);
+my ($str, $d, $extra, $escape) = @_;
+my %hash = &make_domain_substitions($d, 0);
 if ($extra) {
 	%hash = ( %hash, %$extra );
 	}
@@ -18296,8 +18296,8 @@ return &substitute_virtualmin_template($str, \%hash, $escape);
 # variables added to the hash
 sub substitute_virtualmin_template
 {
-local ($str, $hash, $escape) = @_;
-local %ghash = %$hash;
+my ($str, $hash, $escape) = @_;
+my %ghash = %$hash;
 foreach my $v (&get_global_template_variables()) {
 	if ($v->{'enabled'} && !defined($ghash{$v->{'name'}})) {
 		$ghash{$v->{'name'}} = $v->{'value'};
@@ -18398,7 +18398,7 @@ return $content;
 # ~/bar/foo.txt. Absolute paths are not converted.
 sub absolute_domain_path
 {
-local ($d, $path) = @_;
+my ($d, $path) = @_;
 $d->{'home'} || &error("absolute_domain_path called for $path without a home directory!");
 if ($path =~ /^\//) {
 	# Already absolute
@@ -18418,7 +18418,7 @@ else {
 # Returns the ID of the initially selected template
 sub get_init_template
 {
-local $rv = $_[0] ? $config{'initsub_template'} : $config{'init_template'};
+my $rv = $_[0] ? $config{'initsub_template'} : $config{'init_template'};
 if ($rv > 1 && !-r "$templates_dir/$rv") {
 	# Template doesn't exist! Return sensible default
 	return $_[0] ? 1 : 0;
@@ -18431,11 +18431,11 @@ return $rv;
 # on another. Called from .cgi scripts to activate hidden features (mode 3).
 sub set_chained_features
 {
-local ($d, $oldd) = @_;
+my ($d, $oldd) = @_;
 foreach my $f (@features) {
-	local $cfunc = "chained_$f";
+	my $cfunc = "chained_$f";
 	if (defined(&$cfunc)) {
-		local $c = &$cfunc($d, $oldd);
+		my $c = &$cfunc($d, $oldd);
 		if (defined($c) && $c ne "") {
 			$d->{$f} = $c;
 			}
@@ -18455,9 +18455,9 @@ foreach my $f (@plugins) {
 # Returns an error if some user's password (from plainpass) is not acceptable
 sub check_password_restrictions
 {
-local ($user, $webmin, $d) = @_;
+my ($user, $webmin, $d) = @_;
 &require_useradmin();
-local $err = &useradmin::check_password_restrictions(
+my $err = &useradmin::check_password_restrictions(
 	$user->{'plainpass'}, $user->{'user'}, $user);
 return $err if ($err);
 if ($d) {
@@ -18485,7 +18485,7 @@ return undef;
 # Obtain a lock on some domain name, to prevent concurrent creation
 sub lock_domain_name
 {
-local ($name) = @_;
+my ($name) = @_;
 if (!-d $domainnames_dir) {
 	&make_dir($domainnames_dir, 0755);
 	}
@@ -18496,7 +18496,7 @@ if (!-d $domainnames_dir) {
 # Release a lock on some domain name, used to prevent concurrent creation
 sub unlock_domain_name
 {
-local ($name) = @_;
+my ($name) = @_;
 &unlock_file("$domainnames_dir/$name");
 }
 
@@ -18573,12 +18573,12 @@ if ($tcount > 1) {
 # Print ui_table rows for bandwidth usage in a domain
 sub show_domain_bw_usage
 {
-local ($d) = @_;
+my ($d) = @_;
 if (defined($d->{'bw_usage'})) {
-	local $msg = &text('edit_bwusage',
+	my $msg = &text('edit_bwusage',
 		strftime("%d/%m/%Y", localtime($d->{'bw_start'}*(24*60*60))));
 	if ($d->{'bw_limit'} && $d->{'bw_usage'} > $d->{'bw_limit'}) {
-		local $notify = localtime($d->{'bw_notify'});
+		my $notify = localtime($d->{'bw_notify'});
 		print &ui_table_row($msg,
 			"<font color=#ff0000>".
 			&nice_size($d->{'bw_usage'})."</font>\n".
@@ -18595,7 +18595,7 @@ if (defined($d->{'bw_usage'})) {
 # Returns text for a list of domain with links, or a search
 sub domains_list_links
 {
-local ($doms, $field, $what) = @_;
+my ($doms, $field, $what) = @_;
 if (@$doms > 5) {
 	return scalar(@$doms)." <a href='search.cgi?field=$field&what=$what'>".
 			      "$text{'edit_sublist'}</a>";
@@ -18609,7 +18609,7 @@ else {
 		push(@alinks, "<a href='$prog?dom=$a->{'id'}'>".
 			      &show_domain_name($a)."</a>");
 		}
-	local $lr = &ui_links_row(\@alinks);
+	my $lr = &ui_links_row(\@alinks);
 	$lr =~ s/<br>$//;
 	return $lr;
 	}
@@ -18620,11 +18620,11 @@ else {
 # Returns HTML for a link that pops up a password display window
 sub show_password_popup
 {
-local ($d, $user, $mode) = @_;
-local $pass = $mode ? $d->{$mode."_pass"} :
+my ($d, $user, $mode) = @_;
+my $pass = $mode ? $d->{$mode."_pass"} :
 	      $user ? $user->{'plainpass'} : $d->{'pass'};
 if (&can_show_pass() && $pass) {
-	local $link = "showpass.cgi?dom=$d->{'id'}&mode=".&urlize($mode);
+	my $link = "showpass.cgi?dom=$d->{'id'}&mode=".&urlize($mode);
 	if ($user) {
 		$link .= "&amp;user=".&urlize($user->{'user'});
 		}
@@ -18696,7 +18696,7 @@ $config{'sharedip6s'} = join(" ", @_);
 # shared or reseller shared)
 sub is_shared_ip
 {
-local ($ip) = @_;
+my ($ip) = @_;
 return 1 if ($ip eq &get_default_ip());
 return 1 if (&indexof($ip, &list_shared_ips()) >= 0);
 return 1 if ($ip eq &get_default_ip6());
@@ -18717,20 +18717,20 @@ return 0;
 # or an error message on failure.
 sub activate_shared_ip
 {
-local ($ip, $netmask) = @_;
+my ($ip, $netmask) = @_;
 &foreign_require("net");
-local @boot = &net::active_interfaces();
-local ($iface) = grep { $_->{'fullname'} eq $config{'iface'} } @boot;
+my @boot = &net::active_interfaces();
+my ($iface) = grep { $_->{'fullname'} eq $config{'iface'} } @boot;
 if (!$iface) {
 	return &text('sharedips_missing', $config{'iface'});
 	}
-local $vmax = $config{'iface_base'} || int($net::min_virtual_number);
+my $vmax = $config{'iface_base'} || int($net::min_virtual_number);
 foreach my $b (@boot) {
 	$vmax = $b->{'virtual'} if ($b->{'name'} eq $iface->{'name'} &&
 				    $b->{'virtual'} > $vmax);
 	}
 $netmask ||= $net::virtual_netmask || $iface->{'netmask'};
-local $virt = { 'address' => $ip,
+my $virt = { 'address' => $ip,
 		'netmask' => $netmask,
 		'broadcast' => &net::compute_broadcast($ip, $netmask),
 		'name' => $iface->{'name'},
@@ -18754,14 +18754,14 @@ return undef;
 # or an error message on failure.
 sub deactivate_shared_ip
 {
-local ($ip) = @_;
+my ($ip) = @_;
 &foreign_require("net");
-local @boot = &net::boot_interfaces();
-local @active = &net::active_interfaces();
-local ($b) = grep { $_->{'address'} eq $ip } @boot;
+my @boot = &net::boot_interfaces();
+my @active = &net::active_interfaces();
+my ($b) = grep { $_->{'address'} eq $ip } @boot;
 $b || return $text{'sharedips_eboot'};
 $b->{'virtual'} eq '' && return $text{'sharedips_ebootreal'};
-local ($a) = grep { $_->{'address'} eq $ip } @active;
+my ($a) = grep { $_->{'address'} eq $ip } @active;
 $a || return $text{'sharedips_eactives'};
 $a->{'virtual'} eq '' && return $text{'sharedips_ebootreal'};
 &net::delete_interface($b);
@@ -18804,10 +18804,10 @@ return undef;
 # Returns a list of features for which backups are possible
 sub get_available_backup_features
 {
-local ($safe) = @_;
-local @rv;
+my ($safe) = @_;
+my @rv;
 foreach my $f ($safe ? @safe_backup_features : @backup_features) {
-	local $bfunc = "backup_$f";
+	my $bfunc = "backup_$f";
 	if (defined(&$bfunc) &&
 	    ($config{$f} ||
 	     $f eq "unix" || $f eq "virtualmin" || $f eq "mail")) {
@@ -18840,7 +18840,7 @@ return &is_enabled_feature($f, &list_backup_plugins());
 # Given some HTML, extracts the header, body and stuff after the body
 sub html_extract_head_body
 {
-local ($html) = @_;
+my ($html) = @_;
 if ($html =~ /^([\000-\377]*<body[^>]*>)([\000-\377]*)(<\/body[^>]*>[\000-\377]*)/i) {
 	return ($1, $2, $3);
 	}
@@ -18853,7 +18853,7 @@ else {
 # Open a file, uncompressing if needed
 sub open_uncompress_file
 {
-local ($fh, $f) = @_;
+my ($fh, $f) = @_;
 if ($f =~ /\|$/) {
 	return open($fh, $f);
 	}
@@ -18876,10 +18876,10 @@ else {
 # Virtualmin user.
 sub list_available_features
 {
-local ($parentdom, $aliasdom, $subdom) = @_;
+my ($parentdom, $aliasdom, $subdom) = @_;
 
 # Start with core features
-local @core = $aliasdom ? @opt_alias_features :
+my @core = $aliasdom ? @opt_alias_features :
 	    $subdom ? @opt_subdom_features : @opt_features;
 @core = grep { &can_use_feature($_) } @core;
 if ($parentdom) {
@@ -18888,7 +18888,7 @@ if ($parentdom) {
 if ($aliasdom) {
 	@core = grep { $aliasdom->{$_} } @core;
 	}
-local @rv = map { { 'feature' => $_,
+my @rv = map { { 'feature' => $_,
 		    'desc' => $text{'feature_'.$_},
 		    'core' => 1,
 		    'auto' => $config{$_} == 3,
@@ -18896,13 +18896,13 @@ local @rv = map { { 'feature' => $_,
 		    'enabled' => $config{$_} || !defined($config{$_}) } } @core;
 
 # Add plugin features
-local @plug = grep { &plugin_call($_, "feature_suitable",
+my @plug = grep { &plugin_call($_, "feature_suitable",
 			$parentdom, $aliasdom, $subdom) } &list_feature_plugins();
 @plug = grep { &can_use_feature($_) } @plug;
 if ($aliasdom) {
 	@plug = grep { $aliasdom->{$_} } @plug;
 	}
-local %inactive = map { $_, 1 } @plugins_inactive;
+my %inactive = map { $_, 1 } @plugins_inactive;
 push(@rv, map { { 'feature' => $_,
 		  'desc' => &plugin_call($_, "feature_name", 0),
 		  'plugin' => 1,
@@ -18925,15 +18925,15 @@ return ( @opt_features, "virt", "virt6", &list_feature_plugins() );
 # Returns a hash ref from domain IDs to user counts
 sub count_domain_users
 {
-local %rv;
-local (%homemap, %doneuser, %gidmap);
+my %rv;
+my (%homemap, %doneuser, %gidmap);
 foreach my $d (&list_visible_domains()) {
 	$homemap{$d->{'home'}} = $d->{'id'};
 	$gidmap{$d->{'gid'}} = $d->{'id'} if (!$d->{'parent'});
 	}
 foreach my $u (&list_all_users_quotas(1)) {
-	local $h = $u->{'home'};
-	local $did;
+	my $h = $u->{'home'};
+	my $did;
 	if ($homemap{$h}) {
 		# User home is a domain's home .. so this is the domain owner
 		$did = $homemap{$h};
@@ -18961,7 +18961,7 @@ foreach my $u (&list_all_users_quotas(1)) {
 		}
 	if ($mail_system == 0) {
 		# Don't double-count Postfix @ and - users
-		local $noat = &replace_atsign($u->{'user'});
+		my $noat = &replace_atsign($u->{'user'});
 		next if ($doneuser{$noat}++);
 		}
 	if ($did) {
@@ -18975,19 +18975,19 @@ return \%rv;
 # Adds some user (like httpd or ftp) to the Unix group for a domain, if missing
 sub add_user_to_domain_group
 {
-local ($d, $user, $msg) = @_;
+my ($d, $user, $msg) = @_;
 return 0 if ($d->{'alias'} || !$d->{'group'});
 &require_useradmin();
 &obtain_lock_unix($d);
-local @groups = &list_all_groups();
-local ($group) = grep { $_->{'group'} eq $d->{'group'} } @groups;
-local $rv;
+my @groups = &list_all_groups();
+my ($group) = grep { $_->{'group'} eq $d->{'group'} } @groups;
+my $rv;
 if ($group) {
-	local @mems = split(/,/, $group->{'members'});
+	my @mems = split(/,/, $group->{'members'});
 	if (&indexof($user, @mems) < 0) {
 		# Need to add him
 		&$first_print(&text($msg, $user)) if ($msg);
-		local $oldgroup = { %$group };
+		my $oldgroup = { %$group };
 		$group->{'members'} = join(",", @mems, $user);
 		&foreign_call($group->{'module'}, "set_group_envs", $group,
 						  'MODIFY_GROUP', $oldgroup);
@@ -19007,7 +19007,7 @@ return $rv;
 # Returns a list of excluded directories
 sub get_backup_excludes
 {
-local ($d) = @_;
+my ($d) = @_;
 return split(/\t+/, $d->{'backup_excludes'});
 }
 
@@ -19015,7 +19015,7 @@ return split(/\t+/, $d->{'backup_excludes'});
 # Updates the list of excluded directories
 sub save_backup_excludes
 {
-local ($d, $excludes) = @_;
+my ($d, $excludes) = @_;
 &lock_domain($d);
 $d->{'backup_excludes'} = join("\t", @$excludes);
 &save_domain($d);
@@ -19026,7 +19026,7 @@ $d->{'backup_excludes'} = join("\t", @$excludes);
 # Returns a list of excluded DB or DB.table names
 sub get_backup_db_excludes
 {
-local ($d) = @_;
+my ($d) = @_;
 return split(/\t+/, $d->{'backup_db_excludes'});
 }
 
@@ -19034,7 +19034,7 @@ return split(/\t+/, $d->{'backup_db_excludes'});
 # Updates the list of excluded DB or DB.table names
 sub save_backup_db_excludes
 {
-local ($d, $excludes) = @_;
+my ($d, $excludes) = @_;
 &lock_domain($d);
 $d->{'backup_db_excludes'} = join("\t", @$excludes);
 &save_domain($d);
@@ -19046,10 +19046,10 @@ $d->{'backup_db_excludes'} = join("\t", @$excludes);
 # Level 0 = master admin, 1 = domain owner, 2 = reseller
 sub list_plugin_sections
 {
-local ($level) = @_;
-local $want = $level == 0 ? "for_master" :
+my ($level) = @_;
+my $want = $level == 0 ? "for_master" :
 	      $level == 1 ? "for_owner" : "for_reseller";
-local @rv;
+my @rv;
 foreach my $p (@plugins) {
 		if (&plugin_defined($p, "theme_sections")) {
 		foreach my $s (&plugin_call($p, "theme_sections")) {
@@ -19070,8 +19070,8 @@ return @rv;
 sub get_provider_link
 {
 # Does this user's domain's reseller have a logo?
-local ($logo, $link, $alt);
-local $d = &get_domain_by("user", $remote_user, "parent", "");
+my ($logo, $link, $alt);
+my $d = &get_domain_by("user", $remote_user, "parent", "");
 if (!$d) {
 	# No domain found by user .. but is this user an extra admin?
 	if ($access{'admin'}) {
@@ -19081,7 +19081,7 @@ if (!$d) {
 if ($d && $d->{'reseller'} && defined(&get_reseller)) {
 	# Domain has a reseller .. check for his logo
 	foreach my $r (split(/\s+/, $d->{'reseller'})) {
-		local $resel = &get_reseller($r);
+		my $resel = &get_reseller($r);
 		if ($resel->{'acl'}->{'logo'}) {
 			$logo = $resel->{'acl'}->{'logo'};
 			$link = $resel->{'acl'}->{'link'};
@@ -19092,7 +19092,7 @@ if ($d && $d->{'reseller'} && defined(&get_reseller)) {
 	}
 if (!$d && &reseller_admin()) {
 	# This user is a reseller .. use his logo
-	local $resel = &get_reseller($remote_user);
+	my $resel = &get_reseller($remote_user);
 	if ($resel->{'acl'}->{'logo'}) {
 		$logo = $resel->{'acl'}->{'logo'};
 		$link = $resel->{'acl'}->{'link'};
@@ -19106,7 +19106,7 @@ if (!$logo) {
 	$alt = $config{'theme_alt'} || $gconfig{'virtualmin_theme_alt'};
 	}
 if ($logo && $logo ne "none") {
-	local $html;
+	my $html;
 	$html .= "<a href='".&html_escape($link)."' target=_blank>" if ($link);
 	$html .= "<img src='".&html_escape($image)."' ".
 		 "alt='".&html_escape($alt)."' border=0>";
@@ -19122,8 +19122,8 @@ else {
 # Returns a string listing multiple domains
 sub nice_domains_list
 {
-local ($doms) = @_;
-local @ttdoms = map { "<tt>".&show_domain_name($_)."</tt>" } @$doms;
+my ($doms) = @_;
+my @ttdoms = map { "<tt>".&show_domain_name($_)."</tt>" } @$doms;
 if (@ttdoms > 10) {
 	@ttdoms = ( @ttdoms[0..9], &text('index_dmore', @ttdoms-10) );
 	}
@@ -19142,11 +19142,11 @@ return join(", ", @ttdoms);
 # avail - Set to 1 if it is available for use
 sub list_available_shells
 {
-local ($d, $mail) = @_;
+my ($d, $mail) = @_;
 if (!defined($mail)) {
 	$mail = !$d || $d->{'mail'};
 	}
-local @rv;
+my @rv;
 if ($list_available_shells_cache{$mail}) {
 	return @{$list_available_shells_cache{$mail}};
 	}
@@ -19155,7 +19155,7 @@ if (-r $custom_shells_file) {
 	open(SHELLS, "<".$custom_shells_file);
 	while(<SHELLS>) {
 		s/\r|\n//g;
-		local %shell = map { split(/=/, $_, 2) } split(/\t+/, $_);
+		my %shell = map { split(/=/, $_, 2) } split(/\t+/, $_);
 		push(@rv, \%shell);
 		}
 	close(SHELLS);
@@ -19184,8 +19184,8 @@ if (!@rv) {
 			    'avail' => 1,
 			    'id' => 'scp' });
 		}
-	local (%done, %classes, $defclass);
-	local $best_unix_shell;
+	my (%done, %classes, $defclass);
+	my $best_unix_shell;
 	foreach my $s (split(/\s+/, $config{'unix_shell'})) {
 		if (&has_command($s)) {
 			$best_unix_shell = &has_command($s);
@@ -19196,7 +19196,7 @@ if (!@rv) {
 	foreach my $us (&get_unix_shells()) {
 		next if (!-r $us->[1]);
 		next if ($done{$us->[1]}++);
-		local %shell = ( 'shell' => $us->[1],
+		my %shell = ( 'shell' => $us->[1],
 				 'desc' => $mail ? $text{'shells_'.$us->[0]}
 						: $text{'shells_'.$us->[0].'2'},
 				 'id' => $us->[0],
@@ -19213,7 +19213,7 @@ if (!@rv) {
 		}
 	if (!$defclass) {
 		# Default for owners was not found .. use config
-		local %shell = ( 'shell' => $best_unix_shell,
+		my %shell = ( 'shell' => $best_unix_shell,
 				 'desc' => $text{'shells_ssh'},
 				 'id' => 'ssh',
 				 'owner' => 1,
@@ -19261,7 +19261,7 @@ return @rv;
 # defaults if undef is given
 sub save_available_shells
 {
-local ($shells) = @_;
+my ($shells) = @_;
 if ($shells) {
 	&open_lock_tempfile(SHELLS, ">$custom_shells_file");
 	foreach my $s (@$shells) {
@@ -19344,9 +19344,9 @@ return &ui_select($name, $value,
 # Returns the default shell for a mailbox user or domain owner
 sub default_available_shell
 {
-local ($type) = @_;
-local @ashells = grep { $_->{$type} && $_->{'avail'} } &list_available_shells();
-local ($def) = grep { $_->{'default'} } @ashells;
+my ($type) = @_;
+my @ashells = grep { $_->{$type} && $_->{'avail'} } &list_available_shells();
+my ($def) = grep { $_->{'default'} } @ashells;
 return $def ? $def->{'shell'} : undef;
 }
 
@@ -19381,7 +19381,7 @@ return ($nologin_shell, $ftp_shell, $jailed_shell, $def_shell);
 # Creates a new root-owned empty file
 sub create_empty_file
 {
-local ($file) = @_;
+my ($file) = @_;
 &open_tempfile(EMPTY, ">$file", 0, 1);
 &close_tempfile(EMPTY);
 }
@@ -19421,14 +19421,14 @@ return 0 + $t; # numericize
 # plugins.
 sub update_miniserv_preloads
 {
-local ($mode) = @_;
+my ($mode) = @_;
 
-local $msc = $ENV{'MINISERV_CONFIG'} || "$config_directory/miniserv.conf";
+my $msc = $ENV{'MINISERV_CONFIG'} || "$config_directory/miniserv.conf";
 &lock_file($msc);
-local %miniserv;
+my %miniserv;
 &get_miniserv_config(\%miniserv);
-local @preload;
-local $oldpreload = $miniserv{'preload'};
+my @preload;
+my $oldpreload = $miniserv{'preload'};
 delete($miniserv{'premodules'});
 if ($mode == 0) {
 	# Nothing to load
@@ -19436,10 +19436,10 @@ if ($mode == 0) {
 	}
 else {
 	# Do core library and features
-	local $vslf = "virtual-server/virtual-server-lib-funcs.pl";
+	my $vslf = "virtual-server/virtual-server-lib-funcs.pl";
 	push(@preload, "virtual-server=$vslf");
 	foreach my $f (@features, "virt", "virt6") {
-		local $file = "virtual-server/feature-$f.pl";
+		my $file = "virtual-server/feature-$f.pl";
 		push(@preload, "virtual-server=$file");
 		}
 
@@ -19456,11 +19456,11 @@ return $oldpreload ne $miniserv{'preload'};
 # Convert a number of seconds into an HH hours, MM minutes, SS seconds format
 sub nice_hour_mins_secs
 {
-local ($time, $nopad, $showsecs) = @_;
-local $days = int($time / (24*60*60));
-local $hours = int($time / (60*60)) % 24;
-local $mins = sprintf($nopad ? "%d" : "%2.2d", int($time / 60) % 60);
-local $secs = sprintf($nopad ? "%d" : "%2.2d", int($time) % 60);
+my ($time, $nopad, $showsecs) = @_;
+my $days = int($time / (24*60*60));
+my $hours = int($time / (60*60)) % 24;
+my $mins = sprintf($nopad ? "%d" : "%2.2d", int($time / 60) % 60);
+my $secs = sprintf($nopad ? "%d" : "%2.2d", int($time) % 60);
 if ($days) {
 	return &text('nicetime_days', $days, $hours, $mins, $secs);
 	}
@@ -19479,11 +19479,11 @@ else {
 # Convert a number of seconds into an HH:MM:SS format
 sub short_nice_hour_mins_secs
 {
-local ($time) = @_;
-local $days = int($time / (24*60*60));
-local $hours = int($time / (60*60)) % 24;
-local $mins = sprintf("%2.2d", int($time / 60) % 60);
-local $secs = sprintf("%2.2d", int($time) % 60);
+my ($time) = @_;
+my $days = int($time / (24*60*60));
+my $hours = int($time / (60*60)) % 24;
+my $mins = sprintf("%2.2d", int($time / 60) % 60);
+my $secs = sprintf("%2.2d", int($time) % 60);
 return $days ? $days." days, ".$hours.":".$mins.":".$secs :
        $hours ? $hours.":".$mins.":".$secs :
 	        $mins.":".$secs;
@@ -19494,12 +19494,12 @@ return $days ? $days." days, ".$hours.":".$mins.":".$secs :
 # not supported. Returns only those that are supported.
 sub show_check_migration_features
 {
-local @got = @_;
-local %pconfig = map { $_, 1 } &list_feature_plugins();
-local @notgot = grep { !$config{$_} && !$pconfig{$_} } @got;
+my @got = @_;
+my %pconfig = map { $_, 1 } &list_feature_plugins();
+my @notgot = grep { !$config{$_} && !$pconfig{$_} } @got;
 @got = grep { $config{$_} || $pconfig{$_} } @got;
-local @gotmsg = map { &feature_name($_) } @got;
-local @notgotmsg = map { &feature_name($_) } @notgot;
+my @gotmsg = map { &feature_name($_) } @got;
+my @notgotmsg = map { &feature_name($_) } @notgot;
 &$second_print(".. found ",join(", ", @gotmsg),".");
 if (@notgot) {
 	&$second_print("<b>However, the follow features are not supported or enabled on your system : ",join(", ", @notgotmsg).". Some functions of the migrated virtual server may not work.</b>");
@@ -19511,9 +19511,9 @@ return @got;
 # Obtain locks on everything lockable that this domain has enabled
 sub obtain_lock_everything
 {
-local ($d) = @_;
+my ($d) = @_;
 foreach my $f (@features) {
-	local $lfunc = "obtain_lock_".$f;
+	my $lfunc = "obtain_lock_".$f;
 	if (defined(&$lfunc) && $d->{$d}) {
 		&$lfunc($d);
 		}
@@ -19524,9 +19524,9 @@ foreach my $f (@features) {
 # Reverses obtain_lock_everything
 sub release_lock_everything
 {
-local ($d) = @_;
+my ($d) = @_;
 foreach my $f (@features) {
-	local $lfunc = "release_lock_".$f;
+	my $lfunc = "release_lock_".$f;
 	if (defined(&$lfunc) && $d->{$d}) {
 		&$lfunc($d);
 		}
@@ -19537,7 +19537,7 @@ foreach my $f (@features) {
 # Called by the various obtain_lock_* functions
 sub obtain_lock_anything
 {
-local ($d) = @_;
+my ($d) = @_;
 &lock_domain($d) if ($d && $d->{'id'});
 # Assume that we are about to do something important, and so don't want to be
 # killed by a SIGPIPE triggered by a browser cancel.
@@ -19549,7 +19549,7 @@ $SIG{'TERM'} = 'IGNORE';
 # Called by the various release_lock_* functions
 sub release_lock_anything
 {
-local ($d) = @_;
+my ($d) = @_;
 &unlock_domain($d) if ($d && $d->{'id'});
 }
 
@@ -19557,13 +19557,13 @@ local ($d) = @_;
 # Log an action taken by a Virtualmin command-line API call
 sub virtualmin_api_log
 {
-local ($argv, $d, $hide) = @_;
+my ($argv, $d, $hide) = @_;
 
 # Parse into flags hash
-local (%flags, $lastflag);
-local @argv = @$argv;
+my (%flags, $lastflag);
+my @argv = @$argv;
 while(@argv) {
-	local $a = shift(@argv);
+	my $a = shift(@argv);
 	if ($a =~ /^\-+(\S+)$/) {
 		# A new flag
 		$lastflag = $1;
@@ -19604,11 +19604,11 @@ if ($hide) {
 $flags{'argv'} = &urlize(join(" ", @qargv));
 
 # Log it
-local $script = $0;
+my $script = $0;
 $script =~ s/^.*\///;
 local $remote_user = "root";
 local $WebminCore::remote_user = "root";
-local $rh = $ENV{'REMOTE_HOST'};
+my $rh = $ENV{'REMOTE_HOST'};
 local $ENV{'REMOTE_HOST'} = $rh || "127.0.0.1";
 &webmin_log($main::virtualmin_remote_api ||
 	    $ENV{'VIRTUALMIN_REMOTE_API'} ? "remote" : "cmd",
@@ -19620,13 +19620,13 @@ local $ENV{'REMOTE_HOST'} = $rh || "127.0.0.1";
 sub get_global_template_variables
 {
 if (!scalar(@global_template_variables_cache)) {
-	local @rv = ( );
+	my @rv = ( );
 	&open_readfile(GLOBAL, $global_template_variables_file);
 	while(<GLOBAL>) {
 		s/\r|\n//g;
-		local $dis;
+		my $dis;
 		$dis = 1 if (s/^\#+\s*//);
-		local ($n, $v) = split(/\s+/, $_, 2);
+		my ($n, $v) = split(/\s+/, $_, 2);
 		push(@rv, { 'name' => $n,
 			    'value' => $v,
 			    'enabled' => !$dis });
@@ -19641,7 +19641,7 @@ return @global_template_variables_cache;
 # Write out the array ref of hash refs of global variables to a file
 sub save_global_template_variables
 {
-local ($vars) = @_;
+my ($vars) = @_;
 &open_tempfile(GLOBAL, ">$global_template_variables_file");
 foreach my $v (@$vars) {
 	&print_tempfile(GLOBAL,
@@ -19656,8 +19656,8 @@ foreach my $v (@$vars) {
 # Returns a path relative to a domain's home, if possible
 sub home_relative_path
 {
-local ($d, $file) = @_;
-local $l = length($d->{'home'});
+my ($d, $file) = @_;
+my $l = length($d->{'home'});
 if (substr($file, 0, $l+1) eq $d->{'home'}."/") {
 	return substr($file, $l+1);
 	}
@@ -19669,8 +19669,8 @@ return $file;
 # update the IPs of an alias domains too. May print stuff.
 sub update_alias_domain_ips
 {
-local ($d, $oldd) = @_;
-local @aliases = &get_domain_by("alias", $d->{'id'});
+my ($d, $oldd) = @_;
+my @aliases = &get_domain_by("alias", $d->{'id'});
 return 0 if (!@aliases);
 foreach my $ad (@aliases) {
 	next if ($ad->{'ip'} ne $oldd->{'ip'} &&
@@ -19685,7 +19685,7 @@ foreach my $ad (@aliases) {
 	&$first_print(&text('save_aliasip', $ad->{'dom'}, $d->{'ip'}));
 	&$indent_print();
 	foreach my $f (@features) {
-		local $mfunc = "modify_$f";
+		my $mfunc = "modify_$f";
 		if ($config{$f} && $ad->{$f}) {
 			&try_function($f, $mfunc, $ad, $oldad);
 			}
@@ -19714,7 +19714,7 @@ my $suffix = $prefer == 6 ? 6 : "";
 if (defined(&get_reseller)) {
 	# Check if the reseller has an external IP
 	foreach my $r (split(/\s+/, $reselname)) {
-		local $resel = &get_reseller($r);
+		my $resel = &get_reseller($r);
 		if ($resel && $resel->{'acl'}->{'defdnsip'.$suffix}) {
 			return $resel->{'acl'}->{'defdnsip'.$suffix};
 			}
@@ -19736,10 +19736,10 @@ return undef;
 # Create or delete the bandwidth monitoring cron job
 sub setup_bandwidth_job
 {
-local ($active, $step) = @_;
+my ($active, $step) = @_;
 $step ||= 1;
 &foreign_require("cron");
-local $job = &find_bandwidth_job();
+my $job = &find_bandwidth_job();
 if ($job) {
 	&delete_cron_script($job);
 	}
@@ -19769,9 +19769,9 @@ if ($active) {
 # Returns a URL for accessing Virtualmin. Never has a trailing /
 sub get_virtualmin_url
 {
-local ($d) = @_;
+my ($d) = @_;
 $d ||= { 'dom' => &get_system_hostname() };
-local $rv;
+my $rv;
 if ($config{'scriptwarn_url'} && !$main::calling_get_virtualmin_url) {
 	# From module config
 	$main::calling_get_virtualmin_url = 1;
@@ -19806,7 +19806,7 @@ return ($ssl && &domain_has_ssl($d) ? "https" : "http").
 # Returns the template for email to users who are over quota
 sub get_quotas_message
 {
-local $msg = &read_file_contents($user_quota_msg_file);
+my $msg = &read_file_contents($user_quota_msg_file);
 if (!$msg) {
 	$msg = "You have reached or are approaching your disk quota limit:\n".
 	       "\n".
@@ -19826,7 +19826,7 @@ return $msg;
 # Updates the template for over-quota email message
 sub save_quotas_message
 {
-local ($msg) = @_;
+my ($msg) = @_;
 &open_tempfile(QUOTAMSG, ">$user_quota_msg_file");
 &print_tempfile(QUOTAMSG, $msg);
 &close_tempfile(QUOTAMSG);
@@ -19869,8 +19869,8 @@ return $host;
 # Convert a date string like YYYY-MM-DD or -5 to a Unix time
 sub date_to_time
 {
-local ($date, $gmt, $eod) = @_;
-local $rv;
+my ($date, $gmt, $eod) = @_;
+my $rv;
 if ($date =~ /^(\d{4})-(\d+)-(\d+)$/) {
 	# Date only
 	if ($gmt) {
@@ -19897,8 +19897,8 @@ return $rv;
 # Convert a Unix time to a date formatted in YYYY-MM-DD
 sub time_to_date
 {
-local ($secs) = @_;
-local @tm = localtime($secs);
+my ($secs) = @_;
+my @tm = localtime($secs);
 return sprintf "%4.4d-%2.2d-%2.2d", $tm[5]+1900, $tm[4]+1, $tm[3];
 }
 
@@ -19920,14 +19920,14 @@ return $a == 0 || $a == 1 || $a == 4 || $a == 7 ? 'suffix' : 'prefix';
 # Returns -1 if ver1 is older than ver2, 1 if newer, 0 if same
 sub compare_versions
 {
-local ($ver1, $ver2, $script) = @_;
+my ($ver1, $ver2, $script) = @_;
 if ($script && $script->{'numeric_version'}) {
 	# Strict numeric compare
 	return $ver1 <=> $ver2;
 	}
 if ($script && $script->{'release_version'}) {
 	# Compare release and version separately
-	local ($rel1, $rel2);
+	my ($rel1, $rel2);
 	($ver1, $rel1) = split(/-/, $ver1, 2);
 	($ver2, $rel2) = split(/-/, $ver2, 2);
 	return &compare_versions($ver1, $ver2) ||
@@ -19943,13 +19943,13 @@ return &compare_version_numbers($ver1, $ver2);
 # or 1 on success.
 sub clone_virtual_server
 {
-local ($oldd, $newdom, $newuser, $newpass, $ip, $virtalready) = @_;
+my ($oldd, $newdom, $newuser, $newpass, $ip, $virtalready) = @_;
 
 # Create the new domain object, with changes
 &$first_print($text{'clone_object'});
-local $d = { %$oldd };
-local $parent;
-local $tmpl = &get_template($d->{'template'});
+my $d = { %$oldd };
+my $parent;
+my $tmpl = &get_template($d->{'template'});
 $d->{'id'} = &domain_id();
 $d->{'clone'} = $oldd->{'id'};
 $d->{'dom'} = $newdom;
@@ -19981,7 +19981,7 @@ else {
 # Pick a new home directory and prefix
 $d->{'home'} = &server_home_directory($d, $parent);
 $d->{'prefix'} = &compute_prefix($d->{'dom'}, $d->{'group'}, $parent, 1);
-local $pclash = &get_domain_by("prefix", $d->{'prefix'});
+my $pclash = &get_domain_by("prefix", $d->{'prefix'});
 if ($pclash) {
 	&$second_print(&text('clone_prefixclash',
 			     $d->{'prefix'}, $pclash->{'dom'}));
@@ -20020,7 +20020,7 @@ elsif ($d->{'virt'}) {
 		&$second_print($text{'clone_virtrange'});
 		return 0;
 		}
-	local ($ip, $netmask) = &free_ip_address($tmpl);
+	my ($ip, $netmask) = &free_ip_address($tmpl);
 	if (!$ip) {
 		&$second_print($text{'clone_virtalloc'});
 		return 0;
@@ -20039,7 +20039,7 @@ if ($d->{'virt6'}) {
 		&$second_print($text{'clone_virt6range'});
 		return 0;
 		}
-	local ($ip6, $netmask6) = &free_ip6_address($tmpl);
+	my ($ip6, $netmask6) = &free_ip6_address($tmpl);
 	if (!$ip6) {
 		&$second_print($text{'clone_virt6alloc'});
 		return 0;
@@ -20053,7 +20053,7 @@ if ($d->{'virt6'}) {
 # Disable and features that don't support cloning
 &$first_print($text{'clone_clash'});
 foreach my $f (@features) {
-	local $cfunc = "clone_".$f;
+	my $cfunc = "clone_".$f;
 	if ($d->{$f} && !defined(&$cfunc)) {
 		$d->{$f} = 0;
 		}
@@ -20065,12 +20065,12 @@ foreach my $f (@plugins) {
 	}
 
 # Check for clashes / depends
-local $derr = &virtual_server_depends($d);
+my $derr = &virtual_server_depends($d);
 if ($derr) {
 	&$second_print(&text('clone_dependfound', $derr));
 	return 0;
 	}
-local $cerr = &virtual_server_clashes($d);
+my $cerr = &virtual_server_clashes($d);
 if ($cerr) {
 	&$second_print(&text('clone_clashfound', $cerr));
 	return 0;
@@ -20085,7 +20085,7 @@ delete($d->{'ssl_chain'});
 # Create it
 &$first_print($text{'clone_create'});
 &$indent_print();
-local $err = &create_virtual_server($d, $parent,
+my $err = &create_virtual_server($d, $parent,
 				    $parent ? $parent->{'user'} : undef, 1);
 &$outdent_print();
 if ($err) {
@@ -20096,7 +20096,7 @@ if ($err) {
 
 # Run the before clone command
 &set_domain_envs($d, "CLONE_DOMAIN", undef, $oldd);
-local $merr = &making_changes();
+my $merr = &making_changes();
 &reset_domain_envs($d);
 return &text('setup_emaking', "<tt>$merr</tt>") if (defined($merr));
 
@@ -20107,7 +20107,7 @@ if (&indexof("mail", @clonefeatures) >= 0) {
 	}
 foreach my $f (@clonefeatures) {
 	if ($d->{$f}) {
-		local $cfunc = "clone_".$f;
+		my $cfunc = "clone_".$f;
 		&try_function($f, $cfunc, $d, $oldd);
 		}
 	}
@@ -20122,12 +20122,12 @@ foreach my $f (@plugins) {
 
 # Copy across script logs, and then fix paths
 # Fix script installer paths in all domains
-local $scriptsrc = "$script_log_directory/$oldd->{'id'}";
-local $scriptdest = "$script_log_directory/$d->{'id'}";
+my $scriptsrc = "$script_log_directory/$oldd->{'id'}";
+my $scriptdest = "$script_log_directory/$d->{'id'}";
 if (-d $scriptsrc) {
 	&$first_print($text{'clone_scripts'});
 	&copy_source_dest($scriptsrc, $scriptdest);
-	local ($olddir, $newdir) = ($oldd->{'home'}, $d->{'home'});
+	my ($olddir, $newdir) = ($oldd->{'home'}, $d->{'home'});
 	foreach $sinfo (&list_domain_scripts($d)) {
 		my $changed = 0;
 		$changed++ if ($sinfo->{'opts'}->{'dir'} =~
@@ -20142,7 +20142,7 @@ if (-d $scriptsrc) {
 &run_post_actions();
 
 &set_domain_envs($d, "CLONE_DOMAIN", undef, $oldd);
-local $merr = &made_changes();
+my $merr = &made_changes();
 &$second_print(&text('setup_emade', "<tt>$merr</tt>")) if (defined($merr));
 &reset_domain_envs($d);
 
@@ -20175,8 +20175,8 @@ if ($gid) {
 sub check_resolvability
 {
 my ($name) = @_;
-local $page = $resolve_check_page."?host=".&urlize($name);
-local ($out, $error);
+my $page = $resolve_check_page."?host=".&urlize($name);
+my ($out, $error);
 &http_download($resolve_check_host,
 	       $resolve_check_port,
 	       $page, \$out, \$error, undef, 0, undef, undef, 60, 0, 1);
@@ -20238,8 +20238,8 @@ return $d->{'ssl_cert'} && -r $d->{'ssl_cert'} ? 1 : 0;
 # Returns the access or error log for a domain's website. May come from a plugin
 sub get_website_log
 {
-local ($d, $errorlog) = @_;
-local $p = &domain_has_website($d);
+my ($d, $errorlog) = @_;
+my $p = &domain_has_website($d);
 if ($p eq 'web') {
 	return &get_apache_log($d->{'dom'}, $d->{'web_port'}, $errorlog);
 	}
@@ -20253,7 +20253,7 @@ return undef;
 # Returns the log path that would have been used in the old domain
 sub get_old_website_log
 {
-local ($alog, $d, $oldd) = @_;
+my ($alog, $d, $oldd) = @_;
 if ($d->{'home'} ne $oldd->{'home'}) {
         $alog =~ s/\Q$d->{'home'}\E/$oldd->{'home'}/;
         }
@@ -20268,8 +20268,8 @@ return $alog;
 # Calls the restart function for the webserver for a domain
 sub restart_website_server
 {
-local ($d, @args) = @_;
-local $p = &domain_has_website($d);
+my ($d, @args) = @_;
+my $p = &domain_has_website($d);
 if ($p eq "web") {
 	&restart_apache(@args);
 	}
@@ -20446,7 +20446,7 @@ return @rv;
 # Set environment variables containing Virtualmin user-specific info
 sub set_virtualmin_user_envs
 {
-local ($user, $d) = @_;
+my ($user, $d) = @_;
 if ($d) {
 	$ENV{'USERADMIN_DOM'} = $d->{'dom'};
 	}
@@ -20461,7 +20461,7 @@ if ($u->{'extraemail'}) {
 # return a list of just the address parts. Excludes un-qualified addresses
 sub extract_address_parts
 {
-local ($str) = @_;
+my ($str) = @_;
 &foreign_require("mailboxes");
 return grep { /^[^@ ]+\@[^@ ]+$/ }
 	    map { $_->[0] } &mailboxes::split_addresses($str);
@@ -20979,7 +20979,7 @@ return $rv;
 # Create the API helper for virtualmin core and all plugins
 sub create_virtualmin_api_helper_command
 {
-local @plugindirs = map { &module_root_directory($_) } @plugins;
+my @plugindirs = map { &module_root_directory($_) } @plugins;
 return &create_api_helper_command([ "$module_root_directory/pro",
 				    @plugindirs ]);
 }
@@ -20988,9 +20988,9 @@ return &create_api_helper_command([ "$module_root_directory/pro",
 # Call foreign_require on some or all plugins, just once
 sub load_plugin_libraries
 {
-local @load = @_;
+my @load = @_;
 @load = @plugins if (!@load);
-local $loaded = 0;
+my $loaded = 0;
 foreach my $pname (@load) {
 	if (!$main::done_load_plugin_libraries{$pname}++) {
 		if (&foreign_check($pname)) {
@@ -22004,7 +22004,7 @@ return @pairs ? $file . ( ($file =~ /\?/) ? '&' : '?' ) . join('&', @pairs)
 # Updates Virtualmin from the current GPL repo before repo switching
 sub upgrade_pro_upgrade_packages
 {
-local ($itype) = @_;
+my ($itype) = @_;
 if ($itype eq "deb") {
 	return &upgrade_deb_pro_upgrade_packages();
 	}
@@ -22097,7 +22097,7 @@ return $update ? &pro_upgrade_update_error($update) : undef;
 
 sub deb_installed_package_version
 {
-local ($name) = @_;
+my ($name) = @_;
 my $qname = quotemeta($name);
 my $version = `dpkg-query -W -f='\${Version}\\n' $qname 2>/dev/null`;
 chomp($version);
@@ -22106,7 +22106,7 @@ return $version;
 
 sub deb_candidate_package_version
 {
-local ($name) = @_;
+my ($name) = @_;
 my $qname = quotemeta($name);
 open(POLICY, "apt-cache policy $qname 2>/dev/null |");
 my $candidate;
@@ -22122,7 +22122,7 @@ return !$candidate || $candidate eq "(none)" ? undef : $candidate;
 
 sub rpm_package_installed
 {
-local ($name) = @_;
+my ($name) = @_;
 system("rpm -q ".quotemeta($name)." >/dev/null 2>&1");
 return $? ? 0 : 1;
 }

--- a/virtual-server-lib.pl
+++ b/virtual-server-lib.pl
@@ -101,7 +101,7 @@ foreach my $fname (@features, "virt", "virt6") {
 	if (!$done_feature_script{$fname} || $force_load_features) {
 		do "$module_root_directory/feature-$fname.pl";
 		}
-	local $ifunc = "init_$fname";
+	my $ifunc = "init_$fname";
 	&$ifunc() if (defined(&$ifunc));
 	}
 @migration_types = ( "cpanel", "plesk", "directadmin" );
@@ -411,7 +411,7 @@ $mail_system = $config{'mail_system'};
 # or given space-separated string.
 sub generate_plugins_list
 {
-local $str = defined($_[0]) ? $_[0] : $config{'plugins'};
+my $str = defined($_[0]) ? $_[0] : $config{'plugins'};
 @confplugins = split(/\s+/, $str);
 @plugins = ( );
 foreach my $pname (@confplugins) {

--- a/vui-lib.pl
+++ b/vui-lib.pl
@@ -5,8 +5,8 @@
 # them perform any onClick actions
 sub virtualmin_ui_apply_radios
 {
-local ($tag) = @_;
-local $rv = <<EOF;
+my ($tag) = @_;
+my $rv = <<EOF;
 for(i=0; i<document.forms.length; i++) {
   form = document.forms[i];
   for(j=0; j<form.elements.length; j++) {
@@ -31,14 +31,14 @@ sub virtualmin_ui_show_cron_time
 {
 return &theme_virtualmin_ui_show_cron_time(@_)
 	if (defined(&theme_virtualmin_ui_show_cron_time));
-local ($name, $job, $offmsg) = @_;
+my ($name, $job, $offmsg) = @_;
 &foreign_require("cron");
-local $rv;
-local $mode = !$job ? 0 : $job->{'special'} ? 1 : 2;
-local $complex = $mode == 2 ? &cron::when_text($job, 1) : undef;
+my $rv;
+my $mode = !$job ? 0 : $job->{'special'} ? 1 : 2;
+my $complex = $mode == 2 ? &cron::when_text($job, 1) : undef;
 my $modpref = &get_webprefix()."/".$module_name;
-local $button = "<input type=button onClick='cfield = form.${name}_complex; hfield = form.${name}_hidden; chooser = window.open(\"$modpref/cron_chooser.cgi?complex=\"+escape(hfield.value), \"cronchooser\", \"toolbar=no,menubar=no,scrollbars=no,resizable=yes,width=800,height=400\"); chooser.cfield = cfield; window.cfield = cfield; chooser.hfield = hfield; window.hfield = hfield;' value=\"...\">\n";
-local $hidden = $mode == 2 ?
+my $button = "<input type=button onClick='cfield = form.${name}_complex; hfield = form.${name}_hidden; chooser = window.open(\"$modpref/cron_chooser.cgi?complex=\"+escape(hfield.value), \"cronchooser\", \"toolbar=no,menubar=no,scrollbars=no,resizable=yes,width=800,height=400\"); chooser.cfield = cfield; window.cfield = cfield; chooser.hfield = hfield; window.hfield = hfield;' value=\"...\">\n";
+my $hidden = $mode == 2 ?
 	join(" ", $job->{'mins'}, $job->{'hours'},
 		  $job->{'days'}, $job->{'months'}, $job->{'weekdays'}) : "";
 my $complex_title = &quote_escape($complex || '', "'");
@@ -67,7 +67,7 @@ sub virtualmin_ui_parse_cron_time
 {
 return &theme_virtualmin_ui_parse_cron_time(@_)
 	if (defined(&theme_virtualmin_ui_parse_cron_time));
-local ($name, $job, $in) = @_;
+my ($name, $job, $in) = @_;
 if ($in{$name} == 0) {
 	# Disabled
 	return 0;
@@ -80,7 +80,7 @@ else {
 		}
 	else {
 		# Complex time
-		local @j = split(/\s+/, $in{$name."_hidden"});
+		my @j = split(/\s+/, $in{$name."_hidden"});
 		@j == 5 || &error($text{'cron_ehidden'});
 		$job->{'mins'} = $j[0];
 		$job->{'hours'} = $j[1];
@@ -109,8 +109,8 @@ sub virtualmin_ui_show_html_editor
 {
 return &theme_virtualmin_ui_show_html_editor(@_)
 	if (defined(&theme_virtualmin_ui_show_html_editor));
-local ($name, $html, $baseurl) = @_;
-local $rv;
+my ($name, $html, $baseurl) = @_;
+my $rv;
 
 if ($current_theme !~ /authentic-theme/) {
 

--- a/wizard-lib.pl
+++ b/wizard-lib.pl
@@ -35,7 +35,7 @@ sub wizard_show_memory
 {
 print &ui_table_row(undef, $text{'wizard_memory2'}. "<p></p>", 2);
 
-local $mem = &get_uname_arch() =~ /64/ ? "70M" : "35M";
+my $mem = &get_uname_arch() =~ /64/ ? "70M" : "35M";
 print &ui_table_row($text{'wizard_memory_lookup'},
 	&ui_radio("lookup", &check_lookup_domain_daemon(),
 		  [ [ 1, &text('wizard_memory_lookup1', $mem)."<br>" ],
@@ -45,11 +45,11 @@ print &ui_table_row($text{'wizard_memory_lookup'},
 # Enable or disable pre-loading and lookup-domain-daemon
 sub wizard_parse_memory
 {
-local ($in) = @_;
+my ($in) = @_;
 &push_all_print();
 &set_all_null_print();
 
-local $lud = &check_lookup_domain_daemon();
+my $lud = &check_lookup_domain_daemon();
 if ($in->{'lookup'} && !$lud) {
 	# Startup lookup daemon
 	&setup_lookup_domain_daemon();
@@ -69,7 +69,7 @@ return undef;
 sub wizard_show_virus
 {
 print &ui_table_row(undef, $text{'wizard_virusnew'} . "<p></p>", 2);
-local $cs = &check_clamd_status();
+my $cs = &check_clamd_status();
 if ($cs != -1) {
 	$cs = 2 if (!$cs && &get_global_virus_scanner() eq 'clamscan');
 	print &ui_table_row($text{'wizard_virusmsg'},
@@ -86,18 +86,18 @@ else {
 # Parse the clamd form, and enable or disable clamd
 sub wizard_parse_virus
 {
-local ($in) = @_;
+my ($in) = @_;
 if (defined($in->{'clamd'})) {
-	local $cs = &check_clamd_status();
+	my $cs = &check_clamd_status();
 	if ($in->{'clamd'} == 1 && !$cs) {
 		# Enable if needed
 		&push_all_print();
 		&set_all_null_print();
-		local $ok = &enable_clamd();
+		my $ok = &enable_clamd();
 		&pop_all_print();
 		if ($ok) {
 			# Switch to clamdscan, after testing
-			local $last_err;
+			my $last_err;
 			&foreign_require("init");
 			for(my $try=0; $try<20; $try++) {
 				$last_err = &test_virus_scanner("clamdscan");
@@ -155,7 +155,7 @@ return undef;
 sub wizard_show_spam
 {
 print &ui_table_row(undef, $text{'wizard_spam'} . "<p></p>", 2);
-local $cs = &check_spamd_status();
+my $cs = &check_spamd_status();
 if ($cs != -1) {
 	print &ui_table_row($text{'wizard_spamd'},
 		&ui_radio("spamd", $cs ? 1 : 0,
@@ -170,14 +170,14 @@ else {
 # Parse the spamd form, and enable or disable spamd
 sub wizard_parse_spam
 {
-local ($in) = @_;
+my ($in) = @_;
 if (defined($in->{'spamd'})) {
-	local $cs = &check_spamd_status();
+	my $cs = &check_spamd_status();
 	if ($in->{'spamd'} && !$cs) {
 		# Enable if needed
 		&push_all_print();
 		&set_all_null_print();
-		local $ok = &enable_spamd();
+		my $ok = &enable_spamd();
 		&pop_all_print();
 		if ($ok) {
 			# Switch to spamc
@@ -212,7 +212,7 @@ print &ui_table_row($text{'wizard_db_postgres'},
 # Enable or disable MySQL and PostgreSQL, depending on user's selections
 sub wizard_parse_db
 {
-local ($in) = @_;
+my ($in) = @_;
 &foreign_require("init");
 
 &require_mysql();
@@ -223,7 +223,7 @@ if ($in->{'mysql'}) {
 		}
 	$config{'mysql'} ||= 1;
 	if (&mysql::is_mysql_running() == 0) {
-		local $err = &mysql::start_mysql();
+		my $err = &mysql::start_mysql();
 		return &text('wizard_emysqlstart', $err) if ($err);
 		}
 	if (&init::action_status("mysql")) {
@@ -251,7 +251,7 @@ if ($in->{'postgres'}) {
 	&require_postgres();
 	$config{'postgres'} ||= 1;
 	if (&postgresql::is_postgresql_running() == 0) {
-		local $err = &postgresql::start_postgresql();
+		my $err = &postgresql::start_postgresql();
 		return &text('wizard_epostgresstart', $err) if ($err);
 		}
 	if (&init::action_status("postgresql")) {
@@ -342,9 +342,9 @@ else {
 # Set the MySQL password, if changed
 sub wizard_parse_mysql
 {
-local ($in) = @_;
+my ($in) = @_;
 &require_mysql();
-local $user = $mysql::mysql_login || 'root';
+my $user = $mysql::mysql_login || 'root';
 if ($in->{'socket'} && !$in->{'mypass'}) {
 	# Socket auth with no password. Check if we actually have socket plugin,
 	# and not just empty password
@@ -355,7 +355,7 @@ if ($in->{'socket'} && !$in->{'mypass'}) {
 		}
 	return undef;
 	}
-local $pass = $in->{'mypass_def'} ? $mysql::mysql_pass : $in->{'mypass'};
+my $pass = $in->{'mypass_def'} ? $mysql::mysql_pass : $in->{'mypass'};
 if ($in->{'needchange'}) {
 	# Change the password used by subsequent code to validate that it works
 	$mysql::mysql_pass = $pass;
@@ -411,10 +411,10 @@ sub wizard_show_dns
 print &ui_table_row(undef, $text{'wizard_dns'} . "<p></p>", 2);
 
 # Primary nameserver
-local $tmpl = &get_template(0);
-local $tmaster = $tmpl->{'dns_master'} eq 'none' ? undef
+my $tmpl = &get_template(0);
+my $tmaster = $tmpl->{'dns_master'} eq 'none' ? undef
 						 : $tmpl->{'dns_master'};
-local $master = $tmaster ||
+my $master = $tmaster ||
 		$bconfig{'default_prins'} ||
 		&get_system_hostname();
 print &ui_table_row($text{'wizard_dns_prins'},
@@ -423,7 +423,7 @@ print &ui_table_row($text{'wizard_dns_prins'},
 				 $config{'prins_skip'}));
 
 # Secondaries (optional)
-local @secns = split(/\s+/, $tmpl->{'dns_ns'});
+my @secns = split(/\s+/, $tmpl->{'dns_ns'});
 print &ui_table_row($text{'wizard_dns_secns'},
 		    &ui_textarea("secns", join("", map { "$_\n" } @secns),
 				 4, 40));
@@ -431,17 +431,17 @@ print &ui_table_row($text{'wizard_dns_secns'},
 
 sub wizard_parse_dns
 {
-local ($in) = @_;
+my ($in) = @_;
 &require_bind();
-local @tmpls = &list_templates();
-local ($tmpl) = grep { $_->{'id'} eq '0' } @tmpls;
+my @tmpls = &list_templates();
+my ($tmpl) = grep { $_->{'id'} eq '0' } @tmpls;
 $tmpl || return $text{'wizard_etmpl0'};
 
 # Validate primary NS
 $in->{'prins'} =~ /^[a-z0-9\.\_\-]+$/i || return $text{'wizard_dns_eprins'};
 if (!$in->{'prins_skip'}) {
 	&to_ipaddress($in->{'prins'}) || return $text{'wizard_dns_eprins2'};
-	local ($ok, $msg) = &check_resolvability($in->{'prins'});
+	my ($ok, $msg) = &check_resolvability($in->{'prins'});
 	if (!$ok) {
 		return &text('wizard_dns_eprins3', $msg);
 		}
@@ -450,12 +450,12 @@ $tmpl->{'dns_master'} = $in->{'prins'};
 &save_template($tmpl);
 
 # Validate any secondary NSs
-local @secns;
+my @secns;
 foreach my $ns (split(/\s+/, $in->{'secns'})) {
 	$ns =~ /^[a-z0-9\.\_\-]+$/i || return &text('wizard_dns_esecns', $ns);
 	if (!$in->{'prins_skip'}) {
 		&to_ipaddress($ns) || return &text('wizard_dns_esecns2', $ns);
-		local ($ok, $msg) = &check_resolvability($ns);
+		my ($ok, $msg) = &check_resolvability($ns);
 		if (!$ok) {
 			return &text('wizard_dns_esecns3', $ns, $msg);
 			}
@@ -491,7 +491,7 @@ print &ui_table_row($text{'wizard_to_addr'},
 
 sub wizard_parse_email
 {
-local ($in) = @_;
+my ($in) = @_;
 
 &lock_file($module_config_file);
 if ($in->{'from_addr_def'}) {
@@ -528,7 +528,7 @@ sub get_real_memory_size
 return undef if (!&foreign_check("proc"));
 &foreign_require("proc");
 return undef if (!defined(&proc::get_memory_info));
-local ($real) = &proc::get_memory_info();
+my ($real) = &proc::get_memory_info();
 return $real * 1024;
 }
 
@@ -536,7 +536,7 @@ return $real * 1024;
 # Returns the architecture, like x86_64 or i386
 sub get_uname_arch
 {
-local $out = &backquote_command("uname -m");
+my $out = &backquote_command("uname -m");
 $out =~ s/\s+//g;
 return $out;
 }


### PR DESCRIPTION
Hello Jamie!

This PR replaces `local` declarations that were being used as ordinary temporary variables with lexical `my` declarations.

The change preserves `local` where dynamic scoping is required, including package globals, special Perl variables, signal/environment localization, `%access`, and callback-visible context variables.