### PR TITLE
Fix IPv6-only domain lifecycle regressions

### DIFF
--- a/backups-lib.pl
+++ b/backups-lib.pl
@@ -3100,8 +3100,8 @@ if ($ok) {
 				$d->{'ip6'} = $ipinfo->{'ip6'};
 				$d->{'virt6'} = $ipinfo->{'virt6'};
 				$d->{'virt6already'} = $ipinfo->{'virt6already'};
-				$d->{'netmask6'} = $netmaskinfo->{'netmask6'};
-				if ($ipinfo->{'mode'} == 2) {
+				$d->{'netmask6'} = $ipinfo->{'netmask6'};
+				if ($ipinfo->{'mode6'} == 2) {
 					# Re-allocate an IP, as we might be
 					# doing several domains
 					($d->{'ip6'}, $d->{'netmask6'}) =
@@ -3145,12 +3145,13 @@ if ($ok) {
 			# DNS external IP is always reset to match this system,
 			# as the old setting is unlikely to be correct.
 			$d->{'old_dns_ip'} = $d->{'dns_ip'};
-			$d->{'dns_ip'} = $d->{'virt'} ? undef
+			$d->{'dns_ip'} = !$d->{'ip'} || $d->{'virt'} ? undef
 					       : &get_dns_ip($d->{'reseller'});
 			if (&supports_ip6()) {
 				$d->{'old_dns_ip6'} = $d->{'dns_ip6'};
-				$d->{'dns_ip6'} = $d->{'virt6'} ? undef :
-					&get_dns_ip($d->{'reseller'}, 6);
+				$d->{'dns_ip6'} =
+					!$d->{'ip6'} || $d->{'virt6'} ? undef :
+						&get_dns_ip($d->{'reseller'}, 6);
 				}
 
 			# Change provisioning settings to match this system

--- a/create-domain.pl
+++ b/create-domain.pl
@@ -572,8 +572,8 @@ elsif ($virt) {
 	# Make sure manual IPv4 specification is allowed
 	$tmpl->{'ranges'} eq "none" || &usage("The --ip option cannot be used when automatic IP allocation is configured in templates - use --allocate-ip instead");
 	}
-elsif ($ip eq "default") {
-	# Use default IPv4, which may depend on reseller
+elsif ($ip eq "default" && !$aliasdomain && !$parentip) {
+	# Alias and parent IPv4 addresses are resolved below
 	$ip = $defip;
 	$ip || &usage("No default IP address found");
 	$virt = 0;
@@ -603,9 +603,11 @@ elsif ($virt6) {
 elsif ($ip6 eq "default") {
 	# Use default IPv6, which may depend on reseller
 	$ip6 = $defip6;
-	$ip6 || &usage("No default IPv6 address found");
+	if (!$ip6 && &indexof("--default-ip6", @OLDARGV) >= 0) {
+		&usage("No default IPv6 address found");
+		}
 	$virt6 = 0;
-	$name6 = 1;
+	$name6 = $ip6 ? 1 : 0;
 	}
 
 if (!defined($ip) && !defined($ip6)) {
@@ -820,6 +822,8 @@ if (!$alias) {
 		# IP comes from parent domain
 		$parent || &usage("The --parent-ip flag cannot be used for ".
 				  "top-level servers");
+		$ip = $parent->{'ip'};
+		$ip6 = $parent->{'ip6'} if (!$virt6);
 		}
 
 	if ($virt6) {
@@ -932,7 +936,7 @@ $pclash && &usage(&text('setup_eprefix3', $prefix, $pclash->{'dom'}));
 	 'dns_ip6', !$ip6 ? undef :
 		    defined($dns_ip6) ? $dns_ip6 :
 		    $alias ? $alias->{'dns_ip6'} :
-		    $virt ? undef : &get_dns_ip($resel, 6),
+		    $virt6 ? undef : &get_dns_ip($resel, 6),
          'virt', $virt,
          'virtalready', $virtalready,
 	 'ip6', $parentip ? $parent->{'ip6'} : $ip6,
@@ -1251,5 +1255,3 @@ print "                        [--alias-redirect | --no-alias-redirect]\n";
 print "                        [--ssl-redirect | --no-ssl-redirect]\n";
 exit(1);
 }
-
-

--- a/create-domain.pl
+++ b/create-domain.pl
@@ -603,9 +603,6 @@ elsif ($virt6) {
 elsif ($ip6 eq "default") {
 	# Use default IPv6, which may depend on reseller
 	$ip6 = $defip6;
-	if (!$ip6 && &indexof("--default-ip6", @OLDARGV) >= 0) {
-		&usage("No default IPv6 address found");
-		}
 	$virt6 = 0;
 	$name6 = $ip6 ? 1 : 0;
 	}

--- a/feature-dns.pl
+++ b/feature-dns.pl
@@ -1542,17 +1542,20 @@ if (!$tmpl->{'dns_replace'} || $d->{'dns_submode'}) {
 			# Make sure we have some NS records
 			@created_ns = &unique(@created_ns);
 			if ($tmpl->{'dns_indom'}) {
-				@created_ns = grep { &to_ipaddress($_) } @created_ns;
+				@created_ns = grep { &to_ipaddress($_) ||
+						     &to_ip6address($_) }
+						   @created_ns;
 				}
 			if (!@created_ns && !$d->{'dns_cloud'}) {
 				return $text{'setup_ednsns'};
 				}
 
 			if ($tmpl->{'dns_indom'}) {
-				# Add A records pointing to the nameserver IPs
+				# Add address records for the nameserver IPs
 				my $i = 1;
 				foreach my $ns (@created_ns) {
 					my $a = &to_ipaddress($ns);
+					my $aaaa = &to_ip6address($ns);
 					my $r = "ns".$i.".".$d->{'dom'}.".";
 					&create_dns_record($recs, $file,
 						{ 'name' => '@',
@@ -1562,7 +1565,12 @@ if (!$tmpl->{'dns_replace'} || $d->{'dns_submode'}) {
 						{ 'name' => $r,
 						  'type' => 'A',
 						  'proxied' => $proxied == 1 ? 1 : 0,
-						  'values' => [ $a ] });
+						  'values' => [ $a ] }) if ($a);
+					&create_dns_record($recs, $file,
+						{ 'name' => $r,
+						  'type' => 'AAAA',
+						  'proxied' => $proxied == 1 ? 1 : 0,
+						  'values' => [ $aaaa ] }) if ($aaaa);
 					$i++;
 					}
 				}
@@ -2001,8 +2009,10 @@ return 0 if (!$file);
 my $count = 0;
 foreach my $r (reverse('webmail', 'admin')) {
 	my $n = "$r.$d->{'dom'}.";
-	my ($rec) = grep { $_->{'name'} eq $n } @$recs;
-	if ($rec) {
+	my @delrecs = grep { $_->{'name'} eq $n &&
+			     ($_->{'type'} eq 'A' ||
+			      $_->{'type'} eq 'AAAA') } @$recs;
+	foreach my $rec (reverse(@delrecs)) {
 		&delete_dns_record($recs, $rec->{'file'}, $rec);
 		$count++;
 		}
@@ -2040,7 +2050,7 @@ return &add_ip_any_records($d, $recs, $file, 'AAAA', 'A',
 }
 
 # add_ip_any_records(&domain, [&records, file], old-type, new-type,
-# 		     old-values, new-values)
+# 		     old-value, new-value)
 # Change records of one type to another, converting values as well
 sub add_ip_any_records
 {
@@ -2055,7 +2065,7 @@ return 0 if (!$file);
 my %already;
 foreach my $r (@$recs) {
 	if ($r->{'type'} eq $newrtype &&
-	    &indexof($r->{'values'}->[0], @$newvals) >= 0) {
+	    $r->{'values'}->[0] eq $newval) {
 		$already{$r->{'name'}}++;
 		}
 	}
@@ -2074,7 +2084,6 @@ foreach my $od (&list_domains()) {
 my $count = 0;
 my $withdot = $d->{'dom'}.".";
 foreach my $r (@$recs) {
-	my $idx;
 	if ($r->{'type'} &&
 	    $r->{'type'} eq $oldrtype &&
 	    $r->{'values'}->[0] eq $oldval &&
@@ -2153,15 +2162,17 @@ my $tmpl = &get_template($d->{'template'});
 my ($recs, $file) = &get_domain_dns_records_and_file($d);
 return 0 if (!$file);
 my $withstar = "*.".$d->{'dom'}.".";
-my ($r) = grep { $_->{'name'} eq $withstar } @$recs;
+my ($r) = grep { $_->{'name'} eq $withstar &&
+		  ($_->{'type'} eq 'A' || $_->{'type'} eq 'AAAA') } @$recs;
 my $any = 0;
 if ($star && !$r) {
 	# Need to add
 	my $ip = $d->{'dns_ip'} || $d->{'ip'};
+	my $ip6 = $d->{'dns_ip6'} || $d->{'ip6'};
 	$r = { 'name' => $withstar,
-	       'type' => 'A',
+	       'type' => $ip ? 'A' : 'AAAA',
 	       'proxied' => $tmpl->{'dns_cloud_proxy'} == 1 ? 1 : 0,
-	       'values' => [ $ip ] };
+	       'values' => [ $ip || $ip6 ] };
 	&create_dns_record($recs, $file, $r);
 	$any++;
 	}
@@ -2256,7 +2267,12 @@ foreach my $r (@$recs) {
 	}
 $d->{'dns_submode'} || $d->{'dns_cloud'} || $got{'SOA'} ||
 	return $text{'validate_ednssoa2'};
-$got{'A'} || return $text{'validate_ednsa2'};
+if ($ip) {
+	$got{'A'} || return $text{'validate_ednsa2'};
+	}
+else {
+	$got{'AAAA'} || return $text{'validate_ednsa6'};
+	}
 if ($d->{'virt6'}) {
 	$got{'AAAA'} || return $text{'validate_ednsa6'};
 	}
@@ -4310,7 +4326,8 @@ foreach my $i (split(/\s+/, $includes)) {
 if ($d->{'dns_ip'} && !$tmpl->{'dns_spfonly'}) {
 	push(@{$spf->{'ip4:'}}, $d->{'dns_ip'});
 	}
-if ($d->{'ip'} ne $defip && $d->{'ip'} !~ /^(10\.|192\.168\.)/ &&
+if ($d->{'ip'} && $d->{'ip'} ne $defip &&
+    $d->{'ip'} !~ /^(10\.|192\.168\.)/ &&
     !$tmpl->{'dns_spfonly'}) {
 	push(@{$spf->{'ip4:'}}, $d->{'ip'});
 	}
@@ -6156,4 +6173,3 @@ return { 'id' => 0,
 $done_feature_script{'dns'} = 1;
 
 1;
-

--- a/feature-dns.pl
+++ b/feature-dns.pl
@@ -2162,24 +2162,40 @@ my $tmpl = &get_template($d->{'template'});
 my ($recs, $file) = &get_domain_dns_records_and_file($d);
 return 0 if (!$file);
 my $withstar = "*.".$d->{'dom'}.".";
-my ($r) = grep { $_->{'name'} eq $withstar &&
-		  ($_->{'type'} eq 'A' || $_->{'type'} eq 'AAAA') } @$recs;
+my ($r4) = grep { $_->{'name'} eq $withstar &&
+		   $_->{'type'} eq 'A' } @$recs;
+my ($r6) = grep { $_->{'name'} eq $withstar &&
+		   $_->{'type'} eq 'AAAA' } @$recs;
 my $any = 0;
-if ($star && !$r) {
-	# Need to add
+if ($star) {
+	# Add a wildcard record for each available address
 	my $ip = $d->{'dns_ip'} || $d->{'ip'};
 	my $ip6 = $d->{'dns_ip6'} || $d->{'ip6'};
-	$r = { 'name' => $withstar,
-	       'type' => $ip ? 'A' : 'AAAA',
-	       'proxied' => $tmpl->{'dns_cloud_proxy'} == 1 ? 1 : 0,
-	       'values' => [ $ip || $ip6 ] };
-	&create_dns_record($recs, $file, $r);
-	$any++;
+	if ($ip && !$r4) {
+		$r4 = { 'name' => $withstar,
+			'type' => 'A',
+			'proxied' =>
+				$tmpl->{'dns_cloud_proxy'} == 1 ? 1 : 0,
+			'values' => [ $ip ] };
+		&create_dns_record($recs, $file, $r4);
+		$any++;
+		}
+	if ($ip6 && !$r6) {
+		$r6 = { 'name' => $withstar,
+			'type' => 'AAAA',
+			'proxied' =>
+				$tmpl->{'dns_cloud_proxy'} == 1 ? 1 : 0,
+			'values' => [ $ip6 ] };
+		&create_dns_record($recs, $file, $r6);
+		$any++;
+		}
 	}
-elsif (!$star && $r) {
-	# Need to remove
-	&delete_dns_record($recs, $file, $r);
-	$any++;
+else {
+	# Remove both wildcard address records
+	foreach my $r (grep { $_ } ($r4, $r6)) {
+		&delete_dns_record($recs, $file, $r);
+		$any++;
+		}
 	}
 if ($any) {
 	my $err = &post_records_change($d, $recs, $file);

--- a/feature-dns.pl
+++ b/feature-dns.pl
@@ -1542,9 +1542,9 @@ if (!$tmpl->{'dns_replace'} || $d->{'dns_submode'}) {
 			# Make sure we have some NS records
 			@created_ns = &unique(@created_ns);
 			if ($tmpl->{'dns_indom'}) {
-				@created_ns = grep { &to_ipaddress($_) ||
-						     &to_ip6address($_) }
-						   @created_ns;
+				@created_ns =
+					grep { &to_ipaddress($_) ||
+					       &to_ip6address($_) } @created_ns;
 				}
 			if (!@created_ns && !$d->{'dns_cloud'}) {
 				return $text{'setup_ednsns'};

--- a/feature-mail.pl
+++ b/feature-mail.pl
@@ -965,8 +965,8 @@ if ($config{'mail_autoconfig'} &&
 # Update any outgoing IP mapping
 if ($supports_dependent) {
 	if ($d->{'dom'} ne $oldd->{'dom'} ||
-	    $d->{'ip'} && $oldd->{'ip'} && $d->{'ip'} ne $oldd->{'ip'} ||
-	    $d->{'ip6'} && $oldd->{'ip6'} && $d->{'ip6'} ne $oldd->{'ip6'}) {
+	    ($d->{'ip'} || "") ne ($oldd->{'ip'} || "") ||
+	    ($d->{'ip6'} || "") ne ($oldd->{'ip6'} || "")) {
 		# IP or domain name changed
 		my $old_dependent = &get_domain_dependent($oldd);
 		if ($old_dependent) {
@@ -6346,10 +6346,10 @@ my $changed = 0;
 my ($cr) = grep { $_->{'name'} eq $autoconfig &&
 		  $_->{'type'} eq 'CNAME' } @$recs;
 if (!$cr) {
+	my $ip = $d->{'dns_ip'} || $d->{'ip'};
 	my ($r) = grep { $_->{'name'} eq $autoconfig &&
 			    $_->{'type'} eq 'A' } @$recs;
-	if (!$r) {
-		my $ip = $d->{'dns_ip'} || $d->{'ip'};
+	if (!$r && $ip) {
 		my $cr = { 'name' => $autoconfig,
 			   'type' => 'A',
 			   'proxied' => $proxied ? 1 : 0,
@@ -6359,14 +6359,14 @@ if (!$cr) {
 		}
 
 	# Add AAAA record for IPv6
+	my $ip6 = $d->{'dns_ip6'} || $d->{'ip6'};
 	my ($r) = grep { $_->{'name'} eq $autoconfig &&
 			    $_->{'type'} eq 'AAAA' } @$recs;
-	if (!$r && $d->{'ip6'}) {
-		my $ip = $d->{'dns_ip6'} || $d->{'ip6'};
+	if (!$r && $ip6) {
 		my $cr = { 'name' => $autoconfig,
 			   'type' => 'AAAA',
 			   'proxied' => $proxied ? 1 : 0,
-			   'values' => [ $ip ] };
+			   'values' => [ $ip6 ] };
 		&create_dns_record($recs, $file, $cr);
 		$changed++;
 		}
@@ -6718,7 +6718,7 @@ if ($d->{'dns'}) {
 		}
 	else {
 		# Add standard records
-		&create_mx_records($file, $d, $d->{'ip'}, $d->{'ip6'});
+		&create_mx_records($recs, $file, $d);
 		}
 	&post_records_change($d, $recs);
 	&register_post_action(\&restart_bind, $d);
@@ -6854,12 +6854,15 @@ if (!&copy_alias_records($d)) {
 	&pre_records_change($d);
 	my ($recs, $file) = &get_domain_dns_records_and_file($d);
 	$file || return $recs;
+	my $ip = $d->{'dns_ip'} || $d->{'ip'};
+	my $ip6 = $d->{'dns_ip6'} || $d->{'ip6'};
+	my $rtype = $ip ? 'A' : 'AAAA';
 	my ($mtsa) = grep { $_->{'name'} eq 'mta-sts.'.$d->{'dom'}.'.' &&
-			    $_->{'type'} eq 'A' } @$recs;
+			    $_->{'type'} eq $rtype } @$recs;
 	if (!$mtsa) {
 		$mtsa = { 'name' => 'mta-sts.'.$d->{'dom'}.'.',
-			  'type' => 'A',
-			  'values' => [ $d->{'dns_ip'} || $d->{'ip'} ] };
+			  'type' => $rtype,
+			  'values' => [ $ip || $ip6 ] };
 		&create_dns_record($recs, $file, $mtsa);
 		}
 	my ($mtsr) = grep { $_->{'name'} eq '_mta-sts.'.$d->{'dom'}.'.' &&
@@ -7161,4 +7164,3 @@ return $envfile || "";
 $done_feature_script{'mail'} = 1;
 
 1;
-

--- a/feature-mail.pl
+++ b/feature-mail.pl
@@ -6856,13 +6856,13 @@ if (!&copy_alias_records($d)) {
 	$file || return $recs;
 	my $ip = $d->{'dns_ip'} || $d->{'ip'};
 	my $ip6 = $d->{'dns_ip6'} || $d->{'ip6'};
-	my $rtype = $ip ? 'A' : 'AAAA';
+	my ($rtype, $rvalue) = $ip ? ('A', $ip) : ('AAAA', $ip6);
 	my ($mtsa) = grep { $_->{'name'} eq 'mta-sts.'.$d->{'dom'}.'.' &&
 			    $_->{'type'} eq $rtype } @$recs;
 	if (!$mtsa) {
 		$mtsa = { 'name' => 'mta-sts.'.$d->{'dom'}.'.',
 			  'type' => $rtype,
-			  'values' => [ $ip || $ip6 ] };
+			  'values' => [ $rvalue ] };
 		&create_dns_record($recs, $file, $mtsa);
 		}
 	my ($mtsr) = grep { $_->{'name'} eq '_mta-sts.'.$d->{'dom'}.'.' &&

--- a/feature-mail.pl
+++ b/feature-mail.pl
@@ -971,7 +971,7 @@ if ($supports_dependent) {
 		my $old_dependent = &get_domain_dependent($oldd);
 		if ($old_dependent) {
 			&save_domain_dependent($oldd, 0);
-			&save_domain_dependent($d, 1);
+			&save_domain_dependent($d, 1) if ($d->{'ip'});
 			}
 		}
 	}

--- a/feature-ssl.pl
+++ b/feature-ssl.pl
@@ -111,8 +111,8 @@ else {
 		foreach my $v (&apache::find_directive_struct("VirtualHost",
 							      $conf)) {
 			foreach my $w (@{$v->{'words'}}) {
-				$w =~ /^\[([^\/]+)\]/ || next;
-				my $vip = $1;
+				$w =~ /^\[([^\]]+)\]:(\d+)$/ || next;
+				my ($vip, $vport) = ($1, $2);
 				if ($vip eq $d->{'ip6'} && $vport == $port) {
 					return &text('setup_edepssl4',
 						     $d->{'ip6'}, $port);
@@ -667,13 +667,15 @@ if (&foreign_installed("usermin")) {
 	&usermin::get_usermin_miniserv_config(\%uminiserv);
 	push(@checks, [ \%uminiserv, "Usermin" ]);
 	}
+my @ips = grep { $_ } ($d->{'ip'}, $d->{'ip6'});
 foreach my $c (@checks) {
 	my @sockets = &webmin::get_miniserv_sockets($c->[0]);
 	foreach my $s (@sockets) {
-		if (($s->[0] eq '*' || $s->[0] eq $d->{'ip'}) &&
+		if (($s->[0] eq '*' || &indexof($s->[0], @ips) >= 0) &&
 		    $s->[1] == $port) {
 			return &text('setup_esslportclash',
-				     $d->{'ip'}, $port, $c->[1]);
+				     $d->{'ip'} || $d->{'ip6'},
+				     $port, $c->[1]);
 			}
 		}
 	}
@@ -2318,7 +2320,10 @@ $main::got_lock_ssl-- if ($main::got_lock_ssl);
 sub find_matching_certificate_domain
 {
 my ($d) = @_;
-my @sslclashes = grep { $_->{'ip'} eq $d->{'ip'} &&
+my $ipkey = $d->{'ip'} ? 'ip' : 'ip6';
+my $ip = $d->{$ipkey};
+return wantarray ? ( ) : undef if (!$ip);
+my @sslclashes = grep { $_->{$ipkey} && $_->{$ipkey} eq $ip &&
 			   &domain_has_ssl($_) &&
 			   $_->{'id'} ne $d->{'id'} &&
 			   !$_->{'ssl_same'} } &list_domains();
@@ -2869,16 +2874,18 @@ if ($d->{'ip6'}) {
 return ( ) if (!$l && !$l6);
 return ( ) if (!$imap && !$imap6);
 
-# We have at least one IP
-my $ione = $imap || $imap6;
+# Use the address for the protocol block whose certificate we read
+my ($imap_block, $cert_ip, $cert_ip6) = $imap ?
+	($imap, $d->{'ip'}, undef) :
+	($imap6, undef, $d->{'ip6'});
 my %mems = map { $_->{'name'}, $_->{'value'} }
-	       @{$ione->{'members'}};
+	       @{$imap_block->{'members'}};
 my @rv = ( $mems{'ssl_cert'} || $mems{'ssl_server_cert_file'},
            $mems{'ssl_key'} || $mems{'ssl_server_key_file'},
            $mems{'ssl_ca'},
-           $imap ? $d->{'ip'} : undef,
+           $cert_ip,
            undef,	# No domain name for an IP-based certificate
-           $imap6 ? $d->{'ip6'} : undef,
+           $cert_ip6,
 	 );
 return () if (!$rv[0]);
 foreach my $r (@rv) {
@@ -4666,20 +4673,24 @@ return $rv;
 
 # update_ssl_link_on_domain_change(&domain, &old-domain)
 # If a virtual server changed IP address, update SSL cert linkage
-# XXX what about IPv6 ?
 sub update_ssl_link_on_domain_change
 {
 my ($d, $oldd) = @_;
-if (!$d->{'ip'}) {
+my $ipkey = $d->{'ip'} ? 'ip' : 'ip6';
+my $oldipkey = $oldd->{'ip'} ? 'ip' : 'ip6';
+my $ip = $d->{$ipkey};
+my $oldip = $oldd->{$oldipkey};
+if (!$ip) {
 	# With no IP address, SSL cert linkage is not possible
 	if ($oldd->{'ssl_same'}) {
 		my $oldsslclash = &get_domain($oldd->{'ssl_same'});
 		&break_ssl_linkage($d, $oldsslclash);
 		}
 	}
-elsif ((!$oldd->{'ip'} || $d->{'ip'} ne $oldd->{'ip'}) && $oldd->{'ssl_same'}) {
+elsif (($ipkey ne $oldipkey || !$oldip || $ip ne $oldip) &&
+       $oldd->{'ssl_same'}) {
 	# IP has changed or been added - maybe clear ssl_same field
-	my ($sslclash) = grep { $_->{'ip'} eq $d->{'ip'} &&
+	my ($sslclash) = grep { $_->{$ipkey} && $_->{$ipkey} eq $ip &&
 				&domain_has_ssl($_) &&
 				$_->{'id'} ne $d->{'id'} &&
 				!$_->{'ssl_same'} } &list_domains();

--- a/feature-ssl.pl
+++ b/feature-ssl.pl
@@ -667,11 +667,12 @@ if (&foreign_installed("usermin")) {
 	&usermin::get_usermin_miniserv_config(\%uminiserv);
 	push(@checks, [ \%uminiserv, "Usermin" ]);
 	}
-my @ips = grep { $_ } ($d->{'ip'}, $d->{'ip6'});
 foreach my $c (@checks) {
 	my @sockets = &webmin::get_miniserv_sockets($c->[0]);
 	foreach my $s (@sockets) {
-		if (($s->[0] eq '*' || &indexof($s->[0], @ips) >= 0) &&
+		if (($s->[0] eq '*' ||
+		     ($d->{'ip'} && $s->[0] eq $d->{'ip'}) ||
+		     ($d->{'ip6'} && $s->[0] eq $d->{'ip6'})) &&
 		    $s->[1] == $port) {
 			return &text('setup_esslportclash',
 				     $d->{'ip'} || $d->{'ip6'},

--- a/feature-ssl.pl
+++ b/feature-ssl.pl
@@ -2875,18 +2875,16 @@ if ($d->{'ip6'}) {
 return ( ) if (!$l && !$l6);
 return ( ) if (!$imap && !$imap6);
 
-# Use the address for the protocol block whose certificate we read
-my ($imap_block, $cert_ip, $cert_ip6) = $imap ?
-	($imap, $d->{'ip'}, undef) :
-	($imap6, undef, $d->{'ip6'});
+# Use whichever IP block exists
+my $imap_block = $imap || $imap6;
 my %mems = map { $_->{'name'}, $_->{'value'} }
 	       @{$imap_block->{'members'}};
 my @rv = ( $mems{'ssl_cert'} || $mems{'ssl_server_cert_file'},
            $mems{'ssl_key'} || $mems{'ssl_server_key_file'},
            $mems{'ssl_ca'},
-           $cert_ip,
+           $imap ? $d->{'ip'} : undef,
            undef,	# No domain name for an IP-based certificate
-           $cert_ip6,
+           $imap6 ? $d->{'ip6'} : undef,
 	 );
 return () if (!$rv[0]);
 foreach my $r (@rv) {

--- a/feature-web.pl
+++ b/feature-web.pl
@@ -2300,13 +2300,14 @@ foreach my $dip ($d->{'ip'} ? ( $d->{'ip'} ) : ( ),
 sub remove_listen
 {
 my ($d, $conf, $web_port) = @_;
-if ($d->{'virt'} && !$d->{'name'}) {
+if ($d->{'virt'} && !$d->{'name'} ||
+    $d->{'virt6'} && !$d->{'name6'}) {
 	my @listen = &apache::find_directive("Listen", $conf);
 	my @newlisten = @listen;
-	if ($d->{'ip'}) {
+	if ($d->{'ip'} && $d->{'virt'} && !$d->{'name'}) {
 		@newlisten = grep { $_ ne "$d->{'ip'}:$web_port" } @newlisten;
 		}
-	if ($d->{'ip6'}) {
+	if ($d->{'ip6'} && $d->{'virt6'} && !$d->{'name6'}) {
 		@newlisten = grep { $_ ne "[$d->{'ip6'}]:$web_port" } @newlisten;
 		}
 	if (scalar(@listen) != scalar(@newlisten)) {

--- a/mass_create.cgi
+++ b/mass_create.cgi
@@ -127,6 +127,12 @@ foreach $line (@lines) {
 		$ip = $aliasdom->{'ip'};
 		$ip6 = $aliasdom->{'ip6'};
 		}
+	elsif ($ip eq "none") {
+		# No IPv4 address requested
+		$virt = 0;
+		$virtalready = 0;
+		$ip = undef;
+		}
 	elsif ($ip) {
 		if (!&check_ipaddress($ip) && $ip ne 'allocate') {
 			&line_error($text{'cmass_eip'});
@@ -173,12 +179,6 @@ foreach $line (@lines) {
 			$virtalready = 0;
 			}
 		}
-	elsif ($ip eq "none") {
-		# No IP address requested
-		$virt = 0;
-		$virtalready = 0;
-		$ip = undef;
-		}
 	else {
 		# Use default IP address
 		$virt = 0;
@@ -186,13 +186,8 @@ foreach $line (@lines) {
 		$ip = $defip;
 		}
 
-	if (!$ip && !$ip6) {
-		&line_error($text{'cmass_esomeip'});
-		next;
-		}
-
 	# Pick an IPv6 address
-	if (&supports_ipv6()) {
+	if (&supports_ipv6() && !$aliasdom) {
 		if ($allocated) {
 			# IPv4 allocation was requested, assume the same for V6
 			%racl = $resel ? &get_reseller_acl($resel) : ();
@@ -229,6 +224,11 @@ foreach $line (@lines) {
 			$ip6 = undef;
 			$virt6 = 0;
 			}
+		}
+
+	if (!$ip && !$ip6) {
+		&line_error($text{'cmass_esomeip'});
+		next;
 		}
 
 	# Work out username
@@ -343,9 +343,11 @@ foreach $line (@lines) {
 		 'ip6', $ip6,
 		 'netmask', $netmask,
 		 'netmask6', $netmask6,
-		 'dns_ip', $alias ? $alias->{'dns_ip'} :
+		 'dns_ip', !$ip ? undef :
+			   $aliasdom ? $aliasdom->{'dns_ip'} :
 			   $virt ? undef : &get_dns_ip($resel, 4),
-		 'dns_ip6', $alias ? $alias->{'dns_ip6'} :
+		 'dns_ip6', !$ip6 ? undef :
+			    $aliasdom ? $aliasdom->{'dns_ip6'} :
 			    $virt6 ? undef : &get_dns_ip($resel, 6),
 		 'virt', $virt,
 		 'virt6', $virt6,
@@ -483,4 +485,3 @@ else {
 print "</font><br>\n";
 $ecount++;
 }
-

--- a/modify-domain.pl
+++ b/modify-domain.pl
@@ -601,6 +601,8 @@ elsif ($noip) {
 	$dom->{'virt'} = 0;
 	$dom->{'name'} = 0;
 	$dom->{'ip'} = undef;
+	delete($dom->{'dns_ip'});
+	delete($dom->{'defip'});
 	}
 
 # Apply new IPv6 address
@@ -628,11 +630,12 @@ elsif ($noip6) {
 	$dom->{'virt6'} = 0;
 	$dom->{'name6'} = 0;
 	$dom->{'ip6'} = undef;
+	delete($dom->{'dns_ip6'});
 	}
 
 # Make sure there is some kind of IP
 $dom->{'ip'} || $dom->{'ip6'} ||
-	&usage("Either an IPv4 or IPv5 address must be enabled");
+	&usage("Either an IPv4 or IPv6 address must be enabled");
 
 # Apply reseller change
 if ($resel eq "NONE") {
@@ -672,6 +675,8 @@ elsif (defined($resel) || @add_resel || @del_resel) {
 if (defined($dns_ip)) {
 	if ($dns_ip) {
 		# Changing IP address for DNS
+		$dom->{'ip'} ||
+			&usage("--dns-ip cannot be used without an IP address");
 		$dom->{'dns_ip'} = $dns_ip;
 		}
 	else {
@@ -1064,5 +1069,4 @@ print "                        [--disable-2fa]\n";
 print "                        [--skip-warnings]\n";
 exit(1);
 }
-
 

--- a/restore-domain.pl
+++ b/restore-domain.pl
@@ -265,8 +265,8 @@ while(@ARGV > 0) {
 	# Alternate IPv6 options
 	elsif ($a eq "--default-ip6") {
 		$ipinfo = { %$ipinfo,
-			    'virt' => 0, 'ip6' => &get_default_ip6(),
-			    'virtalready' => 0, 'mode6' => 0 };
+			    'virt6' => 0, 'ip6' => &get_default_ip6(),
+			    'virt6already' => 0, 'mode6' => 0 };
 		}
 	elsif ($a eq "--shared-ip6") {
 		$sharedip6 = shift(@ARGV);
@@ -279,7 +279,7 @@ while(@ARGV > 0) {
 	elsif ($a eq "--ip6") {
 		$ip6 = shift(@ARGV);
 		&check_ip6address($ip6) || &usage("Invalid IPv6 address");
-		&check_virt6_clash($ip) &&
+		&check_virt6_clash($ip6) &&
 			&usage("IPv6 address is already in use");
 		$ipinfo = { %$ipinfo,
 			    'virt6' => 1, 'ip6' => $ip6,


### PR DESCRIPTION
Hey Jamie!

This PR corrects IPv6-only creation, parent-address inheritance, DNS, mail, web/SSL cleanup, certificate linkage, and **restore behavior** _when_ IPv4 is absent.