### PR TITLE
Fix to use FindBin for script path resolution

### DIFF
--- a/backup-domain.pl
+++ b/backup-domain.pl
@@ -94,12 +94,9 @@ if (!$module_name) {
 	$main::no_acl_check++;
 	$ENV{'WEBMIN_CONFIG'} ||= "/etc/webmin";
 	$ENV{'WEBMIN_VAR'} ||= "/var/webmin";
-	if ($0 =~ /^(.*)\/[^\/]+$/) {
-		chdir($pwd = $1);
-		}
-	else {
-		chop($pwd = `pwd`);
-		}
+	require FindBin;
+	chdir($pwd = $FindBin::RealBin) ||
+		die "Failed to chdir to $FindBin::RealBin : $!";
 	$0 = "$pwd/backup-domain.pl";
 	require './virtual-server-lib.pl';
 	$< == 0 || die "backup-domain.pl must be run as root";

--- a/change-licence.pl
+++ b/change-licence.pl
@@ -18,12 +18,9 @@ if (!$module_name) {
 	$main::no_acl_check++;
 	$ENV{'WEBMIN_CONFIG'} ||= "/etc/webmin";
 	$ENV{'WEBMIN_VAR'} ||= "/var/webmin";
-	if ($0 =~ /^(.*)\/[^\/]+$/) {
-		chdir($pwd = $1);
-		}
-	else {
-		chop($pwd = `pwd`);
-		}
+	require FindBin;
+	chdir($pwd = $FindBin::RealBin) ||
+		die "Failed to chdir to $FindBin::RealBin : $!";
 	$0 = "$pwd/change-licence.pl";
 	require './virtual-server-lib.pl';
 	require './virtualmin-licence.pl';

--- a/change-password.pl
+++ b/change-password.pl
@@ -13,12 +13,9 @@ instead.
 $no_acl_check++;
 $ENV{'WEBMIN_CONFIG'} ||= "/etc/webmin";
 $ENV{'WEBMIN_VAR'} ||= "/var/webmin";
-if ($0 =~ /^(.*)\/[^\/]+$/) {
-	chdir($pwd = $1);
-	}
-else {
-	chop($pwd = `pwd`);
-	}
+require FindBin;
+chdir($pwd = $FindBin::RealBin) ||
+	die "Failed to chdir to $FindBin::RealBin : $!";
 $0 = "$pwd/change-password.pl";
 require './virtual-server-lib.pl';
 $< == 0 || die "change-password.pl must be run as root";

--- a/check-config.pl
+++ b/check-config.pl
@@ -18,12 +18,9 @@ if (!$module_name) {
 	$main::no_acl_check++;
 	$ENV{'WEBMIN_CONFIG'} ||= "/etc/webmin";
 	$ENV{'WEBMIN_VAR'} ||= "/var/webmin";
-	if ($0 =~ /^(.*)\/[^\/]+$/) {
-		chdir($pwd = $1);
-		}
-	else {
-		chop($pwd = `pwd`);
-		}
+	require FindBin;
+	chdir($pwd = $FindBin::RealBin) ||
+		die "Failed to chdir to $FindBin::RealBin : $!";
 	$0 = "$pwd/check-scripts.pl";
 	require './virtual-server-lib.pl';
 	$< == 0 || die "check-scripts.pl must be run as root";

--- a/check-scripts.pl
+++ b/check-scripts.pl
@@ -15,12 +15,9 @@ if (!$module_name) {
 	$main::no_acl_check++;
 	$ENV{'WEBMIN_CONFIG'} ||= "/etc/webmin";
 	$ENV{'WEBMIN_VAR'} ||= "/var/webmin";
-	if ($0 =~ /^(.*)\/[^\/]+$/) {
-		chdir($pwd = $1);
-		}
-	else {
-		chop($pwd = `pwd`);
-		}
+	require FindBin;
+	chdir($pwd = $FindBin::RealBin) ||
+		die "Failed to chdir to $FindBin::RealBin : $!";
 	$0 = "$pwd/check-scripts.pl";
 	require './virtual-server-lib.pl';
 	$< == 0 || die "check-scripts.pl must be run as root";

--- a/clone-domain.pl
+++ b/clone-domain.pl
@@ -32,12 +32,9 @@ if (!$module_name) {
 	$main::no_acl_check++;
 	$ENV{'WEBMIN_CONFIG'} ||= "/etc/webmin";
 	$ENV{'WEBMIN_VAR'} ||= "/var/webmin";
-	if ($0 =~ /^(.*)\/[^\/]+$/) {
-		chdir($pwd = $1);
-		}
-	else {
-		chop($pwd = `pwd`);
-		}
+	require FindBin;
+	chdir($pwd = $FindBin::RealBin) ||
+		die "Failed to chdir to $FindBin::RealBin : $!";
 	$0 = "$pwd/clone-domain.pl";
 	require './virtual-server-lib.pl';
 	$< == 0 || die "clone-domain.pl must be run as root";

--- a/configure-all-scripts.pl
+++ b/configure-all-scripts.pl
@@ -21,12 +21,9 @@ if (!$module_name) {
 	$main::no_acl_check++;
 	$ENV{'WEBMIN_CONFIG'} ||= "/etc/webmin";
 	$ENV{'WEBMIN_VAR'} ||= "/var/webmin";
-	if ($0 =~ /^(.*)\/[^\/]+$/) {
-		chdir($pwd = $1);
-		}
-	else {
-		chop($pwd = `pwd`);
-		}
+	require FindBin;
+	chdir($pwd = $FindBin::RealBin) ||
+		die "Failed to chdir to $FindBin::RealBin : $!";
 	$0 = "$pwd/configure-all-scripts.pl";
 	require './virtual-server-lib.pl';
 	}

--- a/configure-script.pl
+++ b/configure-script.pl
@@ -20,12 +20,9 @@ if (!$module_name) {
 	$main::no_acl_check++;
 	$ENV{'WEBMIN_CONFIG'} ||= "/etc/webmin";
 	$ENV{'WEBMIN_VAR'} ||= "/var/webmin";
-	if ($0 =~ /^(.*)\/[^\/]+$/) {
-		chdir($pwd = $1);
-		}
-	else {
-		chop($pwd = `pwd`);
-		}
+	require FindBin;
+	chdir($pwd = $FindBin::RealBin) ||
+		die "Failed to chdir to $FindBin::RealBin : $!";
 	$0 = "$pwd/configure-script.pl";
 	require './virtual-server-lib.pl';
 	}

--- a/copy-mailbox.pl
+++ b/copy-mailbox.pl
@@ -18,12 +18,9 @@ if (!$module_name) {
 	$main::no_acl_check++;
 	$ENV{'WEBMIN_CONFIG'} ||= "/etc/webmin";
 	$ENV{'WEBMIN_VAR'} ||= "/var/webmin";
-	if ($0 =~ /^(.*)\/[^\/]+$/) {
-		chdir($pwd = $1);
-		}
-	else {
-		chop($pwd = `pwd`);
-		}
+	require FindBin;
+	chdir($pwd = $FindBin::RealBin) ||
+		die "Failed to chdir to $FindBin::RealBin : $!";
 	$0 = "$pwd/copy-mailbox.pl";
 	require './virtual-server-lib.pl';
 	$< == 0 || die "list-mailbox.pl must be run as root";

--- a/create-admin.pl
+++ b/create-admin.pl
@@ -43,12 +43,9 @@ if (!$module_name) {
 	$main::no_acl_check++;
 	$ENV{'WEBMIN_CONFIG'} ||= "/etc/webmin";
 	$ENV{'WEBMIN_VAR'} ||= "/var/webmin";
-	if ($0 =~ /^(.*)\/[^\/]+$/) {
-		chdir($pwd = $1);
-		}
-	else {
-		chop($pwd = `pwd`);
-		}
+	require FindBin;
+	chdir($pwd = $FindBin::RealBin) ||
+		die "Failed to chdir to $FindBin::RealBin : $!";
 	$0 = "$pwd/create-admin.pl";
 	require './virtual-server-lib.pl';
 	$< == 0 || die "create-admin.pl must be run as root";

--- a/create-alias.pl
+++ b/create-alias.pl
@@ -32,12 +32,9 @@ if (!$module_name) {
 	$main::no_acl_check++;
 	$ENV{'WEBMIN_CONFIG'} ||= "/etc/webmin";
 	$ENV{'WEBMIN_VAR'} ||= "/var/webmin";
-	if ($0 =~ /^(.*)\/[^\/]+$/) {
-		chdir($pwd = $1);
-		}
-	else {
-		chop($pwd = `pwd`);
-		}
+	require FindBin;
+	chdir($pwd = $FindBin::RealBin) ||
+		die "Failed to chdir to $FindBin::RealBin : $!";
 	$0 = "$pwd/create-alias.pl";
 	require './virtual-server-lib.pl';
 	$< == 0 || die "create-alias.pl must be run as root";

--- a/create-database.pl
+++ b/create-database.pl
@@ -27,12 +27,9 @@ if (!$module_name) {
 	$main::no_acl_check++;
 	$ENV{'WEBMIN_CONFIG'} ||= "/etc/webmin";
 	$ENV{'WEBMIN_VAR'} ||= "/var/webmin";
-	if ($0 =~ /^(.*)\/[^\/]+$/) {
-		chdir($pwd = $1);
-		}
-	else {
-		chop($pwd = `pwd`);
-		}
+	require FindBin;
+	chdir($pwd = $FindBin::RealBin) ||
+		die "Failed to chdir to $FindBin::RealBin : $!";
 	$0 = "$pwd/create-database.pl";
 	require './virtual-server-lib.pl';
 	$< == 0 || die "create-database.pl must be run as root";

--- a/create-domain.pl
+++ b/create-domain.pl
@@ -104,12 +104,9 @@ if (!$module_name) {
 	$main::no_acl_check++;
 	$ENV{'WEBMIN_CONFIG'} ||= "/etc/webmin";
 	$ENV{'WEBMIN_VAR'} ||= "/var/webmin";
-	if ($0 =~ /^(.*)\/[^\/]+$/) {
-		chdir($pwd = $1);
-		}
-	else {
-		chop($pwd = `pwd`);
-		}
+	require FindBin;
+	chdir($pwd = $FindBin::RealBin) ||
+		die "Failed to chdir to $FindBin::RealBin : $!";
 	$0 = "$pwd/create-domain.pl";
 	require './virtual-server-lib.pl';
 	$< == 0 || die "create-domain.pl must be run as root";

--- a/create-login-link.pl
+++ b/create-login-link.pl
@@ -25,12 +25,9 @@ if (!$module_name) {
 	$main::no_acl_check++;
 	$ENV{'WEBMIN_CONFIG'} ||= "/etc/webmin";
 	$ENV{'WEBMIN_VAR'} ||= "/var/webmin";
-	if ($0 =~ /^(.*)\/[^\/]+$/) {
-		chdir($pwd = $1);
-		}
-	else {
-		chop($pwd = `pwd`);
-		}
+	require FindBin;
+	chdir($pwd = $FindBin::RealBin) ||
+		die "Failed to chdir to $FindBin::RealBin : $!";
 	$0 = "$pwd/create-login-link.pl";
 	require './virtual-server-lib.pl';
 	$< == 0 || die "create-login-link.pl must be run as root";

--- a/create-plan.pl
+++ b/create-plan.pl
@@ -40,12 +40,9 @@ if (!$module_name) {
 	$main::no_acl_check++;
 	$ENV{'WEBMIN_CONFIG'} ||= "/etc/webmin";
 	$ENV{'WEBMIN_VAR'} ||= "/var/webmin";
-	if ($0 =~ /^(.*)\/[^\/]+$/) {
-		chdir($pwd = $1);
-		}
-	else {
-		chop($pwd = `pwd`);
-		}
+	require FindBin;
+	chdir($pwd = $FindBin::RealBin) ||
+		die "Failed to chdir to $FindBin::RealBin : $!";
 	$0 = "$pwd/create-plan.pl";
 	require './virtual-server-lib.pl';
 	$< == 0 || die "create-plan.pl must be run as root";

--- a/create-proxy.pl
+++ b/create-proxy.pl
@@ -31,12 +31,9 @@ if (!$module_name) {
 	$main::no_acl_check++;
 	$ENV{'WEBMIN_CONFIG'} ||= "/etc/webmin";
 	$ENV{'WEBMIN_VAR'} ||= "/var/webmin";
-	if ($0 =~ /^(.*)\/[^\/]+$/) {
-		chdir($pwd = $1);
-		}
-	else {
-		chop($pwd = `pwd`);
-		}
+	require FindBin;
+	chdir($pwd = $FindBin::RealBin) ||
+		die "Failed to chdir to $FindBin::RealBin : $!";
 	$0 = "$pwd/create-proxy.pl";
 	require './virtual-server-lib.pl';
 	$< == 0 || die "create-proxy.pl must be run as root";

--- a/create-redirect.pl
+++ b/create-redirect.pl
@@ -53,12 +53,9 @@ if (!$module_name) {
 	$main::no_acl_check++;
 	$ENV{'WEBMIN_CONFIG'} ||= "/etc/webmin";
 	$ENV{'WEBMIN_VAR'} ||= "/var/webmin";
-	if ($0 =~ /^(.*)\/[^\/]+$/) {
-		chdir($pwd = $1);
-		}
-	else {
-		chop($pwd = `pwd`);
-		}
+	require FindBin;
+	chdir($pwd = $FindBin::RealBin) ||
+		die "Failed to chdir to $FindBin::RealBin : $!";
 	$0 = "$pwd/create-redirect.pl";
 	require './virtual-server-lib.pl';
 	$< == 0 || die "create-redirect.pl must be run as root";

--- a/create-rs-container.pl
+++ b/create-rs-container.pl
@@ -19,12 +19,9 @@ if (!$module_name) {
 	$main::no_acl_check++;
 	$ENV{'WEBMIN_CONFIG'} ||= "/etc/webmin";
 	$ENV{'WEBMIN_VAR'} ||= "/var/webmin";
-	if ($0 =~ /^(.*)\/[^\/]+$/) {
-		chdir($pwd = $1);
-		}
-	else {
-		chop($pwd = `pwd`);
-		}
+	require FindBin;
+	chdir($pwd = $FindBin::RealBin) ||
+		die "Failed to chdir to $FindBin::RealBin : $!";
 	$0 = "$pwd/create-rs-container.pl";
 	require './virtual-server-lib.pl';
 	$< == 0 || die "create-rs-container.pl must be run as root";

--- a/create-s3-bucket.pl
+++ b/create-s3-bucket.pl
@@ -16,12 +16,9 @@ if (!$module_name) {
 	$main::no_acl_check++;
 	$ENV{'WEBMIN_CONFIG'} ||= "/etc/webmin";
 	$ENV{'WEBMIN_VAR'} ||= "/var/webmin";
-	if ($0 =~ /^(.*)\/[^\/]+$/) {
-		chdir($pwd = $1);
-		}
-	else {
-		chop($pwd = `pwd`);
-		}
+	require FindBin;
+	chdir($pwd = $FindBin::RealBin) ||
+		die "Failed to chdir to $FindBin::RealBin : $!";
 	$0 = "$pwd/create-s3-bucket.pl";
 	require './virtual-server-lib.pl';
 	$< == 0 || die "create-s3-bucket.pl must be run as root";

--- a/create-scheduled-backup.pl
+++ b/create-scheduled-backup.pl
@@ -98,12 +98,9 @@ if (!$module_name) {
 	$main::no_acl_check++;
 	$ENV{'WEBMIN_CONFIG'} ||= "/etc/webmin";
 	$ENV{'WEBMIN_VAR'} ||= "/var/webmin";
-	if ($0 =~ /^(.*)\/[^\/]+$/) {
-		chdir($pwd = $1);
-		}
-	else {
-		chop($pwd = `pwd`);
-		}
+	require FindBin;
+	chdir($pwd = $FindBin::RealBin) ||
+		die "Failed to chdir to $FindBin::RealBin : $!";
 	$0 = "$pwd/create-scheduled-backup.pl";
 	require './virtual-server-lib.pl';
 	$< == 0 || die "create-scheduled-backup.pl must be run as root";

--- a/create-shared-address.pl
+++ b/create-shared-address.pl
@@ -20,12 +20,9 @@ if (!$module_name) {
 	$main::no_acl_check++;
 	$ENV{'WEBMIN_CONFIG'} ||= "/etc/webmin";
 	$ENV{'WEBMIN_VAR'} ||= "/var/webmin";
-	if ($0 =~ /^(.*)\/[^\/]+$/) {
-		chdir($pwd = $1);
-		}
-	else {
-		chop($pwd = `pwd`);
-		}
+	require FindBin;
+	chdir($pwd = $FindBin::RealBin) ||
+		die "Failed to chdir to $FindBin::RealBin : $!";
 	$0 = "$pwd/create-shared-address.pl";
 	require './virtual-server-lib.pl';
 	$< == 0 || die "create-shared-address.pl must be run as root";

--- a/create-simple-alias.pl
+++ b/create-simple-alias.pl
@@ -37,12 +37,9 @@ if (!$module_name) {
 	$main::no_acl_check++;
 	$ENV{'WEBMIN_CONFIG'} ||= "/etc/webmin";
 	$ENV{'WEBMIN_VAR'} ||= "/var/webmin";
-	if ($0 =~ /^(.*)\/[^\/]+$/) {
-		chdir($pwd = $1);
-		}
-	else {
-		chop($pwd = `pwd`);
-		}
+	require FindBin;
+	chdir($pwd = $FindBin::RealBin) ||
+		die "Failed to chdir to $FindBin::RealBin : $!";
 	$0 = "$pwd/create-simple-alias.pl";
 	require './virtual-server-lib.pl';
 	$< == 0 || die "create-simple-alias.pl must be run as root";

--- a/create-template.pl
+++ b/create-template.pl
@@ -17,12 +17,9 @@ if (!$module_name) {
 	$main::no_acl_check++;
 	$ENV{'WEBMIN_CONFIG'} ||= "/etc/webmin";
 	$ENV{'WEBMIN_VAR'} ||= "/var/webmin";
-	if ($0 =~ /^(.*)\/[^\/]+$/) {
-		chdir($pwd = $1);
-		}
-	else {
-		chop($pwd = `pwd`);
-		}
+	require FindBin;
+	chdir($pwd = $FindBin::RealBin) ||
+		die "Failed to chdir to $FindBin::RealBin : $!";
 	$0 = "$pwd/create-template.pl";
 	require './virtual-server-lib.pl';
 	$< == 0 || die "create-template.pl must be run as root";

--- a/create-user.pl
+++ b/create-user.pl
@@ -71,12 +71,9 @@ if (!$module_name) {
 	$main::no_acl_check++;
 	$ENV{'WEBMIN_CONFIG'} ||= "/etc/webmin";
 	$ENV{'WEBMIN_VAR'} ||= "/var/webmin";
-	if ($0 =~ /^(.*)\/[^\/]+$/) {
-		chdir($pwd = $1);
-		}
-	else {
-		chop($pwd = `pwd`);
-		}
+	require FindBin;
+	chdir($pwd = $FindBin::RealBin) ||
+		die "Failed to chdir to $FindBin::RealBin : $!";
 	$0 = "$pwd/create-user.pl";
 	require './virtual-server-lib.pl';
 	$< == 0 || die "create-user.pl must be run as root";

--- a/delete-admin.pl
+++ b/delete-admin.pl
@@ -15,12 +15,9 @@ if (!$module_name) {
 	$main::no_acl_check++;
 	$ENV{'WEBMIN_CONFIG'} ||= "/etc/webmin";
 	$ENV{'WEBMIN_VAR'} ||= "/var/webmin";
-	if ($0 =~ /^(.*)\/[^\/]+$/) {
-		chdir($pwd = $1);
-		}
-	else {
-		chop($pwd = `pwd`);
-		}
+	require FindBin;
+	chdir($pwd = $FindBin::RealBin) ||
+		die "Failed to chdir to $FindBin::RealBin : $!";
 	$0 = "$pwd/delete-admin.pl";
 	require './virtual-server-lib.pl';
 	$< == 0 || die "delete-admin.pl must be run as root";

--- a/delete-alias.pl
+++ b/delete-alias.pl
@@ -21,12 +21,9 @@ if (!$module_name) {
 	$main::no_acl_check++;
 	$ENV{'WEBMIN_CONFIG'} ||= "/etc/webmin";
 	$ENV{'WEBMIN_VAR'} ||= "/var/webmin";
-	if ($0 =~ /^(.*)\/[^\/]+$/) {
-		chdir($pwd = $1);
-		}
-	else {
-		chop($pwd = `pwd`);
-		}
+	require FindBin;
+	chdir($pwd = $FindBin::RealBin) ||
+		die "Failed to chdir to $FindBin::RealBin : $!";
 	$0 = "$pwd/delete-alias.pl";
 	require './virtual-server-lib.pl';
 	$< == 0 || die "delete-alias.pl must be run as root";

--- a/delete-backup.pl
+++ b/delete-backup.pl
@@ -16,12 +16,9 @@ if (!$module_name) {
 	$main::no_acl_check++;
 	$ENV{'WEBMIN_CONFIG'} ||= "/etc/webmin";
 	$ENV{'WEBMIN_VAR'} ||= "/var/webmin";
-	if ($0 =~ /^(.*)\/[^\/]+$/) {
-		chdir($pwd = $1);
-		}
-	else {
-		chop($pwd = `pwd`);
-		}
+	require FindBin;
+	chdir($pwd = $FindBin::RealBin) ||
+		die "Failed to chdir to $FindBin::RealBin : $!";
 	$0 = "$pwd/delete-backup.pl";
 	require './virtual-server-lib.pl';
 	$< == 0 || die "delete-backup.pl must be run as root";

--- a/delete-database.pl
+++ b/delete-database.pl
@@ -16,12 +16,9 @@ if (!$module_name) {
 	$main::no_acl_check++;
 	$ENV{'WEBMIN_CONFIG'} ||= "/etc/webmin";
 	$ENV{'WEBMIN_VAR'} ||= "/var/webmin";
-	if ($0 =~ /^(.*)\/[^\/]+$/) {
-		chdir($pwd = $1);
-		}
-	else {
-		chop($pwd = `pwd`);
-		}
+	require FindBin;
+	chdir($pwd = $FindBin::RealBin) ||
+		die "Failed to chdir to $FindBin::RealBin : $!";
 	$0 = "$pwd/delete-database.pl";
 	require './virtual-server-lib.pl';
 	$< == 0 || die "delete-database.pl must be run as root";

--- a/delete-domain.pl
+++ b/delete-domain.pl
@@ -26,12 +26,9 @@ if (!$module_name) {
 	$main::no_acl_check++;
 	$ENV{'WEBMIN_CONFIG'} ||= "/etc/webmin";
 	$ENV{'WEBMIN_VAR'} ||= "/var/webmin";
-	if ($0 =~ /^(.*)\/[^\/]+$/) {
-		chdir($pwd = $1);
-		}
-	else {
-		chop($pwd = `pwd`);
-		}
+	require FindBin;
+	chdir($pwd = $FindBin::RealBin) ||
+		die "Failed to chdir to $FindBin::RealBin : $!";
 	$0 = "$pwd/delete-domain.pl";
 	require './virtual-server-lib.pl';
 	$< == 0 || die "delete-domain.pl must be run as root";

--- a/delete-php-directory.pl
+++ b/delete-php-directory.pl
@@ -16,12 +16,9 @@ if (!$module_name) {
 	$main::no_acl_check++;
 	$ENV{'WEBMIN_CONFIG'} ||= "/etc/webmin";
 	$ENV{'WEBMIN_VAR'} ||= "/var/webmin";
-	if ($0 =~ /^(.*)\/[^\/]+$/) {
-		chdir($pwd = $1);
-		}
-	else {
-		chop($pwd = `pwd`);
-		}
+	require FindBin;
+	chdir($pwd = $FindBin::RealBin) ||
+		die "Failed to chdir to $FindBin::RealBin : $!";
 	$0 = "$pwd/delete-php-directory.pl";
 	require './virtual-server-lib.pl';
 	$< == 0 || die "delete-php-directory.pl must be run as root";

--- a/delete-plan.pl
+++ b/delete-plan.pl
@@ -17,12 +17,9 @@ if (!$module_name) {
 	$main::no_acl_check++;
 	$ENV{'WEBMIN_CONFIG'} ||= "/etc/webmin";
 	$ENV{'WEBMIN_VAR'} ||= "/var/webmin";
-	if ($0 =~ /^(.*)\/[^\/]+$/) {
-		chdir($pwd = $1);
-		}
-	else {
-		chop($pwd = `pwd`);
-		}
+	require FindBin;
+	chdir($pwd = $FindBin::RealBin) ||
+		die "Failed to chdir to $FindBin::RealBin : $!";
 	$0 = "$pwd/delete-plan.pl";
 	require './virtual-server-lib.pl';
 	$< == 0 || die "delete-plan.pl must be run as root";

--- a/delete-proxy.pl
+++ b/delete-proxy.pl
@@ -16,12 +16,9 @@ if (!$module_name) {
 	$main::no_acl_check++;
 	$ENV{'WEBMIN_CONFIG'} ||= "/etc/webmin";
 	$ENV{'WEBMIN_VAR'} ||= "/var/webmin";
-	if ($0 =~ /^(.*)\/[^\/]+$/) {
-		chdir($pwd = $1);
-		}
-	else {
-		chop($pwd = `pwd`);
-		}
+	require FindBin;
+	chdir($pwd = $FindBin::RealBin) ||
+		die "Failed to chdir to $FindBin::RealBin : $!";
 	$0 = "$pwd/delete-proxy.pl";
 	require './virtual-server-lib.pl';
 	$< == 0 || die "delete-proxy.pl must be run as root";

--- a/delete-redirect.pl
+++ b/delete-redirect.pl
@@ -18,12 +18,9 @@ if (!$module_name) {
 	$main::no_acl_check++;
 	$ENV{'WEBMIN_CONFIG'} ||= "/etc/webmin";
 	$ENV{'WEBMIN_VAR'} ||= "/var/webmin";
-	if ($0 =~ /^(.*)\/[^\/]+$/) {
-		chdir($pwd = $1);
-		}
-	else {
-		chop($pwd = `pwd`);
-		}
+	require FindBin;
+	chdir($pwd = $FindBin::RealBin) ||
+		die "Failed to chdir to $FindBin::RealBin : $!";
 	$0 = "$pwd/delete-redirect.pl";
 	require './virtual-server-lib.pl';
 	$< == 0 || die "delete-redirect.pl must be run as root";

--- a/delete-rs-container.pl
+++ b/delete-rs-container.pl
@@ -20,12 +20,9 @@ if (!$module_name) {
 	$main::no_acl_check++;
 	$ENV{'WEBMIN_CONFIG'} ||= "/etc/webmin";
 	$ENV{'WEBMIN_VAR'} ||= "/var/webmin";
-	if ($0 =~ /^(.*)\/[^\/]+$/) {
-		chdir($pwd = $1);
-		}
-	else {
-		chop($pwd = `pwd`);
-		}
+	require FindBin;
+	chdir($pwd = $FindBin::RealBin) ||
+		die "Failed to chdir to $FindBin::RealBin : $!";
 	$0 = "$pwd/delete-rs-container.pl";
 	require './virtual-server-lib.pl';
 	$< == 0 || die "delete-rs-container.pl must be run as root";

--- a/delete-rs-file.pl
+++ b/delete-rs-file.pl
@@ -18,12 +18,9 @@ if (!$module_name) {
 	$main::no_acl_check++;
 	$ENV{'WEBMIN_CONFIG'} ||= "/etc/webmin";
 	$ENV{'WEBMIN_VAR'} ||= "/var/webmin";
-	if ($0 =~ /^(.*)\/[^\/]+$/) {
-		chdir($pwd = $1);
-		}
-	else {
-		chop($pwd = `pwd`);
-		}
+	require FindBin;
+	chdir($pwd = $FindBin::RealBin) ||
+		die "Failed to chdir to $FindBin::RealBin : $!";
 	$0 = "$pwd/delete-rs-file.pl";
 	require './virtual-server-lib.pl';
 	$< == 0 || die "delete-rs-file.pl must be run as root";

--- a/delete-s3-bucket.pl
+++ b/delete-s3-bucket.pl
@@ -18,12 +18,9 @@ if (!$module_name) {
 	$main::no_acl_check++;
 	$ENV{'WEBMIN_CONFIG'} ||= "/etc/webmin";
 	$ENV{'WEBMIN_VAR'} ||= "/var/webmin";
-	if ($0 =~ /^(.*)\/[^\/]+$/) {
-		chdir($pwd = $1);
-		}
-	else {
-		chop($pwd = `pwd`);
-		}
+	require FindBin;
+	chdir($pwd = $FindBin::RealBin) ||
+		die "Failed to chdir to $FindBin::RealBin : $!";
 	$0 = "$pwd/delete-s3-bucket.pl";
 	require './virtual-server-lib.pl';
 	$< == 0 || die "delete-s3-bucket.pl must be run as root";

--- a/delete-s3-file.pl
+++ b/delete-s3-file.pl
@@ -18,12 +18,9 @@ if (!$module_name) {
 	$main::no_acl_check++;
 	$ENV{'WEBMIN_CONFIG'} ||= "/etc/webmin";
 	$ENV{'WEBMIN_VAR'} ||= "/var/webmin";
-	if ($0 =~ /^(.*)\/[^\/]+$/) {
-		chdir($pwd = $1);
-		}
-	else {
-		chop($pwd = `pwd`);
-		}
+	require FindBin;
+	chdir($pwd = $FindBin::RealBin) ||
+		die "Failed to chdir to $FindBin::RealBin : $!";
 	$0 = "$pwd/delete-s3-file.pl";
 	require './virtual-server-lib.pl';
 	$< == 0 || die "delete-s3-file.pl must be run as root";

--- a/delete-scheduled-backup.pl
+++ b/delete-scheduled-backup.pl
@@ -18,12 +18,9 @@ if (!$module_name) {
 	$main::no_acl_check++;
 	$ENV{'WEBMIN_CONFIG'} ||= "/etc/webmin";
 	$ENV{'WEBMIN_VAR'} ||= "/var/webmin";
-	if ($0 =~ /^(.*)\/[^\/]+$/) {
-		chdir($pwd = $1);
-		}
-	else {
-		chop($pwd = `pwd`);
-		}
+	require FindBin;
+	chdir($pwd = $FindBin::RealBin) ||
+		die "Failed to chdir to $FindBin::RealBin : $!";
 	$0 = "$pwd/delete-scheduled-backup.pl";
 	require './virtual-server-lib.pl';
 	$< == 0 || die "delete-scheduled-backup.pl must be run as root";

--- a/delete-script.pl
+++ b/delete-script.pl
@@ -23,12 +23,9 @@ if (!$module_name) {
 	$main::no_acl_check++;
 	$ENV{'WEBMIN_CONFIG'} ||= "/etc/webmin";
 	$ENV{'WEBMIN_VAR'} ||= "/var/webmin";
-	if ($0 =~ /^(.*)\/[^\/]+$/) {
-		chdir($pwd = $1);
-		}
-	else {
-		chop($pwd = `pwd`);
-		}
+	require FindBin;
+	chdir($pwd = $FindBin::RealBin) ||
+		die "Failed to chdir to $FindBin::RealBin : $!";
 	$0 = "$pwd/delete-script.pl";
 	require './virtual-server-lib.pl';
 	$< == 0 || die "delete-script.pl must be run as root";

--- a/delete-shared-address.pl
+++ b/delete-shared-address.pl
@@ -16,12 +16,9 @@ if (!$module_name) {
 	$main::no_acl_check++;
 	$ENV{'WEBMIN_CONFIG'} ||= "/etc/webmin";
 	$ENV{'WEBMIN_VAR'} ||= "/var/webmin";
-	if ($0 =~ /^(.*)\/[^\/]+$/) {
-		chdir($pwd = $1);
-		}
-	else {
-		chop($pwd = `pwd`);
-		}
+	require FindBin;
+	chdir($pwd = $FindBin::RealBin) ||
+		die "Failed to chdir to $FindBin::RealBin : $!";
 	$0 = "$pwd/delete-shared-address.pl";
 	require './virtual-server-lib.pl';
 	$< == 0 || die "delete-shared-address.pl must be run as root";

--- a/delete-template.pl
+++ b/delete-template.pl
@@ -15,12 +15,9 @@ if (!$module_name) {
 	$main::no_acl_check++;
 	$ENV{'WEBMIN_CONFIG'} ||= "/etc/webmin";
 	$ENV{'WEBMIN_VAR'} ||= "/var/webmin";
-	if ($0 =~ /^(.*)\/[^\/]+$/) {
-		chdir($pwd = $1);
-		}
-	else {
-		chop($pwd = `pwd`);
-		}
+	require FindBin;
+	chdir($pwd = $FindBin::RealBin) ||
+		die "Failed to chdir to $FindBin::RealBin : $!";
 	$0 = "$pwd/delete-templates.pl";
 	require './virtual-server-lib.pl';
 	$< == 0 || die "delete-templates.pl must be run as root";

--- a/delete-user.pl
+++ b/delete-user.pl
@@ -15,12 +15,9 @@ if (!$module_name) {
 	$main::no_acl_check++;
 	$ENV{'WEBMIN_CONFIG'} ||= "/etc/webmin";
 	$ENV{'WEBMIN_VAR'} ||= "/var/webmin";
-	if ($0 =~ /^(.*)\/[^\/]+$/) {
-		chdir($pwd = $1);
-		}
-	else {
-		chop($pwd = `pwd`);
-		}
+	require FindBin;
+	chdir($pwd = $FindBin::RealBin) ||
+		die "Failed to chdir to $FindBin::RealBin : $!";
 	$0 = "$pwd/delete-user.pl";
 	require './virtual-server-lib.pl';
 	$< == 0 || die "delete-user.pl must be run as root";

--- a/detect-scripts.pl
+++ b/detect-scripts.pl
@@ -22,12 +22,9 @@ if (!$module_name) {
 	$main::no_acl_check++;
 	$ENV{'WEBMIN_CONFIG'} ||= "/etc/webmin";
 	$ENV{'WEBMIN_VAR'} ||= "/var/webmin";
-	if ($0 =~ /^(.*)\/[^\/]+$/) {
-		chdir($pwd = $1);
-		}
-	else {
-		chop($pwd = `pwd`);
-		}
+	require FindBin;
+	chdir($pwd = $FindBin::RealBin) ||
+		die "Failed to chdir to $FindBin::RealBin : $!";
 	$0 = "$pwd/detect-scripts.pl";
 	require './virtual-server-lib.pl';
 	$< == 0 || die "detect-scripts.pl must be run as root";

--- a/disable-domain.pl
+++ b/disable-domain.pl
@@ -33,12 +33,9 @@ if (!$module_name) {
 	$main::no_acl_check++;
 	$ENV{'WEBMIN_CONFIG'} ||= "/etc/webmin";
 	$ENV{'WEBMIN_VAR'} ||= "/var/webmin";
-	if ($0 =~ /^(.*)\/[^\/]+$/) {
-		chdir($pwd = $1);
-		}
-	else {
-		chop($pwd = `pwd`);
-		}
+	require FindBin;
+	chdir($pwd = $FindBin::RealBin) ||
+		die "Failed to chdir to $FindBin::RealBin : $!";
 	$0 = "$pwd/disable-domain.pl";
 	require './virtual-server-lib.pl';
 	$< == 0 || die "disable-domain.pl must be run as root";

--- a/disable-feature.pl
+++ b/disable-feature.pl
@@ -27,12 +27,9 @@ if (!$module_name) {
 	$main::no_acl_check++;
 	$ENV{'WEBMIN_CONFIG'} ||= "/etc/webmin";
 	$ENV{'WEBMIN_VAR'} ||= "/var/webmin";
-	if ($0 =~ /^(.*)\/[^\/]+$/) {
-		chdir($pwd = $1);
-		}
-	else {
-		chop($pwd = `pwd`);
-		}
+	require FindBin;
+	chdir($pwd = $FindBin::RealBin) ||
+		die "Failed to chdir to $FindBin::RealBin : $!";
 	$0 = "$pwd/disable-feature.pl";
 	require './virtual-server-lib.pl';
 	$< == 0 || die "disable-feature.pl must be run as root";

--- a/disable-limit.pl
+++ b/disable-limit.pl
@@ -21,12 +21,9 @@ if (!$module_name) {
 	$main::no_acl_check++;
 	$ENV{'WEBMIN_CONFIG'} ||= "/etc/webmin";
 	$ENV{'WEBMIN_VAR'} ||= "/var/webmin";
-	if ($0 =~ /^(.*)\/[^\/]+$/) {
-		chdir($pwd = $1);
-		}
-	else {
-		chop($pwd = `pwd`);
-		}
+	require FindBin;
+	chdir($pwd = $FindBin::RealBin) ||
+		die "Failed to chdir to $FindBin::RealBin : $!";
 	$0 = "$pwd/disable-limit.pl";
 	require './virtual-server-lib.pl';
 	$< == 0 || die "disable-limit.pl must be run as root";

--- a/disconnect-database.pl
+++ b/disconnect-database.pl
@@ -17,12 +17,9 @@ if (!$module_name) {
 	$main::no_acl_check++;
 	$ENV{'WEBMIN_CONFIG'} ||= "/etc/webmin";
 	$ENV{'WEBMIN_VAR'} ||= "/var/webmin";
-	if ($0 =~ /^(.*)\/[^\/]+$/) {
-		chdir($pwd = $1);
-		}
-	else {
-		chop($pwd = `pwd`);
-		}
+	require FindBin;
+	chdir($pwd = $FindBin::RealBin) ||
+		die "Failed to chdir to $FindBin::RealBin : $!";
 	$0 = "$pwd/disconnect-database.pl";
 	require './virtual-server-lib.pl';
 	$< == 0 || die "delete-database.pl must be run as root";

--- a/downgrade-licence.pl
+++ b/downgrade-licence.pl
@@ -15,12 +15,9 @@ if (!$module_name) {
 	$main::no_acl_check++;
 	$ENV{'WEBMIN_CONFIG'} ||= "/etc/webmin";
 	$ENV{'WEBMIN_VAR'} ||= "/var/webmin";
-	if ($0 =~ /^(.*)\/[^\/]+$/) {
-		chdir($pwd = $1);
-		}
-	else {
-		chop($pwd = `pwd`);
-		}
+	require FindBin;
+	chdir($pwd = $FindBin::RealBin) ||
+		die "Failed to chdir to $FindBin::RealBin : $!";
 	$0 = "$pwd/downgrade-licence.pl";
 	require './virtual-server-lib.pl';
 	require './virtualmin-licence.pl';

--- a/download-dropbox-file.pl
+++ b/download-dropbox-file.pl
@@ -15,12 +15,9 @@ if (!$module_name) {
 	$main::no_acl_check++;
 	$ENV{'WEBMIN_CONFIG'} ||= "/etc/webmin";
 	$ENV{'WEBMIN_VAR'} ||= "/var/webmin";
-	if ($0 =~ /^(.*)\/[^\/]+$/) {
-		chdir($pwd = $1);
-		}
-	else {
-		chop($pwd = `pwd`);
-		}
+	require FindBin;
+	chdir($pwd = $FindBin::RealBin) ||
+		die "Failed to chdir to $FindBin::RealBin : $!";
 	$0 = "$pwd/download-dropbox-file.pl";
 	require './virtual-server-lib.pl';
 	$< == 0 || die "download-dropbox-file.pl must be run as root";

--- a/download-rs-file.pl
+++ b/download-rs-file.pl
@@ -20,12 +20,9 @@ if (!$module_name) {
 	$main::no_acl_check++;
 	$ENV{'WEBMIN_CONFIG'} ||= "/etc/webmin";
 	$ENV{'WEBMIN_VAR'} ||= "/var/webmin";
-	if ($0 =~ /^(.*)\/[^\/]+$/) {
-		chdir($pwd = $1);
-		}
-	else {
-		chop($pwd = `pwd`);
-		}
+	require FindBin;
+	chdir($pwd = $FindBin::RealBin) ||
+		die "Failed to chdir to $FindBin::RealBin : $!";
 	$0 = "$pwd/download-rs-file.pl";
 	require './virtual-server-lib.pl';
 	$< == 0 || die "download-rs-file.pl must be run as root";

--- a/download-s3-file.pl
+++ b/download-s3-file.pl
@@ -20,12 +20,9 @@ if (!$module_name) {
 	$main::no_acl_check++;
 	$ENV{'WEBMIN_CONFIG'} ||= "/etc/webmin";
 	$ENV{'WEBMIN_VAR'} ||= "/var/webmin";
-	if ($0 =~ /^(.*)\/[^\/]+$/) {
-		chdir($pwd = $1);
-		}
-	else {
-		chop($pwd = `pwd`);
-		}
+	require FindBin;
+	chdir($pwd = $FindBin::RealBin) ||
+		die "Failed to chdir to $FindBin::RealBin : $!";
 	$0 = "$pwd/download-s3-file.pl";
 	require './virtual-server-lib.pl';
 	$< == 0 || die "download-s3-file.pl must be run as root";

--- a/enable-domain.pl
+++ b/enable-domain.pl
@@ -18,12 +18,9 @@ if (!$module_name) {
 	$main::no_acl_check++;
 	$ENV{'WEBMIN_CONFIG'} ||= "/etc/webmin";
 	$ENV{'WEBMIN_VAR'} ||= "/var/webmin";
-	if ($0 =~ /^(.*)\/[^\/]+$/) {
-		chdir($pwd = $1);
-		}
-	else {
-		chop($pwd = `pwd`);
-		}
+	require FindBin;
+	chdir($pwd = $FindBin::RealBin) ||
+		die "Failed to chdir to $FindBin::RealBin : $!";
 	$0 = "$pwd/enable-domain.pl";
 	require './virtual-server-lib.pl';
 	$< == 0 || die "enable-domain.pl must be run as root";

--- a/enable-feature.pl
+++ b/enable-feature.pl
@@ -29,12 +29,9 @@ if (!$module_name) {
 	$main::no_acl_check++;
 	$ENV{'WEBMIN_CONFIG'} ||= "/etc/webmin";
 	$ENV{'WEBMIN_VAR'} ||= "/var/webmin";
-	if ($0 =~ /^(.*)\/[^\/]+$/) {
-		chdir($pwd = $1);
-		}
-	else {
-		chop($pwd = `pwd`);
-		}
+	require FindBin;
+	chdir($pwd = $FindBin::RealBin) ||
+		die "Failed to chdir to $FindBin::RealBin : $!";
 	$0 = "$pwd/enable-feature.pl";
 	require './virtual-server-lib.pl';
 	$< == 0 || die "enable-feature.pl must be run as root";

--- a/enable-limit.pl
+++ b/enable-limit.pl
@@ -21,12 +21,9 @@ if (!$module_name) {
 	$main::no_acl_check++;
 	$ENV{'WEBMIN_CONFIG'} ||= "/etc/webmin";
 	$ENV{'WEBMIN_VAR'} ||= "/var/webmin";
-	if ($0 =~ /^(.*)\/[^\/]+$/) {
-		chdir($pwd = $1);
-		}
-	else {
-		chop($pwd = `pwd`);
-		}
+	require FindBin;
+	chdir($pwd = $FindBin::RealBin) ||
+		die "Failed to chdir to $FindBin::RealBin : $!";
 	$0 = "$pwd/enable-limit.pl";
 	require './virtual-server-lib.pl';
 	$< == 0 || die "enable-limit.pl must be run as root";

--- a/fetch-script-files.pl
+++ b/fetch-script-files.pl
@@ -6,12 +6,9 @@ if (!$module_name) {
 	$main::no_acl_check++;
 	$ENV{'WEBMIN_CONFIG'} ||= "/etc/webmin";
 	$ENV{'WEBMIN_VAR'} ||= "/var/webmin";
-	if ($0 =~ /^(.*)\/[^\/]+$/) {
-		chdir($pwd = $1);
-		}
-	else {
-		chop($pwd = `pwd`);
-		}
+	require FindBin;
+	chdir($pwd = $FindBin::RealBin) ||
+		die "Failed to chdir to $FindBin::RealBin : $!";
 	$0 = "$pwd/fetch-script-files.pl";
 	require './virtual-server-lib.pl';
 	$< == 0 || die "fetch-script-files.pl must be run as root";

--- a/fix-domain-permissions.pl
+++ b/fix-domain-permissions.pl
@@ -17,12 +17,9 @@ if (!$module_name) {
 	$main::no_acl_check++;
 	$ENV{'WEBMIN_CONFIG'} ||= "/etc/webmin";
 	$ENV{'WEBMIN_VAR'} ||= "/var/webmin";
-	if ($0 =~ /^(.*)\/[^\/]+$/) {
-		chdir($pwd = $1);
-		}
-	else {
-		chop($pwd = `pwd`);
-		}
+	require FindBin;
+	chdir($pwd = $FindBin::RealBin) ||
+		die "Failed to chdir to $FindBin::RealBin : $!";
 	$0 = "$pwd/fix-domain-permissions.pl";
 	require './virtual-server-lib.pl';
 	$< == 0 || die "fix-domain-permissions.pl must be run as root";

--- a/fix-domain-quota.pl
+++ b/fix-domain-quota.pl
@@ -16,12 +16,9 @@ if (!$module_name) {
 	$main::no_acl_check++;
 	$ENV{'WEBMIN_CONFIG'} ||= "/etc/webmin";
 	$ENV{'WEBMIN_VAR'} ||= "/var/webmin";
-	if ($0 =~ /^(.*)\/[^\/]+$/) {
-		chdir($pwd = $1);
-		}
-	else {
-		chop($pwd = `pwd`);
-		}
+	require FindBin;
+	chdir($pwd = $FindBin::RealBin) ||
+		die "Failed to chdir to $FindBin::RealBin : $!";
 	$0 = "$pwd/fix-domain-quota.pl";
 	require './virtual-server-lib.pl';
 	$< == 0 || die "fix-domain-quota.pl must be run as root";

--- a/functional-test.pl
+++ b/functional-test.pl
@@ -6,12 +6,9 @@ if (!$module_name) {
 	$main::no_acl_check++;
 	$ENV{'WEBMIN_CONFIG'} ||= "/etc/webmin";
 	$ENV{'WEBMIN_VAR'} ||= "/var/webmin";
-	if ($0 =~ /^(.*)\/[^\/]+$/) {
-		chdir($pwd = $1);
-		}
-	else {
-		chop($pwd = `pwd`);
-		}
+	require FindBin;
+	chdir($pwd = $FindBin::RealBin) ||
+		die "Failed to chdir to $FindBin::RealBin : $!";
 	$0 = "$pwd/functional-test.pl";
 	require './virtual-server-lib.pl';
 	$< == 0 || die "functional-test.pl must be run as root";

--- a/generate-acme-cert.pl
+++ b/generate-acme-cert.pl
@@ -57,12 +57,9 @@ if (!$module_name) {
 	$main::no_acl_check++;
 	$ENV{'WEBMIN_CONFIG'} ||= "/etc/webmin";
 	$ENV{'WEBMIN_VAR'} ||= "/var/webmin";
-	if ($0 =~ /^(.*)\/[^\/]+$/) {
-		chdir($pwd = $1);
-		}
-	else {
-		chop($pwd = `pwd`);
-		}
+	require FindBin;
+	chdir($pwd = $FindBin::RealBin) ||
+		die "Failed to chdir to $FindBin::RealBin : $!";
 	$0 = "$pwd/generate-acme-cert.pl";
 	require './virtual-server-lib.pl';
 	$< == 0 || die "generate-acme-cert.pl must be run as root";

--- a/generate-cert.pl
+++ b/generate-cert.pl
@@ -57,12 +57,9 @@ if (!$module_name) {
 	$main::no_acl_check++;
 	$ENV{'WEBMIN_CONFIG'} ||= "/etc/webmin";
 	$ENV{'WEBMIN_VAR'} ||= "/var/webmin";
-	if ($0 =~ /^(.*)\/[^\/]+$/) {
-		chdir($pwd = $1);
-		}
-	else {
-		chop($pwd = `pwd`);
-		}
+	require FindBin;
+	chdir($pwd = $FindBin::RealBin) ||
+		die "Failed to chdir to $FindBin::RealBin : $!";
 	$0 = "$pwd/generate-cert.pl";
 	require './virtual-server-lib.pl';
 	$< == 0 || die "generate-cert.pl must be run as root";

--- a/generate-script-sites.pl
+++ b/generate-script-sites.pl
@@ -6,12 +6,9 @@ if (!$module_name) {
 	$main::no_acl_check++;
 	$ENV{'WEBMIN_CONFIG'} ||= "/etc/webmin";
 	$ENV{'WEBMIN_VAR'} ||= "/var/webmin";
-	if ($0 =~ /^(.*)\/[^\/]+$/) {
-		chdir($pwd = $1);
-		}
-	else {
-		chop($pwd = `pwd`);
-		}
+	require FindBin;
+	chdir($pwd = $FindBin::RealBin) ||
+		die "Failed to chdir to $FindBin::RealBin : $!";
 	$0 = "$pwd/generate-script-sites.pl";
 	require './virtual-server-lib.pl';
 	$< == 0 || die "generate-script-sites.pl must be run as root";

--- a/get-command.pl
+++ b/get-command.pl
@@ -15,12 +15,9 @@ if (!$module_name) {
 	$main::no_acl_check++;
 	$ENV{'WEBMIN_CONFIG'} ||= "/etc/webmin";
 	$ENV{'WEBMIN_VAR'} ||= "/var/webmin";
-	if ($0 =~ /^(.*)\/[^\/]+$/) {
-		chdir($pwd = $1);
-		}
-	else {
-		chop($pwd = `pwd`);
-		}
+	require FindBin;
+	chdir($pwd = $FindBin::RealBin) ||
+		die "Failed to chdir to $FindBin::RealBin : $!";
 	$0 = "$pwd/get-command.pl";
 	require './virtual-server-lib.pl';
 	$< == 0 || die "get-command.pl must be run as root";

--- a/get-dns.pl
+++ b/get-dns.pl
@@ -29,12 +29,9 @@ if (!$module_name) {
 	$main::no_acl_check++;
 	$ENV{'WEBMIN_CONFIG'} ||= "/etc/webmin";
 	$ENV{'WEBMIN_VAR'} ||= "/var/webmin";
-	if ($0 =~ /^(.*)\/[^\/]+$/) {
-		chdir($pwd = $1);
-		}
-	else {
-		chop($pwd = `pwd`);
-		}
+	require FindBin;
+	chdir($pwd = $FindBin::RealBin) ||
+		die "Failed to chdir to $FindBin::RealBin : $!";
 	$0 = "$pwd/get-dns.pl";
 	require './virtual-server-lib.pl';
 	$< == 0 || die "get-dns.pl must be run as root";

--- a/get-logs.pl
+++ b/get-logs.pl
@@ -17,12 +17,9 @@ if (!$module_name) {
 	$main::no_acl_check++;
 	$ENV{'WEBMIN_CONFIG'} ||= "/etc/webmin";
 	$ENV{'WEBMIN_VAR'} ||= "/var/webmin";
-	if ($0 =~ /^(.*)\/[^\/]+$/) {
-		chdir($pwd = $1);
-		}
-	else {
-		chop($pwd = `pwd`);
-		}
+	require FindBin;
+	chdir($pwd = $FindBin::RealBin) ||
+		die "Failed to chdir to $FindBin::RealBin : $!";
 	$0 = "$pwd/get-ssl.pl";
 	require './virtual-server-lib.pl';
 	$< == 0 || die "get-ssl.pl must be run as root";

--- a/get-ssl.pl
+++ b/get-ssl.pl
@@ -17,12 +17,9 @@ if (!$module_name) {
 	$main::no_acl_check++;
 	$ENV{'WEBMIN_CONFIG'} ||= "/etc/webmin";
 	$ENV{'WEBMIN_VAR'} ||= "/var/webmin";
-	if ($0 =~ /^(.*)\/[^\/]+$/) {
-		chdir($pwd = $1);
-		}
-	else {
-		chop($pwd = `pwd`);
-		}
+	require FindBin;
+	chdir($pwd = $FindBin::RealBin) ||
+		die "Failed to chdir to $FindBin::RealBin : $!";
 	$0 = "$pwd/get-ssl.pl";
 	require './virtual-server-lib.pl';
 	$< == 0 || die "get-ssl.pl must be run as root";

--- a/get-template.pl
+++ b/get-template.pl
@@ -28,12 +28,9 @@ if (!$module_name) {
 	$main::no_acl_check++;
 	$ENV{'WEBMIN_CONFIG'} ||= "/etc/webmin";
 	$ENV{'WEBMIN_VAR'} ||= "/var/webmin";
-	if ($0 =~ /^(.*)\/[^\/]+$/) {
-		chdir($pwd = $1);
-		}
-	else {
-		chop($pwd = `pwd`);
-		}
+	require FindBin;
+	chdir($pwd = $FindBin::RealBin) ||
+		die "Failed to chdir to $FindBin::RealBin : $!";
 	$0 = "$pwd/get-templates.pl";
 	require './virtual-server-lib.pl';
 	$< == 0 || die "get-templates.pl must be run as root";

--- a/import-database.pl
+++ b/import-database.pl
@@ -20,12 +20,9 @@ if (!$module_name) {
 	$main::no_acl_check++;
 	$ENV{'WEBMIN_CONFIG'} ||= "/etc/webmin";
 	$ENV{'WEBMIN_VAR'} ||= "/var/webmin";
-	if ($0 =~ /^(.*)\/[^\/]+$/) {
-		chdir($pwd = $1);
-		}
-	else {
-		chop($pwd = `pwd`);
-		}
+	require FindBin;
+	chdir($pwd = $FindBin::RealBin) ||
+		die "Failed to chdir to $FindBin::RealBin : $!";
 	$0 = "$pwd/import-database.pl";
 	require './virtual-server-lib.pl';
 	$< == 0 || die "import-database.pl must be run as root";

--- a/info.pl
+++ b/info.pl
@@ -29,12 +29,9 @@ if (!$module_name) {
 	$main::no_acl_check++;
 	$ENV{'WEBMIN_CONFIG'} ||= "/etc/webmin";
 	$ENV{'WEBMIN_VAR'} ||= "/var/webmin";
-	if ($0 =~ /^(.*)\/[^\/]+$/) {
-		chdir($pwd = $1);
-		}
-	else {
-		chop($pwd = `pwd`);
-		}
+	require FindBin;
+	chdir($pwd = $FindBin::RealBin) ||
+		die "Failed to chdir to $FindBin::RealBin : $!";
 	$0 = "$pwd/info.pl";
 	require './virtual-server-lib.pl';
 	$< == 0 || die "info.pl must be run as root";

--- a/install-cert.pl
+++ b/install-cert.pl
@@ -34,12 +34,9 @@ if (!$module_name) {
 	$main::no_acl_check++;
 	$ENV{'WEBMIN_CONFIG'} ||= "/etc/webmin";
 	$ENV{'WEBMIN_VAR'} ||= "/var/webmin";
-	if ($0 =~ /^(.*)\/[^\/]+$/) {
-		chdir($pwd = $1);
-		}
-	else {
-		chop($pwd = `pwd`);
-		}
+	require FindBin;
+	chdir($pwd = $FindBin::RealBin) ||
+		die "Failed to chdir to $FindBin::RealBin : $!";
 	$0 = "$pwd/install-cert.pl";
 	require './virtual-server-lib.pl';
 	$< == 0 || die "install-cert.pl must be run as root";

--- a/install-script.pl
+++ b/install-script.pl
@@ -59,12 +59,9 @@ if (!$module_name) {
 	$main::no_acl_check++;
 	$ENV{'WEBMIN_CONFIG'} ||= "/etc/webmin";
 	$ENV{'WEBMIN_VAR'} ||= "/var/webmin";
-	if ($0 =~ /^(.*)\/[^\/]+$/) {
-		chdir($pwd = $1);
-		}
-	else {
-		chop($pwd = `pwd`);
-		}
+	require FindBin;
+	chdir($pwd = $FindBin::RealBin) ||
+		die "Failed to chdir to $FindBin::RealBin : $!";
 	$0 = "$pwd/install-script.pl";
 	require './virtual-server-lib.pl';
 	$< == 0 || die "install-script.pl must be run as root";

--- a/install-service-cert.pl
+++ b/install-service-cert.pl
@@ -25,12 +25,9 @@ if (!$module_name) {
 	$main::no_acl_check++;
 	$ENV{'WEBMIN_CONFIG'} ||= "/etc/webmin";
 	$ENV{'WEBMIN_VAR'} ||= "/var/webmin";
-	if ($0 =~ /^(.*)\/[^\/]+$/) {
-		chdir($pwd = $1);
-		}
-	else {
-		chop($pwd = `pwd`);
-		}
+	require FindBin;
+	chdir($pwd = $FindBin::RealBin) ||
+		die "Failed to chdir to $FindBin::RealBin : $!";
 	$0 = "$pwd/install-cert.pl";
 	require './virtual-server-lib.pl';
 	$< == 0 || die "install-cert.pl must be run as root";

--- a/licence-info.pl
+++ b/licence-info.pl
@@ -15,12 +15,9 @@ if (!$module_name) {
 	$main::no_acl_check++;
 	$ENV{'WEBMIN_CONFIG'} ||= "/etc/webmin";
 	$ENV{'WEBMIN_VAR'} ||= "/var/webmin";
-	if ($0 =~ /^(.*)\/[^\/]+$/) {
-		chdir($pwd = $1);
-		}
-	else {
-		chop($pwd = `pwd`);
-		}
+	require FindBin;
+	chdir($pwd = $FindBin::RealBin) ||
+		die "Failed to chdir to $FindBin::RealBin : $!";
 	$0 = "$pwd/info.pl";
 	require './virtual-server-lib.pl';
 	$< == 0 || die "license-info.pl must be run as root";

--- a/list-admins.pl
+++ b/list-admins.pl
@@ -17,12 +17,9 @@ if (!$module_name) {
 	$main::no_acl_check++;
 	$ENV{'WEBMIN_CONFIG'} ||= "/etc/webmin";
 	$ENV{'WEBMIN_VAR'} ||= "/var/webmin";
-	if ($0 =~ /^(.*)\/[^\/]+$/) {
-		chdir($pwd = $1);
-		}
-	else {
-		chop($pwd = `pwd`);
-		}
+	require FindBin;
+	chdir($pwd = $FindBin::RealBin) ||
+		die "Failed to chdir to $FindBin::RealBin : $!";
 	$0 = "$pwd/list-databases.pl";
 	require './virtual-server-lib.pl';
 	$< == 0 || die "list-admins.pl must be run as root";

--- a/list-aliases.pl
+++ b/list-aliases.pl
@@ -34,12 +34,9 @@ if (!$module_name) {
 	$main::no_acl_check++;
 	$ENV{'WEBMIN_CONFIG'} ||= "/etc/webmin";
 	$ENV{'WEBMIN_VAR'} ||= "/var/webmin";
-	if ($0 =~ /^(.*)\/[^\/]+$/) {
-		chdir($pwd = $1);
-		}
-	else {
-		chop($pwd = `pwd`);
-		}
+	require FindBin;
+	chdir($pwd = $FindBin::RealBin) ||
+		die "Failed to chdir to $FindBin::RealBin : $!";
 	$0 = "$pwd/list-aliases.pl";
 	require './virtual-server-lib.pl';
 	$< == 0 || die "list-aliases.pl must be run as root";

--- a/list-available-scripts.pl
+++ b/list-available-scripts.pl
@@ -22,12 +22,9 @@ if (!$module_name) {
 	$main::no_acl_check++;
 	$ENV{'WEBMIN_CONFIG'} ||= "/etc/webmin";
 	$ENV{'WEBMIN_VAR'} ||= "/var/webmin";
-	if ($0 =~ /^(.*)\/[^\/]+$/) {
-		chdir($pwd = $1);
-		}
-	else {
-		chop($pwd = `pwd`);
-		}
+	require FindBin;
+	chdir($pwd = $FindBin::RealBin) ||
+		die "Failed to chdir to $FindBin::RealBin : $!";
 	$0 = "$pwd/list-available-scripts.pl";
 	require './virtual-server-lib.pl';
 	$< == 0 || die "list-available-scripts.pl must be run as root";

--- a/list-available-shells.pl
+++ b/list-available-shells.pl
@@ -22,12 +22,9 @@ if (!$module_name) {
 	$main::no_acl_check++;
 	$ENV{'WEBMIN_CONFIG'} ||= "/etc/webmin";
 	$ENV{'WEBMIN_VAR'} ||= "/var/webmin";
-	if ($0 =~ /^(.*)\/[^\/]+$/) {
-		chdir($pwd = $1);
-		}
-	else {
-		chop($pwd = `pwd`);
-		}
+	require FindBin;
+	chdir($pwd = $FindBin::RealBin) ||
+		die "Failed to chdir to $FindBin::RealBin : $!";
 	$0 = "$pwd/list-available-shells.pl";
 	require './virtual-server-lib.pl';
 	$< == 0 || die "list-available-shells.pl must be run as root";

--- a/list-backup-logs.pl
+++ b/list-backup-logs.pl
@@ -33,12 +33,9 @@ if (!$module_name) {
 	$main::no_acl_check++;
 	$ENV{'WEBMIN_CONFIG'} ||= "/etc/webmin";
 	$ENV{'WEBMIN_VAR'} ||= "/var/webmin";
-	if ($0 =~ /^(.*)\/[^\/]+$/) {
-		chdir($pwd = $1);
-		}
-	else {
-		chop($pwd = `pwd`);
-		}
+	require FindBin;
+	chdir($pwd = $FindBin::RealBin) ||
+		die "Failed to chdir to $FindBin::RealBin : $!";
 	$0 = "$pwd/list-backup-logs.pl";
 	require './virtual-server-lib.pl';
 	$< == 0 || die "list-backup-logs.pl must be run as root";

--- a/list-bandwidth.pl
+++ b/list-bandwidth.pl
@@ -25,12 +25,9 @@ if (!$module_name) {
 	$main::no_acl_check++;
 	$ENV{'WEBMIN_CONFIG'} ||= "/etc/webmin";
 	$ENV{'WEBMIN_VAR'} ||= "/var/webmin";
-	if ($0 =~ /^(.*)\/[^\/]+$/) {
-		chdir($pwd = $1);
-		}
-	else {
-		chop($pwd = `pwd`);
-		}
+	require FindBin;
+	chdir($pwd = $FindBin::RealBin) ||
+		die "Failed to chdir to $FindBin::RealBin : $!";
 	$0 = "$pwd/list-bandwidth.pl";
 	require './virtual-server-lib.pl';
 	$< == 0 || die "list-bandwidth.pl must be run as root";

--- a/list-certs-expiry.pl
+++ b/list-certs-expiry.pl
@@ -25,12 +25,9 @@ if (!$module_name) {
 	$main::no_acl_check++;
 	$ENV{'WEBMIN_CONFIG'} ||= "/etc/webmin";
 	$ENV{'WEBMIN_VAR'}    ||= "/var/webmin";
-	if ($0 =~ /^(.*)\/[^\/]+$/) {
-		chdir($pwd = $1);
-		}
-	else {
-		chop($pwd = `pwd`);
-		}
+	require FindBin;
+	chdir($pwd = $FindBin::RealBin) ||
+		die "Failed to chdir to $FindBin::RealBin : $!";
 	$0 = "$pwd/list-certs.pl";
 	require './virtual-server-lib.pl';
 	$< == 0 || die "list-certs.pl must be run as root";

--- a/list-certs.pl
+++ b/list-certs.pl
@@ -31,12 +31,9 @@ if (!$module_name) {
 	$main::no_acl_check++;
 	$ENV{'WEBMIN_CONFIG'} ||= "/etc/webmin";
 	$ENV{'WEBMIN_VAR'} ||= "/var/webmin";
-	if ($0 =~ /^(.*)\/[^\/]+$/) {
-		chdir($pwd = $1);
-		}
-	else {
-		chop($pwd = `pwd`);
-		}
+	require FindBin;
+	chdir($pwd = $FindBin::RealBin) ||
+		die "Failed to chdir to $FindBin::RealBin : $!";
 	$0 = "$pwd/list-certs.pl";
 	require './virtual-server-lib.pl';
 	$< == 0 || die "list-certs.pl must be run as root";

--- a/list-commands.pl
+++ b/list-commands.pl
@@ -16,12 +16,9 @@ if (!$module_name) {
 	$main::no_acl_check++;
 	$ENV{'WEBMIN_CONFIG'} ||= "/etc/webmin";
 	$ENV{'WEBMIN_VAR'} ||= "/var/webmin";
-	if ($0 =~ /^(.*)\/[^\/]+$/) {
-		chdir($pwd = $1);
-		}
-	else {
-		chop($pwd = `pwd`);
-		}
+	require FindBin;
+	chdir($pwd = $FindBin::RealBin) ||
+		die "Failed to chdir to $FindBin::RealBin : $!";
 	$0 = "$pwd/list-features.pl";
 	require './virtual-server-lib.pl';
 	$< == 0 || die "list-commands.pl must be run as root";

--- a/list-config-revisions.pl
+++ b/list-config-revisions.pl
@@ -76,12 +76,9 @@ if (!$module_name) {
 	$main::no_acl_check++;
 	$ENV{'WEBMIN_CONFIG'} ||= "/etc/webmin";
 	$ENV{'WEBMIN_VAR'} ||= "/var/webmin";
-	if ($0 =~ /^(.*)\/[^\/]+$/) {
-		chdir($pwd = $1);
-		}
-	else {
-		chop($pwd = `pwd`);
-		}
+	require FindBin;
+	chdir($pwd = $FindBin::RealBin) ||
+		die "Failed to chdir to $FindBin::RealBin : $!";
 	$0 = "$pwd/list-config-revisions.pl";
 	require './virtual-server-lib.pl';
 	$< == 0 || die "list-config-revisions.pl must be run as root";

--- a/list-custom.pl
+++ b/list-custom.pl
@@ -20,12 +20,9 @@ if (!$module_name) {
 	$main::no_acl_check++;
 	$ENV{'WEBMIN_CONFIG'} ||= "/etc/webmin";
 	$ENV{'WEBMIN_VAR'} ||= "/var/webmin";
-	if ($0 =~ /^(.*)\/[^\/]+$/) {
-		chdir($pwd = $1);
-		}
-	else {
-		chop($pwd = `pwd`);
-		}
+	require FindBin;
+	chdir($pwd = $FindBin::RealBin) ||
+		die "Failed to chdir to $FindBin::RealBin : $!";
 	$0 = "$pwd/list-custom.pl";
 	require './virtual-server-lib.pl';
 	$< == 0 || die "list-custom.pl must be run as root";

--- a/list-databases.pl
+++ b/list-databases.pl
@@ -17,12 +17,9 @@ if (!$module_name) {
 	$main::no_acl_check++;
 	$ENV{'WEBMIN_CONFIG'} ||= "/etc/webmin";
 	$ENV{'WEBMIN_VAR'} ||= "/var/webmin";
-	if ($0 =~ /^(.*)\/[^\/]+$/) {
-		chdir($pwd = $1);
-		}
-	else {
-		chop($pwd = `pwd`);
-		}
+	require FindBin;
+	chdir($pwd = $FindBin::RealBin) ||
+		die "Failed to chdir to $FindBin::RealBin : $!";
 	$0 = "$pwd/list-databases.pl";
 	require './virtual-server-lib.pl';
 	$< == 0 || die "list-databases.pl must be run as root";

--- a/list-domains.pl
+++ b/list-domains.pl
@@ -61,12 +61,9 @@ if (!$module_name) {
 	$main::no_acl_check++;
 	$ENV{'WEBMIN_CONFIG'} ||= "/etc/webmin";
 	$ENV{'WEBMIN_VAR'} ||= "/var/webmin";
-	if ($0 =~ /^(.*)\/[^\/]+$/) {
-		chdir($pwd = $1);
-		}
-	else {
-		chop($pwd = `pwd`);
-		}
+	require FindBin;
+	chdir($pwd = $FindBin::RealBin) ||
+		die "Failed to chdir to $FindBin::RealBin : $!";
 	$0 = "$pwd/list-domains.pl";
 	require './virtual-server-lib.pl';
 	$< == 0 || die "list-domains.pl must be run as root";

--- a/list-dropbox-files.pl
+++ b/list-dropbox-files.pl
@@ -18,12 +18,9 @@ if (!$module_name) {
 	$main::no_acl_check++;
 	$ENV{'WEBMIN_CONFIG'} ||= "/etc/webmin";
 	$ENV{'WEBMIN_VAR'} ||= "/var/webmin";
-	if ($0 =~ /^(.*)\/[^\/]+$/) {
-		chdir($pwd = $1);
-		}
-	else {
-		chop($pwd = `pwd`);
-		}
+	require FindBin;
+	chdir($pwd = $FindBin::RealBin) ||
+		die "Failed to chdir to $FindBin::RealBin : $!";
 	$0 = "$pwd/list-gcs-files.pl";
 	require './virtual-server-lib.pl';
 	$< == 0 || die "list-gcs-files.pl must be run as root";

--- a/list-features.pl
+++ b/list-features.pl
@@ -26,12 +26,9 @@ if (!$module_name) {
 	$main::no_acl_check++;
 	$ENV{'WEBMIN_CONFIG'} ||= "/etc/webmin";
 	$ENV{'WEBMIN_VAR'} ||= "/var/webmin";
-	if ($0 =~ /^(.*)\/[^\/]+$/) {
-		chdir($pwd = $1);
-		}
-	else {
-		chop($pwd = `pwd`);
-		}
+	require FindBin;
+	chdir($pwd = $FindBin::RealBin) ||
+		die "Failed to chdir to $FindBin::RealBin : $!";
 	$0 = "$pwd/list-features.pl";
 	require './virtual-server-lib.pl';
 	$< == 0 || die "list-features.pl must be run as root";

--- a/list-gcs-buckets.pl
+++ b/list-gcs-buckets.pl
@@ -19,12 +19,9 @@ if (!$module_name) {
 	$main::no_acl_check++;
 	$ENV{'WEBMIN_CONFIG'} ||= "/etc/webmin";
 	$ENV{'WEBMIN_VAR'} ||= "/var/webmin";
-	if ($0 =~ /^(.*)\/[^\/]+$/) {
-		chdir($pwd = $1);
-		}
-	else {
-		chop($pwd = `pwd`);
-		}
+	require FindBin;
+	chdir($pwd = $FindBin::RealBin) ||
+		die "Failed to chdir to $FindBin::RealBin : $!";
 	$0 = "$pwd/list-gcs-buckets.pl";
 	require './virtual-server-lib.pl';
 	$< == 0 || die "list-gcs-buckets.pl must be run as root";

--- a/list-gcs-files.pl
+++ b/list-gcs-files.pl
@@ -18,12 +18,9 @@ if (!$module_name) {
 	$main::no_acl_check++;
 	$ENV{'WEBMIN_CONFIG'} ||= "/etc/webmin";
 	$ENV{'WEBMIN_VAR'} ||= "/var/webmin";
-	if ($0 =~ /^(.*)\/[^\/]+$/) {
-		chdir($pwd = $1);
-		}
-	else {
-		chop($pwd = `pwd`);
-		}
+	require FindBin;
+	chdir($pwd = $FindBin::RealBin) ||
+		die "Failed to chdir to $FindBin::RealBin : $!";
 	$0 = "$pwd/list-gcs-files.pl";
 	require './virtual-server-lib.pl';
 	$< == 0 || die "list-gcs-files.pl must be run as root";

--- a/list-mailbox.pl
+++ b/list-mailbox.pl
@@ -26,12 +26,9 @@ if (!$module_name) {
 	$main::no_acl_check++;
 	$ENV{'WEBMIN_CONFIG'} ||= "/etc/webmin";
 	$ENV{'WEBMIN_VAR'} ||= "/var/webmin";
-	if ($0 =~ /^(.*)\/[^\/]+$/) {
-		chdir($pwd = $1);
-		}
-	else {
-		chop($pwd = `pwd`);
-		}
+	require FindBin;
+	chdir($pwd = $FindBin::RealBin) ||
+		die "Failed to chdir to $FindBin::RealBin : $!";
 	$0 = "$pwd/list-mailbox.pl";
 	require './virtual-server-lib.pl';
 	$< == 0 || die "list-mailbox.pl must be run as root";

--- a/list-mysql-servers.pl
+++ b/list-mysql-servers.pl
@@ -15,12 +15,9 @@ if (!$module_name) {
 	$main::no_acl_check++;
 	$ENV{'WEBMIN_CONFIG'} ||= "/etc/webmin";
 	$ENV{'WEBMIN_VAR'} ||= "/var/webmin";
-	if ($0 =~ /^(.*)\/[^\/]+$/) {
-		chdir($pwd = $1);
-		}
-	else {
-		chop($pwd = `pwd`);
-		}
+	require FindBin;
+	chdir($pwd = $FindBin::RealBin) ||
+		die "Failed to chdir to $FindBin::RealBin : $!";
 	$0 = "$pwd/list-mysql-servers.pl";
 	require './virtual-server-lib.pl';
 	$< == 0 || die "list-mysql-servers.pl must be run as root";

--- a/list-php-directories.pl
+++ b/list-php-directories.pl
@@ -20,12 +20,9 @@ if (!$module_name) {
 	$main::no_acl_check++;
 	$ENV{'WEBMIN_CONFIG'} ||= "/etc/webmin";
 	$ENV{'WEBMIN_VAR'} ||= "/var/webmin";
-	if ($0 =~ /^(.*)\/[^\/]+$/) {
-		chdir($pwd = $1);
-		}
-	else {
-		chop($pwd = `pwd`);
-		}
+	require FindBin;
+	chdir($pwd = $FindBin::RealBin) ||
+		die "Failed to chdir to $FindBin::RealBin : $!";
 	$0 = "$pwd/list-users.pl";
 	require './virtual-server-lib.pl';
 	$< == 0 || die "list-php-directories.pl must be run as root";

--- a/list-php-ini.pl
+++ b/list-php-ini.pl
@@ -23,12 +23,9 @@ if (!$module_name) {
 	$main::no_acl_check++;
 	$ENV{'WEBMIN_CONFIG'} ||= "/etc/webmin";
 	$ENV{'WEBMIN_VAR'} ||= "/var/webmin";
-	if ($0 =~ /^(.*)\/[^\/]+$/) {
-		chdir($pwd = $1);
-		}
-	else {
-		chop($pwd = `pwd`);
-		}
+	require FindBin;
+	chdir($pwd = $FindBin::RealBin) ||
+		die "Failed to chdir to $FindBin::RealBin : $!";
 	$0 = "$pwd/list-php-ini.pl";
 	require './virtual-server-lib.pl';
 	$< == 0 || die "list-php-ini.pl must be run as root";

--- a/list-php-versions.pl
+++ b/list-php-versions.pl
@@ -22,12 +22,9 @@ if (!$module_name) {
 	$no_acl_check++;
 	$ENV{'WEBMIN_CONFIG'} ||= "/etc/webmin";
 	$ENV{'WEBMIN_VAR'} ||= "/var/webmin";
-	if ($0 =~ /^(.*)\/[^\/]+$/) {
-		chdir($pwd = $1);
-		}
-	else {
-		chop($pwd = `pwd`);
-		}
+	require FindBin;
+	chdir($pwd = $FindBin::RealBin) ||
+		die "Failed to chdir to $FindBin::RealBin : $!";
 	$0 = "$pwd/list-php-versions.pl";
 	require './virtual-server-lib.pl';
 	$< == 0 || die "list-php-versions.pl must be run as root";

--- a/list-plans.pl
+++ b/list-plans.pl
@@ -18,12 +18,9 @@ if (!$module_name) {
 	$main::no_acl_check++;
 	$ENV{'WEBMIN_CONFIG'} ||= "/etc/webmin";
 	$ENV{'WEBMIN_VAR'} ||= "/var/webmin";
-	if ($0 =~ /^(.*)\/[^\/]+$/) {
-		chdir($pwd = $1);
-		}
-	else {
-		chop($pwd = `pwd`);
-		}
+	require FindBin;
+	chdir($pwd = $FindBin::RealBin) ||
+		die "Failed to chdir to $FindBin::RealBin : $!";
 	$0 = "$pwd/list-plans.pl";
 	require './virtual-server-lib.pl';
 	$< == 0 || die "list-plans.pl must be run as root";

--- a/list-ports.pl
+++ b/list-ports.pl
@@ -16,12 +16,9 @@ if (!$module_name) {
 	$main::no_acl_check++;
 	$ENV{'WEBMIN_CONFIG'} ||= "/etc/webmin";
 	$ENV{'WEBMIN_VAR'} ||= "/var/webmin";
-	if ($0 =~ /^(.*)\/[^\/]+$/) {
-		chdir($pwd = $1);
-		}
-	else {
-		chop($pwd = `pwd`);
-		}
+	require FindBin;
+	chdir($pwd = $FindBin::RealBin) ||
+		die "Failed to chdir to $FindBin::RealBin : $!";
 	$0 = "$pwd/list-ports.pl";
 	require './virtual-server-lib.pl';
 	$< == 0 || die "list-ports.pl must be run as root";

--- a/list-proxies.pl
+++ b/list-proxies.pl
@@ -17,12 +17,9 @@ if (!$module_name) {
 	$main::no_acl_check++;
 	$ENV{'WEBMIN_CONFIG'} ||= "/etc/webmin";
 	$ENV{'WEBMIN_VAR'} ||= "/var/webmin";
-	if ($0 =~ /^(.*)\/[^\/]+$/) {
-		chdir($pwd = $1);
-		}
-	else {
-		chop($pwd = `pwd`);
-		}
+	require FindBin;
+	chdir($pwd = $FindBin::RealBin) ||
+		die "Failed to chdir to $FindBin::RealBin : $!";
 	$0 = "$pwd/list-proxies.pl";
 	require './virtual-server-lib.pl';
 	$< == 0 || die "list-proxies.pl must be run as root";

--- a/list-redirects.pl
+++ b/list-redirects.pl
@@ -26,12 +26,9 @@ if (!$module_name) {
 	$main::no_acl_check++;
 	$ENV{'WEBMIN_CONFIG'} ||= "/etc/webmin";
 	$ENV{'WEBMIN_VAR'} ||= "/var/webmin";
-	if ($0 =~ /^(.*)\/[^\/]+$/) {
-		chdir($pwd = $1);
-		}
-	else {
-		chop($pwd = `pwd`);
-		}
+	require FindBin;
+	chdir($pwd = $FindBin::RealBin) ||
+		die "Failed to chdir to $FindBin::RealBin : $!";
 	$0 = "$pwd/list-proxies.pl";
 	require './virtual-server-lib.pl';
 	$< == 0 || die "list-redirects.pl must be run as root";

--- a/list-rs-containers.pl
+++ b/list-rs-containers.pl
@@ -20,12 +20,9 @@ if (!$module_name) {
 	$main::no_acl_check++;
 	$ENV{'WEBMIN_CONFIG'} ||= "/etc/webmin";
 	$ENV{'WEBMIN_VAR'} ||= "/var/webmin";
-	if ($0 =~ /^(.*)\/[^\/]+$/) {
-		chdir($pwd = $1);
-		}
-	else {
-		chop($pwd = `pwd`);
-		}
+	require FindBin;
+	chdir($pwd = $FindBin::RealBin) ||
+		die "Failed to chdir to $FindBin::RealBin : $!";
 	$0 = "$pwd/list-rs-containers.pl";
 	require './virtual-server-lib.pl';
 	$< == 0 || die "list-rs-containers.pl must be run as root";

--- a/list-rs-files.pl
+++ b/list-rs-files.pl
@@ -21,12 +21,9 @@ if (!$module_name) {
 	$main::no_acl_check++;
 	$ENV{'WEBMIN_CONFIG'} ||= "/etc/webmin";
 	$ENV{'WEBMIN_VAR'} ||= "/var/webmin";
-	if ($0 =~ /^(.*)\/[^\/]+$/) {
-		chdir($pwd = $1);
-		}
-	else {
-		chop($pwd = `pwd`);
-		}
+	require FindBin;
+	chdir($pwd = $FindBin::RealBin) ||
+		die "Failed to chdir to $FindBin::RealBin : $!";
 	$0 = "$pwd/list-rs-files.pl";
 	require './virtual-server-lib.pl';
 	$< == 0 || die "list-rs-files.pl must be run as root";

--- a/list-s3-accounts.pl
+++ b/list-s3-accounts.pl
@@ -17,12 +17,9 @@ if (!$module_name) {
 	$main::no_acl_check++;
 	$ENV{'WEBMIN_CONFIG'} ||= "/etc/webmin";
 	$ENV{'WEBMIN_VAR'} ||= "/var/webmin";
-	if ($0 =~ /^(.*)\/[^\/]+$/) {
-		chdir($pwd = $1);
-		}
-	else {
-		chop($pwd = `pwd`);
-		}
+	require FindBin;
+	chdir($pwd = $FindBin::RealBin) ||
+		die "Failed to chdir to $FindBin::RealBin : $!";
 	$0 = "$pwd/list-s3-accounts.pl";
 	require './virtual-server-lib.pl';
 	$< == 0 || die "list-s3-accounts.pl must be run as root";

--- a/list-s3-buckets.pl
+++ b/list-s3-buckets.pl
@@ -20,12 +20,9 @@ if (!$module_name) {
 	$main::no_acl_check++;
 	$ENV{'WEBMIN_CONFIG'} ||= "/etc/webmin";
 	$ENV{'WEBMIN_VAR'} ||= "/var/webmin";
-	if ($0 =~ /^(.*)\/[^\/]+$/) {
-		chdir($pwd = $1);
-		}
-	else {
-		chop($pwd = `pwd`);
-		}
+	require FindBin;
+	chdir($pwd = $FindBin::RealBin) ||
+		die "Failed to chdir to $FindBin::RealBin : $!";
 	$0 = "$pwd/list-s3-buckets.pl";
 	require './virtual-server-lib.pl';
 	$< == 0 || die "list-s3-buckets.pl must be run as root";

--- a/list-s3-files.pl
+++ b/list-s3-files.pl
@@ -20,12 +20,9 @@ if (!$module_name) {
 	$main::no_acl_check++;
 	$ENV{'WEBMIN_CONFIG'} ||= "/etc/webmin";
 	$ENV{'WEBMIN_VAR'} ||= "/var/webmin";
-	if ($0 =~ /^(.*)\/[^\/]+$/) {
-		chdir($pwd = $1);
-		}
-	else {
-		chop($pwd = `pwd`);
-		}
+	require FindBin;
+	chdir($pwd = $FindBin::RealBin) ||
+		die "Failed to chdir to $FindBin::RealBin : $!";
 	$0 = "$pwd/list-s3-files.pl";
 	require './virtual-server-lib.pl';
 	$< == 0 || die "list-s3-files.pl must be run as root";

--- a/list-scheduled-backups.pl
+++ b/list-scheduled-backups.pl
@@ -22,12 +22,9 @@ if (!$module_name) {
 	$main::no_acl_check++;
 	$ENV{'WEBMIN_CONFIG'} ||= "/etc/webmin";
 	$ENV{'WEBMIN_VAR'} ||= "/var/webmin";
-	if ($0 =~ /^(.*)\/[^\/]+$/) {
-		chdir($pwd = $1);
-		}
-	else {
-		chop($pwd = `pwd`);
-		}
+	require FindBin;
+	chdir($pwd = $FindBin::RealBin) ||
+		die "Failed to chdir to $FindBin::RealBin : $!";
 	$0 = "$pwd/list-scheduled-backups.pl";
 	require './virtual-server-lib.pl';
 	$< == 0 || die "list-scheduled-backups.pl must be run as root";

--- a/list-scripts.pl
+++ b/list-scripts.pl
@@ -25,12 +25,9 @@ if (!$module_name) {
 	$main::no_acl_check++;
 	$ENV{'WEBMIN_CONFIG'} ||= "/etc/webmin";
 	$ENV{'WEBMIN_VAR'} ||= "/var/webmin";
-	if ($0 =~ /^(.*)\/[^\/]+$/) {
-		chdir($pwd = $1);
-		}
-	else {
-		chop($pwd = `pwd`);
-		}
+	require FindBin;
+	chdir($pwd = $FindBin::RealBin) ||
+		die "Failed to chdir to $FindBin::RealBin : $!";
 	$0 = "$pwd/list-scripts.pl";
 	require './virtual-server-lib.pl';
 	$< == 0 || die "list-scripts.pl must be run as root";

--- a/list-server-statuses.pl
+++ b/list-server-statuses.pl
@@ -14,12 +14,9 @@ if (!$module_name) {
 	$main::no_acl_check++;
 	$ENV{'WEBMIN_CONFIG'} ||= "/etc/webmin";
 	$ENV{'WEBMIN_VAR'} ||= "/var/webmin";
-	if ($0 =~ /^(.*)\/[^\/]+$/) {
-		chdir($pwd = $1);
-		}
-	else {
-		chop($pwd = `pwd`);
-		}
+	require FindBin;
+	chdir($pwd = $FindBin::RealBin) ||
+		die "Failed to chdir to $FindBin::RealBin : $!";
 	$0 = "$pwd/check-scripts.pl";
 	require './virtual-server-lib.pl';
 	$< == 0 || die "list-server-statuses.pl must be run as root";

--- a/list-service-certs.pl
+++ b/list-service-certs.pl
@@ -15,12 +15,9 @@ if (!$module_name) {
 	$main::no_acl_check++;
 	$ENV{'WEBMIN_CONFIG'} ||= "/etc/webmin";
 	$ENV{'WEBMIN_VAR'} ||= "/var/webmin";
-	if ($0 =~ /^(.*)\/[^\/]+$/) {
-		chdir($pwd = $1);
-		}
-	else {
-		chop($pwd = `pwd`);
-		}
+	require FindBin;
+	chdir($pwd = $FindBin::RealBin) ||
+		die "Failed to chdir to $FindBin::RealBin : $!";
 	$0 = "$pwd/list-certs.pl";
 	require './virtual-server-lib.pl';
 	$< == 0 || die "list-certs.pl must be run as root";

--- a/list-shared-addresses.pl
+++ b/list-shared-addresses.pl
@@ -21,12 +21,9 @@ if (!$module_name) {
 	$main::no_acl_check++;
 	$ENV{'WEBMIN_CONFIG'} ||= "/etc/webmin";
 	$ENV{'WEBMIN_VAR'} ||= "/var/webmin";
-	if ($0 =~ /^(.*)\/[^\/]+$/) {
-		chdir($pwd = $1);
-		}
-	else {
-		chop($pwd = `pwd`);
-		}
+	require FindBin;
+	chdir($pwd = $FindBin::RealBin) ||
+		die "Failed to chdir to $FindBin::RealBin : $!";
 	$0 = "$pwd/list-shared-addresses.pl";
 	require './virtual-server-lib.pl';
 	$< == 0 || die "list-shared-addresses.pl must be run as root";

--- a/list-simple-aliases.pl
+++ b/list-simple-aliases.pl
@@ -16,12 +16,9 @@ if (!$module_name) {
 	$main::no_acl_check++;
 	$ENV{'WEBMIN_CONFIG'} ||= "/etc/webmin";
 	$ENV{'WEBMIN_VAR'} ||= "/var/webmin";
-	if ($0 =~ /^(.*)\/[^\/]+$/) {
-		chdir($pwd = $1);
-		}
-	else {
-		chop($pwd = `pwd`);
-		}
+	require FindBin;
+	chdir($pwd = $FindBin::RealBin) ||
+		die "Failed to chdir to $FindBin::RealBin : $!";
 	$0 = "$pwd/list-simple-aliases.pl";
 	require './virtual-server-lib.pl';
 	$< == 0 || die "list-simple-aliases.pl must be run as root";

--- a/list-templates.pl
+++ b/list-templates.pl
@@ -21,12 +21,9 @@ if (!$module_name) {
 	$main::no_acl_check++;
 	$ENV{'WEBMIN_CONFIG'} ||= "/etc/webmin";
 	$ENV{'WEBMIN_VAR'} ||= "/var/webmin";
-	if ($0 =~ /^(.*)\/[^\/]+$/) {
-		chdir($pwd = $1);
-		}
-	else {
-		chop($pwd = `pwd`);
-		}
+	require FindBin;
+	chdir($pwd = $FindBin::RealBin) ||
+		die "Failed to chdir to $FindBin::RealBin : $!";
 	$0 = "$pwd/list-templates.pl";
 	require './virtual-server-lib.pl';
 	$< == 0 || die "list-templates.pl must be run as root";

--- a/list-users.pl
+++ b/list-users.pl
@@ -38,12 +38,9 @@ if (!$module_name) {
 	$main::no_acl_check++;
 	$ENV{'WEBMIN_CONFIG'} ||= "/etc/webmin";
 	$ENV{'WEBMIN_VAR'} ||= "/var/webmin";
-	if ($0 =~ /^(.*)\/[^\/]+$/) {
-		chdir($pwd = $1);
-		}
-	else {
-		chop($pwd = `pwd`);
-		}
+	require FindBin;
+	chdir($pwd = $FindBin::RealBin) ||
+		die "Failed to chdir to $FindBin::RealBin : $!";
 	$0 = "$pwd/list-users.pl";
 	require './virtual-server-lib.pl';
 	$< == 0 || die "list-users.pl must be run as root";

--- a/lookup-domain-daemon.pl
+++ b/lookup-domain-daemon.pl
@@ -23,12 +23,9 @@ package virtual_server;
 $main::no_acl_check++;
 $ENV{'WEBMIN_CONFIG'} ||= "/etc/webmin";
 $ENV{'WEBMIN_VAR'} ||= "/var/webmin";
-if ($0 =~ /^(.*)\/[^\/]+$/) {
-	chdir($pwd = $1);
-	}
-else {
-	chop($pwd = `pwd`);
-	}
+require FindBin;
+chdir($pwd = $FindBin::RealBin) ||
+	die "Failed to chdir to $FindBin::RealBin : $!";
 $0 = "$pwd/lookup-domain-daemon.pl";
 $no_virtualmin_plugins = 1;
 require './virtual-server-lib.pl';

--- a/migrate-domain.pl
+++ b/migrate-domain.pl
@@ -57,12 +57,9 @@ if (!$module_name) {
 	$main::no_acl_check++;
 	$ENV{'WEBMIN_CONFIG'} ||= "/etc/webmin";
 	$ENV{'WEBMIN_VAR'} ||= "/var/webmin";
-	if ($0 =~ /^(.*)\/[^\/]+$/) {
-		chdir($pwd = $1);
-		}
-	else {
-		chop($pwd = `pwd`);
-		}
+	require FindBin;
+	chdir($pwd = $FindBin::RealBin) ||
+		die "Failed to chdir to $FindBin::RealBin : $!";
 	$0 = "$pwd/migrate-domain.pl";
 	require './virtual-server-lib.pl';
 	$< == 0 || die "migrate-domain.pl must be run as root";

--- a/modify-admin.pl
+++ b/modify-admin.pl
@@ -46,12 +46,9 @@ if (!$module_name) {
 	$main::no_acl_check++;
 	$ENV{'WEBMIN_CONFIG'} ||= "/etc/webmin";
 	$ENV{'WEBMIN_VAR'} ||= "/var/webmin";
-	if ($0 =~ /^(.*)\/[^\/]+$/) {
-		chdir($pwd = $1);
-		}
-	else {
-		chop($pwd = `pwd`);
-		}
+	require FindBin;
+	chdir($pwd = $FindBin::RealBin) ||
+		die "Failed to chdir to $FindBin::RealBin : $!";
 	$0 = "$pwd/modify-admin.pl";
 	require './virtual-server-lib.pl';
 	$< == 0 || die "modify-admin.pl must be run as root";

--- a/modify-all-ips.pl
+++ b/modify-all-ips.pl
@@ -25,12 +25,9 @@ if (!$module_name) {
 	$main::no_acl_check++;
 	$ENV{'WEBMIN_CONFIG'} ||= "/etc/webmin";
 	$ENV{'WEBMIN_VAR'} ||= "/var/webmin";
-	if ($0 =~ /^(.*)\/[^\/]+$/) {
-		chdir($pwd = $1);
-		}
-	else {
-		chop($pwd = `pwd`);
-		}
+	require FindBin;
+	chdir($pwd = $FindBin::RealBin) ||
+		die "Failed to chdir to $FindBin::RealBin : $!";
 	$0 = "$pwd/modify-all-ips.pl";
 	require './virtual-server-lib.pl';
 	$< == 0 || die "modify-all-ips.pl must be run as root";

--- a/modify-custom.pl
+++ b/modify-custom.pl
@@ -21,12 +21,9 @@ if (!$module_name) {
 	$main::no_acl_check++;
 	$ENV{'WEBMIN_CONFIG'} ||= "/etc/webmin";
 	$ENV{'WEBMIN_VAR'} ||= "/var/webmin";
-	if ($0 =~ /^(.*)\/[^\/]+$/) {
-		chdir($pwd = $1);
-		}
-	else {
-		chop($pwd = `pwd`);
-		}
+	require FindBin;
+	chdir($pwd = $FindBin::RealBin) ||
+		die "Failed to chdir to $FindBin::RealBin : $!";
 	$0 = "$pwd/modify-custom.pl";
 	require './virtual-server-lib.pl';
 	$< == 0 || die "modify-custom.pl must be run as root";

--- a/modify-database-hosts.pl
+++ b/modify-database-hosts.pl
@@ -28,12 +28,9 @@ if (!$module_name) {
 	$main::no_acl_check++;
 	$ENV{'WEBMIN_CONFIG'} ||= "/etc/webmin";
 	$ENV{'WEBMIN_VAR'} ||= "/var/webmin";
-	if ($0 =~ /^(.*)\/[^\/]+$/) {
-		chdir($pwd = $1);
-		}
-	else {
-		chop($pwd = `pwd`);
-		}
+	require FindBin;
+	chdir($pwd = $FindBin::RealBin) ||
+		die "Failed to chdir to $FindBin::RealBin : $!";
 	$0 = "$pwd/modify-database-hosts.pl";
 	require './virtual-server-lib.pl';
 	$< == 0 || die "modify-database-hosts.pl must be run as root";

--- a/modify-database-pass.pl
+++ b/modify-database-pass.pl
@@ -21,12 +21,9 @@ if (!$module_name) {
 	$main::no_acl_check++;
 	$ENV{'WEBMIN_CONFIG'} ||= "/etc/webmin";
 	$ENV{'WEBMIN_VAR'} ||= "/var/webmin";
-	if ($0 =~ /^(.*)\/[^\/]+$/) {
-		chdir($pwd = $1);
-		}
-	else {
-		chop($pwd = `pwd`);
-		}
+	require FindBin;
+	chdir($pwd = $FindBin::RealBin) ||
+		die "Failed to chdir to $FindBin::RealBin : $!";
 	$0 = "$pwd/modify-database-pass.pl";
 	require './virtual-server-lib.pl';
 	$< == 0 || die "modify-database-pass.pl must be run as root";

--- a/modify-database-user.pl
+++ b/modify-database-user.pl
@@ -21,12 +21,9 @@ if (!$module_name) {
 	$main::no_acl_check++;
 	$ENV{'WEBMIN_CONFIG'} ||= "/etc/webmin";
 	$ENV{'WEBMIN_VAR'} ||= "/var/webmin";
-	if ($0 =~ /^(.*)\/[^\/]+$/) {
-		chdir($pwd = $1);
-		}
-	else {
-		chop($pwd = `pwd`);
-		}
+	require FindBin;
+	chdir($pwd = $FindBin::RealBin) ||
+		die "Failed to chdir to $FindBin::RealBin : $!";
 	$0 = "$pwd/modify-database-user.pl";
 	require './virtual-server-lib.pl';
 	$< == 0 || die "modify-database-user.pl must be run as root";

--- a/modify-dns.pl
+++ b/modify-dns.pl
@@ -119,12 +119,9 @@ if (!$module_name) {
 	$main::no_acl_check++;
 	$ENV{'WEBMIN_CONFIG'} ||= "/etc/webmin";
 	$ENV{'WEBMIN_VAR'} ||= "/var/webmin";
-	if ($0 =~ /^(.*)\/[^\/]+$/) {
-		chdir($pwd = $1);
-		}
-	else {
-		chop($pwd = `pwd`);
-		}
+	require FindBin;
+	chdir($pwd = $FindBin::RealBin) ||
+		die "Failed to chdir to $FindBin::RealBin : $!";
 	$0 = "$pwd/modify-dns.pl";
 	require './virtual-server-lib.pl';
 	$< == 0 || die "modify-dns.pl must be run as root";

--- a/modify-domain.pl
+++ b/modify-domain.pl
@@ -84,12 +84,9 @@ if (!$module_name) {
 	$main::no_acl_check++;
 	$ENV{'WEBMIN_CONFIG'} ||= "/etc/webmin";
 	$ENV{'WEBMIN_VAR'} ||= "/var/webmin";
-	if ($0 =~ /^(.*)\/[^\/]+$/) {
-		chdir($pwd = $1);
-		}
-	else {
-		chop($pwd = `pwd`);
-		}
+	require FindBin;
+	chdir($pwd = $FindBin::RealBin) ||
+		die "Failed to chdir to $FindBin::RealBin : $!";
 	$0 = "$pwd/modify-domain.pl";
 	require './virtual-server-lib.pl';
 	$< == 0 || die "modify-domain.pl must be run as root";

--- a/modify-limits.pl
+++ b/modify-limits.pl
@@ -100,12 +100,9 @@ if (!$module_name) {
 	$main::no_acl_check++;
 	$ENV{'WEBMIN_CONFIG'} ||= "/etc/webmin";
 	$ENV{'WEBMIN_VAR'} ||= "/var/webmin";
-	if ($0 =~ /^(.*)\/[^\/]+$/) {
-		chdir($pwd = $1);
-		}
-	else {
-		chop($pwd = `pwd`);
-		}
+	require FindBin;
+	chdir($pwd = $FindBin::RealBin) ||
+		die "Failed to chdir to $FindBin::RealBin : $!";
 	$0 = "$pwd/modify-limits.pl";
 	require './virtual-server-lib.pl';
 	$< == 0 || die "modify-limits.pl must be run as root";

--- a/modify-mail.pl
+++ b/modify-mail.pl
@@ -75,12 +75,9 @@ if (!$module_name) {
 	$main::no_acl_check++;
 	$ENV{'WEBMIN_CONFIG'} ||= "/etc/webmin";
 	$ENV{'WEBMIN_VAR'} ||= "/var/webmin";
-	if ($0 =~ /^(.*)\/[^\/]+$/) {
-		chdir($pwd = $1);
-		}
-	else {
-		chop($pwd = `pwd`);
-		}
+	require FindBin;
+	chdir($pwd = $FindBin::RealBin) ||
+		die "Failed to chdir to $FindBin::RealBin : $!";
 	$0 = "$pwd/modify-mail.pl";
 	require './virtual-server-lib.pl';
 	$< == 0 || die "modify-mail.pl must be run as root";

--- a/modify-php-ini.pl
+++ b/modify-php-ini.pl
@@ -32,12 +32,9 @@ if (!$module_name) {
 	$main::no_acl_check++;
 	$ENV{'WEBMIN_CONFIG'} ||= "/etc/webmin";
 	$ENV{'WEBMIN_VAR'} ||= "/var/webmin";
-	if ($0 =~ /^(.*)\/[^\/]+$/) {
-		chdir($pwd = $1);
-		}
-	else {
-		chop($pwd = `pwd`);
-		}
+	require FindBin;
+	chdir($pwd = $FindBin::RealBin) ||
+		die "Failed to chdir to $FindBin::RealBin : $!";
 	$0 = "$pwd/modify-php-ini.pl";
 	require './virtual-server-lib.pl';
 	$< == 0 || die "modify-php-ini.pl must be run as root";

--- a/modify-plan.pl
+++ b/modify-plan.pl
@@ -19,12 +19,9 @@ if (!$module_name) {
 	$main::no_acl_check++;
 	$ENV{'WEBMIN_CONFIG'} ||= "/etc/webmin";
 	$ENV{'WEBMIN_VAR'} ||= "/var/webmin";
-	if ($0 =~ /^(.*)\/[^\/]+$/) {
-		chdir($pwd = $1);
-		}
-	else {
-		chop($pwd = `pwd`);
-		}
+	require FindBin;
+	chdir($pwd = $FindBin::RealBin) ||
+		die "Failed to chdir to $FindBin::RealBin : $!";
 	$0 = "$pwd/modify-plan.pl";
 	require './virtual-server-lib.pl';
 	$< == 0 || die "modify-plan.pl must be run as root";

--- a/modify-proxy.pl
+++ b/modify-proxy.pl
@@ -22,12 +22,9 @@ if (!$module_name) {
 	$main::no_acl_check++;
 	$ENV{'WEBMIN_CONFIG'} ||= "/etc/webmin";
 	$ENV{'WEBMIN_VAR'} ||= "/var/webmin";
-	if ($0 =~ /^(.*)\/[^\/]+$/) {
-		chdir($pwd = $1);
-		}
-	else {
-		chop($pwd = `pwd`);
-		}
+	require FindBin;
+	chdir($pwd = $FindBin::RealBin) ||
+		die "Failed to chdir to $FindBin::RealBin : $!";
 	$0 = "$pwd/modify-proxy.pl";
 	require './virtual-server-lib.pl';
 	$< == 0 || die "delete-proxy.pl must be run as root";

--- a/modify-scheduled-backup.pl
+++ b/modify-scheduled-backup.pl
@@ -19,12 +19,9 @@ if (!$module_name) {
 	$main::no_acl_check++;
 	$ENV{'WEBMIN_CONFIG'} ||= "/etc/webmin";
 	$ENV{'WEBMIN_VAR'} ||= "/var/webmin";
-	if ($0 =~ /^(.*)\/[^\/]+$/) {
-		chdir($pwd = $1);
-		}
-	else {
-		chop($pwd = `pwd`);
-		}
+	require FindBin;
+	chdir($pwd = $FindBin::RealBin) ||
+		die "Failed to chdir to $FindBin::RealBin : $!";
 	$0 = "$pwd/modify-scheduled-backup.pl";
 	require './virtual-server-lib.pl';
 	$< == 0 || die "modify-scheduled-backup.pl must be run as root";

--- a/modify-spam.pl
+++ b/modify-spam.pl
@@ -58,12 +58,9 @@ if (!$module_name) {
 	$main::no_acl_check++;
 	$ENV{'WEBMIN_CONFIG'} ||= "/etc/webmin";
 	$ENV{'WEBMIN_VAR'} ||= "/var/webmin";
-	if ($0 =~ /^(.*)\/[^\/]+$/) {
-		chdir($pwd = $1);
-		}
-	else {
-		chop($pwd = `pwd`);
-		}
+	require FindBin;
+	chdir($pwd = $FindBin::RealBin) ||
+		die "Failed to chdir to $FindBin::RealBin : $!";
 	$0 = "$pwd/modify-spam.pl";
 	require './virtual-server-lib.pl';
 	$< == 0 || die "modify-spam.pl must be run as root";

--- a/modify-template.pl
+++ b/modify-template.pl
@@ -23,12 +23,9 @@ if (!$module_name) {
 	$main::no_acl_check++;
 	$ENV{'WEBMIN_CONFIG'} ||= "/etc/webmin";
 	$ENV{'WEBMIN_VAR'} ||= "/var/webmin";
-	if ($0 =~ /^(.*)\/[^\/]+$/) {
-		chdir($pwd = $1);
-		}
-	else {
-		chop($pwd = `pwd`);
-		}
+	require FindBin;
+	chdir($pwd = $FindBin::RealBin) ||
+		die "Failed to chdir to $FindBin::RealBin : $!";
 	$0 = "$pwd/modify-templates.pl";
 	require './virtual-server-lib.pl';
 	$< == 0 || die "modify-templates.pl must be run as root";

--- a/modify-user.pl
+++ b/modify-user.pl
@@ -84,12 +84,9 @@ if (!$module_name) {
 	$main::no_acl_check++;
 	$ENV{'WEBMIN_CONFIG'} ||= "/etc/webmin";
 	$ENV{'WEBMIN_VAR'} ||= "/var/webmin";
-	if ($0 =~ /^(.*)\/[^\/]+$/) {
-		chdir($pwd = $1);
-		}
-	else {
-		chop($pwd = `pwd`);
-		}
+	require FindBin;
+	chdir($pwd = $FindBin::RealBin) ||
+		die "Failed to chdir to $FindBin::RealBin : $!";
 	$0 = "$pwd/modify-user.pl";
 	require './virtual-server-lib.pl';
 	$< == 0 || die "modify-user.pl must be run as root";

--- a/modify-users.pl
+++ b/modify-users.pl
@@ -29,12 +29,9 @@ if (!$module_name) {
 	$main::no_acl_check++;
 	$ENV{'WEBMIN_CONFIG'} ||= "/etc/webmin";
 	$ENV{'WEBMIN_VAR'} ||= "/var/webmin";
-	if ($0 =~ /^(.*)\/[^\/]+$/) {
-		chdir($pwd = $1);
-		}
-	else {
-		chop($pwd = `pwd`);
-		}
+	require FindBin;
+	chdir($pwd = $FindBin::RealBin) ||
+		die "Failed to chdir to $FindBin::RealBin : $!";
 	$0 = "$pwd/modify-users.pl";
 	require './virtual-server-lib.pl';
 	$< == 0 || die "modify-users.pl must be run as root";

--- a/modify-web.pl
+++ b/modify-web.pl
@@ -149,12 +149,9 @@ if (!$module_name) {
 	$main::no_acl_check++;
 	$ENV{'WEBMIN_CONFIG'} ||= "/etc/webmin";
 	$ENV{'WEBMIN_VAR'} ||= "/var/webmin";
-	if ($0 =~ /^(.*)\/[^\/]+$/) {
-		chdir($pwd = $1);
-		}
-	else {
-		chop($pwd = `pwd`);
-		}
+	require FindBin;
+	chdir($pwd = $FindBin::RealBin) ||
+		die "Failed to chdir to $FindBin::RealBin : $!";
 	$0 = "$pwd/modify-web.pl";
 	require './virtual-server-lib.pl';
 	$< == 0 || die "modify-web.pl must be run as root";

--- a/move-domain.pl
+++ b/move-domain.pl
@@ -31,12 +31,9 @@ if (!$module_name) {
 	$main::no_acl_check++;
 	$ENV{'WEBMIN_CONFIG'} ||= "/etc/webmin";
 	$ENV{'WEBMIN_VAR'} ||= "/var/webmin";
-	if ($0 =~ /^(.*)\/[^\/]+$/) {
-		chdir($pwd = $1);
-		}
-	else {
-		chop($pwd = `pwd`);
-		}
+	require FindBin;
+	chdir($pwd = $FindBin::RealBin) ||
+		die "Failed to chdir to $FindBin::RealBin : $!";
 	$0 = "$pwd/move-domain.pl";
 	require './virtual-server-lib.pl';
 	$< == 0 || die "move-domain.pl must be run as root";

--- a/notify-domains.pl
+++ b/notify-domains.pl
@@ -38,12 +38,9 @@ if (!$module_name) {
 	$main::no_acl_check++;
 	$ENV{'WEBMIN_CONFIG'} ||= "/etc/webmin";
 	$ENV{'WEBMIN_VAR'} ||= "/var/webmin";
-	if ($0 =~ /^(.*)\/[^\/]+$/) {
-		chdir($pwd = $1);
-		}
-	else {
-		chop($pwd = `pwd`);
-		}
+	require FindBin;
+	chdir($pwd = $FindBin::RealBin) ||
+		die "Failed to chdir to $FindBin::RealBin : $!";
 	$0 = "$pwd/resend-email.pl";
 	require './virtual-server-lib.pl';
 	$< == 0 || die "resend-email.pl must be run as root";

--- a/rename-domain.pl
+++ b/rename-domain.pl
@@ -24,12 +24,9 @@ if (!$module_name) {
 	$main::no_acl_check++;
 	$ENV{'WEBMIN_CONFIG'} ||= "/etc/webmin";
 	$ENV{'WEBMIN_VAR'} ||= "/var/webmin";
-	if ($0 =~ /^(.*)\/[^\/]+$/) {
-		chdir($pwd = $1);
-		}
-	else {
-		chop($pwd = `pwd`);
-		}
+	require FindBin;
+	chdir($pwd = $FindBin::RealBin) ||
+		die "Failed to chdir to $FindBin::RealBin : $!";
 	$0 = "$pwd/modify-domain.pl";
 	require './virtual-server-lib.pl';
 	$< == 0 || die "modify-domain.pl must be run as root";

--- a/resend-email.pl
+++ b/resend-email.pl
@@ -14,12 +14,9 @@ if (!$module_name) {
 	$main::no_acl_check++;
 	$ENV{'WEBMIN_CONFIG'} ||= "/etc/webmin";
 	$ENV{'WEBMIN_VAR'} ||= "/var/webmin";
-	if ($0 =~ /^(.*)\/[^\/]+$/) {
-		chdir($pwd = $1);
-		}
-	else {
-		chop($pwd = `pwd`);
-		}
+	require FindBin;
+	chdir($pwd = $FindBin::RealBin) ||
+		die "Failed to chdir to $FindBin::RealBin : $!";
 	$0 = "$pwd/resend-email.pl";
 	require './virtual-server-lib.pl';
 	$< == 0 || die "resend-email.pl must be run as root";

--- a/reset-feature.pl
+++ b/reset-feature.pl
@@ -23,12 +23,9 @@ if (!$module_name) {
 	$main::no_acl_check++;
 	$ENV{'WEBMIN_CONFIG'} ||= "/etc/webmin";
 	$ENV{'WEBMIN_VAR'} ||= "/var/webmin";
-	if ($0 =~ /^(.*)\/[^\/]+$/) {
-		chdir($pwd = $1);
-		}
-	else {
-		chop($pwd = `pwd`);
-		}
+	require FindBin;
+	chdir($pwd = $FindBin::RealBin) ||
+		die "Failed to chdir to $FindBin::RealBin : $!";
 	$0 = "$pwd/reset-feature.pl";
 	require './virtual-server-lib.pl';
 	$< == 0 || die "reset-feature.pl must be run as root";

--- a/reset-pass.pl
+++ b/reset-pass.pl
@@ -32,12 +32,9 @@ if (!$module_name) {
 	$main::no_acl_check++;
 	$ENV{'WEBMIN_CONFIG'} ||= "/etc/webmin";
 	$ENV{'WEBMIN_VAR'} ||= "/var/webmin";
-	if ($0 =~ /^(.*)\/[^\/]+$/) {
-		chdir($pwd = $1);
-		}
-	else {
-		chop($pwd = `pwd`);
-		}
+	require FindBin;
+	chdir($pwd = $FindBin::RealBin) ||
+		die "Failed to chdir to $FindBin::RealBin : $!";
 	$0 = "$pwd/reset-pass.pl";
 	require './virtual-server-lib.pl';
 	$< == 0 || die "reset-pass.pl must be run as root";

--- a/restart-server.pl
+++ b/restart-server.pl
@@ -23,12 +23,9 @@ if (!$module_name) {
 	$main::no_acl_check++;
 	$ENV{'WEBMIN_CONFIG'} ||= "/etc/webmin";
 	$ENV{'WEBMIN_VAR'} ||= "/var/webmin";
-	if ($0 =~ /^(.*)\/[^\/]+$/) {
-		chdir($pwd = $1);
-		}
-	else {
-		chop($pwd = `pwd`);
-		}
+	require FindBin;
+	chdir($pwd = $FindBin::RealBin) ||
+		die "Failed to chdir to $FindBin::RealBin : $!";
 	$0 = "$pwd/restart-server.pl";
 	require './virtual-server-lib.pl';
 	$< == 0 || die "restart-server.pl must be run as root";

--- a/restore-config-revision.pl
+++ b/restore-config-revision.pl
@@ -98,12 +98,9 @@ if (!$module_name) {
 	$main::no_acl_check++;
 	$ENV{'WEBMIN_CONFIG'} ||= "/etc/webmin";
 	$ENV{'WEBMIN_VAR'} ||= "/var/webmin";
-	if ($0 =~ /^(.*)\/[^\/]+$/) {
-		chdir($pwd = $1);
-		}
-	else {
-		chop($pwd = `pwd`);
-		}
+	require FindBin;
+	chdir($pwd = $FindBin::RealBin) ||
+		die "Failed to chdir to $FindBin::RealBin : $!";
 	$0 = "$pwd/restore-config-revision.pl";
 	require './virtual-server-lib.pl';
 	$< == 0 || die "restore-config-revision.pl must be run as root";

--- a/restore-domain.pl
+++ b/restore-domain.pl
@@ -103,12 +103,9 @@ if (!$module_name) {
 	$main::no_acl_check++;
 	$ENV{'WEBMIN_CONFIG'} ||= "/etc/webmin";
 	$ENV{'WEBMIN_VAR'} ||= "/var/webmin";
-	if ($0 =~ /^(.*)\/[^\/]+$/) {
-		chdir($pwd = $1);
-		}
-	else {
-		chop($pwd = `pwd`);
-		}
+	require FindBin;
+	chdir($pwd = $FindBin::RealBin) ||
+		die "Failed to chdir to $FindBin::RealBin : $!";
 	$0 = "$pwd/restore-domain.pl";
 	require './virtual-server-lib.pl';
 	$< == 0 || die "restore-domain.pl must be run as root";

--- a/run-all-webalizer.pl
+++ b/run-all-webalizer.pl
@@ -16,12 +16,9 @@ package virtual_server;
 $main::no_acl_check++;
 $ENV{'WEBMIN_CONFIG'} ||= "/etc/webmin";
 $ENV{'WEBMIN_VAR'} ||= "/var/webmin";
-if ($0 =~ /^(.*)\/[^\/]+$/) {
-	chdir($pwd = $1);
-	}
-else {
-	chop($pwd = `pwd`);
-	}
+require FindBin;
+chdir($pwd = $FindBin::RealBin) ||
+	die "Failed to chdir to $FindBin::RealBin : $!";
 $0 = "$pwd/run-all-webalizer.pl";
 require './virtual-server-lib.pl';
 $< == 0 || die "run-all-webalizer.pl must be run as root";

--- a/run-api-command.pl
+++ b/run-api-command.pl
@@ -47,12 +47,9 @@ if (!$module_name) {
 	$main::no_acl_check++;
 	$ENV{'WEBMIN_CONFIG'} ||= "/etc/webmin";
 	$ENV{'WEBMIN_VAR'} ||= "/var/webmin";
-	if ($0 =~ /^(.*)\/[^\/]+$/) {
-		chdir($pwd = $1);
-		}
-	else {
-		chop($pwd = `pwd`);
-		}
+	require FindBin;
+	chdir($pwd = $FindBin::RealBin) ||
+		die "Failed to chdir to $FindBin::RealBin : $!";
 	$0 = "$pwd/run-api-command.pl";
 	require './virtual-server-lib.pl';
 	$< == 0 || die "run-api-command.pl must be run as root";

--- a/set-dkim.pl
+++ b/set-dkim.pl
@@ -24,12 +24,9 @@ if (!$module_name) {
 	$main::no_acl_check++;
 	$ENV{'WEBMIN_CONFIG'} ||= "/etc/webmin";
 	$ENV{'WEBMIN_VAR'} ||= "/var/webmin";
-	if ($0 =~ /^(.*)\/[^\/]+$/) {
-		chdir($pwd = $1);
-		}
-	else {
-		chop($pwd = `pwd`);
-		}
+	require FindBin;
+	chdir($pwd = $FindBin::RealBin) ||
+		die "Failed to chdir to $FindBin::RealBin : $!";
 	$0 = "$pwd/set-dkim.pl";
 	require './virtual-server-lib.pl';
 	$< == 0 || die "set-spam.pl must be run as root";

--- a/set-global-feature.pl
+++ b/set-global-feature.pl
@@ -24,12 +24,9 @@ if (!$module_name) {
 	$main::no_acl_check++;
 	$ENV{'WEBMIN_CONFIG'} ||= "/etc/webmin";
 	$ENV{'WEBMIN_VAR'} ||= "/var/webmin";
-	if ($0 =~ /^(.*)\/[^\/]+$/) {
-		chdir($pwd = $1);
-		}
-	else {
-		chop($pwd = `pwd`);
-		}
+	require FindBin;
+	chdir($pwd = $FindBin::RealBin) ||
+		die "Failed to chdir to $FindBin::RealBin : $!";
 	$0 = "$pwd/set-global-feature.pl";
 	require './virtual-server-lib.pl';
 	$< == 0 || die "set-global-feature.pl must be run as root";

--- a/set-mysql-pass.pl
+++ b/set-mysql-pass.pl
@@ -16,12 +16,9 @@ if (!$module_name) {
 	$main::no_acl_check++;
 	$ENV{'WEBMIN_CONFIG'} ||= "/etc/webmin";
 	$ENV{'WEBMIN_VAR'} ||= "/var/webmin";
-	if ($0 =~ /^(.*)\/[^\/]+$/) {
-		chdir($pwd = $1);
-		}
-	else {
-		chop($pwd = `pwd`);
-		}
+	require FindBin;
+	chdir($pwd = $FindBin::RealBin) ||
+		die "Failed to chdir to $FindBin::RealBin : $!";
 	$0 = "$pwd/set-mysql-pass.pl";
 	require './virtual-server-lib.pl';
 	$< == 0 || die "set-mysql-pass.pl must be run as root";

--- a/set-php-directory.pl
+++ b/set-php-directory.pl
@@ -20,12 +20,9 @@ if (!$module_name) {
 	$main::no_acl_check++;
 	$ENV{'WEBMIN_CONFIG'} ||= "/etc/webmin";
 	$ENV{'WEBMIN_VAR'} ||= "/var/webmin";
-	if ($0 =~ /^(.*)\/[^\/]+$/) {
-		chdir($pwd = $1);
-		}
-	else {
-		chop($pwd = `pwd`);
-		}
+	require FindBin;
+	chdir($pwd = $FindBin::RealBin) ||
+		die "Failed to chdir to $FindBin::RealBin : $!";
 	$0 = "$pwd/set-php-directory.pl";
 	require './virtual-server-lib.pl';
 	$< == 0 || die "set-php-directory.pl must be run as root";

--- a/set-spam.pl
+++ b/set-spam.pl
@@ -31,12 +31,9 @@ if (!$module_name) {
 	$main::no_acl_check++;
 	$ENV{'WEBMIN_CONFIG'} ||= "/etc/webmin";
 	$ENV{'WEBMIN_VAR'} ||= "/var/webmin";
-	if ($0 =~ /^(.*)\/[^\/]+$/) {
-		chdir($pwd = $1);
-		}
-	else {
-		chop($pwd = `pwd`);
-		}
+	require FindBin;
+	chdir($pwd = $FindBin::RealBin) ||
+		die "Failed to chdir to $FindBin::RealBin : $!";
 	$0 = "$pwd/set-spam.pl";
 	require './virtual-server-lib.pl';
 	$< == 0 || die "set-spam.pl must be run as root";

--- a/setup-repos.pl
+++ b/setup-repos.pl
@@ -25,12 +25,9 @@ if (!$module_name) {
 	$main::no_acl_check++;
 	$ENV{'WEBMIN_CONFIG'} ||= "/etc/webmin";
 	$ENV{'WEBMIN_VAR'} ||= "/var/webmin";
-	if ($0 =~ /^(.*)\/[^\/]+$/) {
-		chdir($pwd = $1);
-		}
-	else {
-		chop($pwd = `pwd`);
-		}
+	require FindBin;
+	chdir($pwd = $FindBin::RealBin) ||
+		die "Failed to chdir to $FindBin::RealBin : $!";
 	$0 = "$pwd/setup-repos.pl";
 	require './virtual-server-lib.pl';
 	require './virtualmin-licence.pl';

--- a/sign-script-installers.pl
+++ b/sign-script-installers.pl
@@ -7,12 +7,9 @@ if (!$module_name) {
         $main::no_acl_check++;
         $ENV{'WEBMIN_CONFIG'} ||= "/etc/webmin";
         $ENV{'WEBMIN_VAR'} ||= "/var/webmin";
-	if ($0 =~ /^(.*)\/[^\/]+$/) {
-		chdir($pwd = $1);
-		}
-	else {
-		chop($pwd = `pwd`);
-		}
+	require FindBin;
+	chdir($pwd = $FindBin::RealBin) ||
+		die "Failed to chdir to $FindBin::RealBin : $!";
         $0 = "$pwd/sign-script-installers.pl";
         require './virtual-server-lib.pl';
         $< == 0 || die "fetch-script-files.pl must be run as root";

--- a/start-stop-script.pl
+++ b/start-stop-script.pl
@@ -22,12 +22,9 @@ if (!$module_name) {
 	$main::no_acl_check++;
 	$ENV{'WEBMIN_CONFIG'} ||= "/etc/webmin";
 	$ENV{'WEBMIN_VAR'} ||= "/var/webmin";
-	if ($0 =~ /^(.*)\/[^\/]+$/) {
-		chdir($pwd = $1);
-		}
-	else {
-		chop($pwd = `pwd`);
-		}
+	require FindBin;
+	chdir($pwd = $FindBin::RealBin) ||
+		die "Failed to chdir to $FindBin::RealBin : $!";
 	$0 = "$pwd/delete-script.pl";
 	require './virtual-server-lib.pl';
 	$< == 0 || die "start-stop-script.pl must be run as root";

--- a/syncmx-domain.pl
+++ b/syncmx-domain.pl
@@ -19,12 +19,9 @@ if (!$module_name) {
 	$main::no_acl_check++;
 	$ENV{'WEBMIN_CONFIG'} ||= "/etc/webmin";
 	$ENV{'WEBMIN_VAR'} ||= "/var/webmin";
-	if ($0 =~ /^(.*)\/[^\/]+$/) {
-		chdir($pwd = $1);
-		}
-	else {
-		chop($pwd = `pwd`);
-		}
+	require FindBin;
+	chdir($pwd = $FindBin::RealBin) ||
+		die "Failed to chdir to $FindBin::RealBin : $!";
 	$0 = "$pwd/syncmx-domain.pl";
 	require './virtual-server-lib.pl';
 	$< == 0 || die "syncmx-domain.pl must be run as root";

--- a/test-imap.pl
+++ b/test-imap.pl
@@ -22,12 +22,9 @@ if (!$module_name) {
 	$main::no_acl_check++;
 	$ENV{'WEBMIN_CONFIG'} ||= "/etc/webmin";
 	$ENV{'WEBMIN_VAR'} ||= "/var/webmin";
-	if ($0 =~ /^(.*)\/[^\/]+$/) {
-		chdir($pwd = $1);
-		}
-	else {
-		chop($pwd = `pwd`);
-		}
+	require FindBin;
+	chdir($pwd = $FindBin::RealBin) ||
+		die "Failed to chdir to $FindBin::RealBin : $!";
 	$0 = "$pwd/test-imap.pl";
 	require './virtual-server-lib.pl';
 	$< == 0 || die "test-imap.pl must be run as root";

--- a/test-pop3.pl
+++ b/test-pop3.pl
@@ -15,12 +15,9 @@ if (!$module_name) {
 	$main::no_acl_check++;
 	$ENV{'WEBMIN_CONFIG'} ||= "/etc/webmin";
 	$ENV{'WEBMIN_VAR'} ||= "/var/webmin";
-	if ($0 =~ /^(.*)\/[^\/]+$/) {
-		chdir($pwd = $1);
-		}
-	else {
-		chop($pwd = `pwd`);
-		}
+	require FindBin;
+	chdir($pwd = $FindBin::RealBin) ||
+		die "Failed to chdir to $FindBin::RealBin : $!";
 	$0 = "$pwd/test-pop3.pl";
 	require './virtual-server-lib.pl';
 	$< == 0 || die "test-pop3.pl must be run as root";

--- a/test-smtp.pl
+++ b/test-smtp.pl
@@ -31,12 +31,9 @@ if (!$module_name) {
 	$main::no_acl_check++;
 	$ENV{'WEBMIN_CONFIG'} ||= "/etc/webmin";
 	$ENV{'WEBMIN_VAR'} ||= "/var/webmin";
-	if ($0 =~ /^(.*)\/[^\/]+$/) {
-		chdir($pwd = $1);
-		}
-	else {
-		chop($pwd = `pwd`);
-		}
+	require FindBin;
+	chdir($pwd = $FindBin::RealBin) ||
+		die "Failed to chdir to $FindBin::RealBin : $!";
 	$0 = "$pwd/test-smtp.pl";
 	require './virtual-server-lib.pl';
 	$< == 0 || die "test-smtp.pl must be run as root";

--- a/transfer-domain.pl
+++ b/transfer-domain.pl
@@ -41,12 +41,9 @@ if (!$module_name) {
 	$main::no_acl_check++;
 	$ENV{'WEBMIN_CONFIG'} ||= "/etc/webmin";
 	$ENV{'WEBMIN_VAR'} ||= "/var/webmin";
-	if ($0 =~ /^(.*)\/[^\/]+$/) {
-		chdir($pwd = $1);
-		}
-	else {
-		chop($pwd = `pwd`);
-		}
+	require FindBin;
+	chdir($pwd = $FindBin::RealBin) ||
+		die "Failed to chdir to $FindBin::RealBin : $!";
 	$0 = "$pwd/transfer-domain.pl";
 	require './virtual-server-lib.pl';
 	$< == 0 || die "transfer-domain.pl must be run as root";

--- a/unalias-domain.pl
+++ b/unalias-domain.pl
@@ -19,12 +19,9 @@ if (!$module_name) {
 	$main::no_acl_check++;
 	$ENV{'WEBMIN_CONFIG'} ||= "/etc/webmin";
 	$ENV{'WEBMIN_VAR'} ||= "/var/webmin";
-	if ($0 =~ /^(.*)\/[^\/]+$/) {
-		chdir($pwd = $1);
-		}
-	else {
-		chop($pwd = `pwd`);
-		}
+	require FindBin;
+	chdir($pwd = $FindBin::RealBin) ||
+		die "Failed to chdir to $FindBin::RealBin : $!";
 	$0 = "$pwd/unalias-domain.pl";
 	require './virtual-server-lib.pl';
 	$< == 0 || die "unalias-domain.pl must be run as root";

--- a/unsub-domain.pl
+++ b/unsub-domain.pl
@@ -19,12 +19,9 @@ if (!$module_name) {
 	$main::no_acl_check++;
 	$ENV{'WEBMIN_CONFIG'} ||= "/etc/webmin";
 	$ENV{'WEBMIN_VAR'} ||= "/var/webmin";
-	if ($0 =~ /^(.*)\/[^\/]+$/) {
-		chdir($pwd = $1);
-		}
-	else {
-		chop($pwd = `pwd`);
-		}
+	require FindBin;
+	chdir($pwd = $FindBin::RealBin) ||
+		die "Failed to chdir to $FindBin::RealBin : $!";
 	$0 = "$pwd/unsub-domain.pl";
 	require './virtual-server-lib.pl';
 	$< == 0 || die "unsub-domain.pl must be run as root";

--- a/upgrade-licence.pl
+++ b/upgrade-licence.pl
@@ -16,12 +16,9 @@ if (!$module_name) {
 	$main::no_acl_check++;
 	$ENV{'WEBMIN_CONFIG'} ||= "/etc/webmin";
 	$ENV{'WEBMIN_VAR'} ||= "/var/webmin";
-	if ($0 =~ /^(.*)\/[^\/]+$/) {
-		chdir($pwd = $1);
-		}
-	else {
-		chop($pwd = `pwd`);
-		}
+	require FindBin;
+	chdir($pwd = $FindBin::RealBin) ||
+		die "Failed to chdir to $FindBin::RealBin : $!";
 	$0 = "$pwd/upgrade-license.pl";
 	require './virtual-server-lib.pl';
 	$< == 0 || die "upgrade-license.pl must be run as root";

--- a/upload-dropbox-file.pl
+++ b/upload-dropbox-file.pl
@@ -15,12 +15,9 @@ if (!$module_name) {
 	$main::no_acl_check++;
 	$ENV{'WEBMIN_CONFIG'} ||= "/etc/webmin";
 	$ENV{'WEBMIN_VAR'} ||= "/var/webmin";
-	if ($0 =~ /^(.*)\/[^\/]+$/) {
-		chdir($pwd = $1);
-		}
-	else {
-		chop($pwd = `pwd`);
-		}
+	require FindBin;
+	chdir($pwd = $FindBin::RealBin) ||
+		die "Failed to chdir to $FindBin::RealBin : $!";
 	$0 = "$pwd/upload-dropbox-file.pl";
 	require './virtual-server-lib.pl';
 	$< == 0 || die "upload-dropbox-file.pl must be run as root";

--- a/upload-rs-file.pl
+++ b/upload-rs-file.pl
@@ -24,12 +24,9 @@ if (!$module_name) {
 	$main::no_acl_check++;
 	$ENV{'WEBMIN_CONFIG'} ||= "/etc/webmin";
 	$ENV{'WEBMIN_VAR'} ||= "/var/webmin";
-	if ($0 =~ /^(.*)\/[^\/]+$/) {
-		chdir($pwd = $1);
-		}
-	else {
-		chop($pwd = `pwd`);
-		}
+	require FindBin;
+	chdir($pwd = $FindBin::RealBin) ||
+		die "Failed to chdir to $FindBin::RealBin : $!";
 	$0 = "$pwd/upload-rs-file.pl";
 	require './virtual-server-lib.pl';
 	$< == 0 || die "upload-rs-file.pl must be run as root";

--- a/upload-s3-file.pl
+++ b/upload-s3-file.pl
@@ -31,12 +31,9 @@ if (!$module_name) {
 	$main::no_acl_check++;
 	$ENV{'WEBMIN_CONFIG'} ||= "/etc/webmin";
 	$ENV{'WEBMIN_VAR'} ||= "/var/webmin";
-	if ($0 =~ /^(.*)\/[^\/]+$/) {
-		chdir($pwd = $1);
-		}
-	else {
-		chop($pwd = `pwd`);
-		}
+	require FindBin;
+	chdir($pwd = $FindBin::RealBin) ||
+		die "Failed to chdir to $FindBin::RealBin : $!";
 	$0 = "$pwd/upload-s3-file.pl";
 	require './virtual-server-lib.pl';
 	$< == 0 || die "upload-s3-file.pl must be run as root";

--- a/validate-domains.pl
+++ b/validate-domains.pl
@@ -19,12 +19,9 @@ if (!$module_name) {
 	$main::no_acl_check++;
 	$ENV{'WEBMIN_CONFIG'} ||= "/etc/webmin";
 	$ENV{'WEBMIN_VAR'} ||= "/var/webmin";
-	if ($0 =~ /^(.*)\/[^\/]+$/) {
-		chdir($pwd = $1);
-		}
-	else {
-		chop($pwd = `pwd`);
-		}
+	require FindBin;
+	chdir($pwd = $FindBin::RealBin) ||
+		die "Failed to chdir to $FindBin::RealBin : $!";
 	$0 = "$pwd/validate-domains.pl";
 	require './virtual-server-lib.pl';
 	$< == 0 || die "validate-domains.pl must be run as root";


### PR DESCRIPTION
Hello Jamie!

As we just discussed on the other PR, this PR replaces existing hand-rolled `$0` path parsing in Virtualmin script bootstraps with Perl’s core `FindBin::RealBin`.

This keeps the current bootstrap behavior and existing `$0` assignments, while avoiding custom path-detection logic.
