### PR TITLE
Add ability for domain owners to use audited remote API commands

### DIFF
--- a/commands-lib.pl
+++ b/commands-lib.pl
@@ -454,10 +454,8 @@ return &$capfunc($d);
 sub require_remote_api_domain
 {
 my ($d, $requested, $program) = @_;
-# Default to the API script that called this function
-if (!$program) {
-	(undef, $program) = caller;
-	}
+# Default to the API script set by the dispatcher or standalone command
+$program ||= $0;
 return if (&remote_api_can_domain($d, $program));
 # Only distinguish capability failures for domains the caller can see
 my $msg = $d && &can_edit_domain($d) ?
@@ -472,10 +470,9 @@ exit(1);
 sub get_remote_api_domain
 {
 my ($field, $value, $requested) = @_;
-my (undef, $program) = caller;
 my $d = &get_domain_by($field, $value);
 &require_remote_api_domain(
-	$d, defined($requested) ? $requested : $value, $program);
+	$d, defined($requested) ? $requested : $value);
 return $d;
 }
 

--- a/commands-lib.pl
+++ b/commands-lib.pl
@@ -417,6 +417,68 @@ END {
 return 1;
 }
 
+# Core command-line API scripts audited for non-master remote use, and the
+# capability required for each one.
+my %user_remote_api_commands = (
+	"list-databases" => "can_edit_databases",
+	"list-proxies" => "can_edit_forward",
+	"list-redirects" => "can_edit_redirect",
+	"modify-user" => "can_edit_users",
+	);
+
+# get_user_remote_api_command(program-name)
+# Returns the capability function for an API command allowed for non-master users,
+# or undef if the command has not been allowed.
+sub get_user_remote_api_command
+{
+my ($program) = @_;
+$program = &normalize_api_command_name($program);
+$program =~ s/\.pl$//;
+return $user_remote_api_commands{$program};
+}
+
+# remote_api_can_domain(&domain, program-name)
+# Returns 1 if the current user can run an allowed API command for a domain.
+sub remote_api_can_domain
+{
+my ($d, $program) = @_;
+return 1 if (&master_admin());
+my $capfunc = &get_user_remote_api_command($program);
+return 0 if (!$capfunc || !$d || !&can_edit_domain($d));
+return &$capfunc($d);
+}
+
+# require_remote_api_domain(&domain, requested-domain, [program-name])
+# Exits with a non-leaking error if the current user cannot run the calling
+# API command for the requested domain.
+sub require_remote_api_domain
+{
+my ($d, $requested, $program) = @_;
+# Default to the API script that called this function
+if (!$program) {
+	(undef, $program) = caller;
+	}
+return if (&remote_api_can_domain($d, $program));
+# Only distinguish capability failures for domains the caller can see
+my $msg = $d && &can_edit_domain($d) ?
+	&text('remote_ecannotcap', $requested) :
+	&text('remote_ecannotdom', $requested);
+print $msg,"\n";
+exit(1);
+}
+
+# get_remote_api_domain(field, value, [requested-domain])
+# Looks up a domain and enforces remote API access for the calling command.
+sub get_remote_api_domain
+{
+my ($field, $value, $requested) = @_;
+my (undef, $program) = caller;
+my $d = &get_domain_by($field, $value);
+&require_remote_api_domain(
+	$d, defined($requested) ? $requested : $value, $program);
+return $d;
+}
+
 # can_remote(program-name)
 # Returns 1 if the current user can execute remote commands
 sub can_remote
@@ -436,6 +498,8 @@ if ($program eq "configure-script" ||
     $program eq "configure-all-scripts") {
 	return 1;
 	}
+# Allow audited core commands
+return 1 if (&get_user_remote_api_command($program));
 # Let plugins declare their own command-line API scripts that are safe to run
 # over the remote API as a non-master (domain owner or reseller) user. Each such
 # script must enforce its own per-domain access checks.

--- a/commands-lib.pl
+++ b/commands-lib.pl
@@ -426,6 +426,13 @@ my %user_remote_api_commands = (
 	"modify-user" => "can_edit_users",
 	);
 
+# can_use_remote_api()
+# Returns 1 if the current user has permission to call the remote API.
+sub can_use_remote_api
+{
+return &master_admin() || &reseller_admin() || $access{'edit_remote_api'};
+}
+
 # get_user_remote_api_command(program-name)
 # Returns the capability function for an API command allowed for non-master users,
 # or undef if the command has not been allowed.
@@ -443,6 +450,7 @@ sub remote_api_can_domain
 {
 my ($d, $program) = @_;
 return 1 if (&master_admin());
+return 0 if (!&can_use_remote_api());
 my $capfunc = &get_user_remote_api_command($program);
 return 0 if (!$capfunc || !$d || !&can_edit_domain($d));
 return &$capfunc($d);
@@ -490,6 +498,7 @@ return &master_admin() || &can_remote_as_user($program);
 sub can_remote_as_user
 {
 my ($program) = @_;
+return 0 if (!&can_use_remote_api());
 $program =~ s/\.pl$//;
 if ($program eq "configure-script" ||
     $program eq "configure-all-scripts") {

--- a/lang/en
+++ b/lang/en
@@ -3233,6 +3233,7 @@ limits_edit_ip=Can change IP address
 limits_edit_dnsip=Can change external IP address
 limits_edit_forward=Can edit forwarding and proxies
 limits_edit_redirect=Can edit website redirects
+limits_edit_remote_api=Can call remote API
 limits_edit_backup=Can make backups
 limits_edit_restore=Can restore backups
 limits_edit_sched=Can schedule backups

--- a/lang/en
+++ b/lang/en
@@ -5004,6 +5004,8 @@ sysinfo_python=Python version
 sysinfo_pythonpath=Path to Python
 
 remote_ecannot=You are not allowed to run remote commands
+remote_ecannotcap=You are not allowed to run this command for virtual server $1
+remote_ecannotdom=Virtual server $1 does not exist
 remote_eprogram=Invalid remote program name
 remote_eprogram2=Remote program $1 does not exist
 

--- a/list-databases.pl
+++ b/list-databases.pl
@@ -44,7 +44,7 @@ while(@ARGV > 0) {
 	}
 
 $domain || &usage("No domain specified");
-$d = &get_domain_by("dom", $domain);
+$d = &get_remote_api_domain("dom", $domain);
 $d || usage("Virtual server $domain does not exist");
 @dbs = &domain_databases($d);
 if ($type) {

--- a/list-proxies.pl
+++ b/list-proxies.pl
@@ -41,7 +41,7 @@ while(@ARGV > 0) {
 	}
 
 $domain || &usage("No domain specified");
-$d = &get_domain_by("dom", $domain);
+$d = &get_remote_api_domain("dom", $domain);
 $d || usage("Virtual server $domain does not exist");
 &has_proxy_balancer($d) || &usage("Proxies cannot be configured for this virtual server");
 

--- a/list-redirects.pl
+++ b/list-redirects.pl
@@ -59,7 +59,7 @@ while(@ARGV > 0) {
 	}
 
 $domain || &usage("No domain specified");
-$d = &get_domain_by("dom", $domain);
+$d = &get_remote_api_domain("dom", $domain);
 $d || usage("Virtual server $domain does not exist");
 &has_web_redirects($d) ||
 	&usage("Virtual server $domain does not support redirects");

--- a/modify-limits.pl
+++ b/modify-limits.pl
@@ -83,6 +83,8 @@ C<disable> - Disable virtual servers
 
 C<delete> - Delete virtual servers
 
+C<remote_api> - Call the Virtualmin remote API
+
 Access to capabilities can also be taken away with the C<--cannot-edit> flag.
 
 To restrict the virtual server owner to only installing certain scripts 

--- a/modify-user.pl
+++ b/modify-user.pl
@@ -100,6 +100,8 @@ if (!$module_name) {
 # Get shells
 @ashells = grep { $_->{'mailbox'} && $_->{'avail'} } &list_available_shells();
 ($nologin_shell, $ftp_shell, $jailed_shell) = &get_common_available_shells();
+# Cache the caller level used by the remote-safe option checks
+my $is_master = &master_admin();
 
 # Parse command-line args
 while(@ARGV > 0) {
@@ -114,6 +116,9 @@ while(@ARGV > 0) {
 		$pass = shift(@ARGV);
 		}
 	elsif ($a eq "--passfile") {
+		# Prevent non-master callers from reading server-side files
+		$is_master ||
+			&usage("--passfile is only available to the master administrator");
 		$pass = &read_file_contents(shift(@ARGV));
 		$pass =~ s/\r|\n//g;
 		}
@@ -277,7 +282,7 @@ while(@ARGV > 0) {
 
 # Make sure all needed args are set
 $domain && $username || &usage("No domain name or username specified");
-$d = &get_domain_by("dom", $domain);
+$d = &get_remote_api_domain("dom", $domain);
 $d || &usage("Virtual server $domain does not exist");
 &obtain_lock_mail($d);
 &obtain_lock_unix($d);
@@ -287,7 +292,44 @@ $d || &usage("Virtual server $domain does not exist");
 $user || &usage("No user named $username was found in the server $domain");
 ($user->{'feature_user'} || $user->{'noactions'}) &&
 	&usage("The user $username is managed by a feature plugin, and so cannot be modified by this command");
+
+# Enforce the same input and option restrictions as the user interface
+if (!$is_master && $shell &&
+    (!&can_mailbox_ftp() ||
+     !&check_available_shell($shell->{'shell'}, 'mailbox', $user->{'shell'}))) {
+	&usage($text{'user_eshell'});
+	}
+if (defined($quota) && !$is_master && !&can_mailbox_quota()) {
+	&usage("You are not allowed to change mailbox quotas");
+	}
+
+# Server-side SSH key selection is only safe for the master administrator
+if (defined($sshpubkeyid) && !$is_master) {
+	&usage("--ssh-pubkey-id is only available to the master administrator");
+	}
+if (!$is_master) {
+	if (defined($newusername)) {
+		$err = &valid_mailbox_name($newusername);
+		&usage($err) if ($err);
+		}
+	defined($real) && $real !~ /^[^:\r\n]*$/ &&
+		&usage($text{'user_ereal'});
+	defined($firstname) && $firstname !~ /^[^:\r\n]*$/ &&
+		&usage($text{'user_efirstname'});
+	defined($surname) && $surname !~ /^[^:\r\n]*$/ &&
+		&usage($text{'user_esurname'});
+	foreach my $forward (@addforward) {
+		$forward =~ /^([^\|\:\"\' \t\/\\\%]\S*)$/ ||
+			&usage(&text('alias_etype1', $forward));
+		&can_forward_alias($forward) ||
+			&usage(&text('alias_etype1f', $forward));
+		$forward eq $user->{'email'} &&
+			&usage($text{'user_eloop'});
+		}
+	}
 $olduser = { %$user };
+# Keep the original count because the user copy shares nested array references
+$oldextracount = scalar(@{$user->{'extraemail'}});
 $shortusername = &remove_userdom($user->{'user'}, $d);
 &build_taken(\%taken, \%utaken);
 %cangroups = map { $_, 1 } &allowed_secondary_groups($d);
@@ -297,14 +339,20 @@ foreach $g (@addgroups) {
 	}
 $disable && $enable && &usage("Only one of the --disable and --enable options can be used");
 
-# Limit what can be done to domain owners
+# Limit what can be done to domain owners, preserving existing master behavior
 if ($user->{'domainowner'}) {
-	$real &&
+	($is_master ? $real : defined($real)) &&
 	  &usage("The --real flag cannot be used when editing a domain owner");
+	!$is_master && (defined($firstname) || defined($surname)) &&
+	  &usage("First and last names cannot be changed when editing a domain owner");
 	defined($pass) &&
 	  &usage("The --pass and --passfile flags cannot be used when ".
 		 "editing a domain owner");
-	$quota &&
+	!$is_master && defined($sshpubkey) &&
+	  &usage("The SSH public key cannot be changed when editing a domain owner");
+	!$is_master && defined($recovery) &&
+	  &usage("The recovery address cannot be changed when editing a domain owner");
+	($is_master ? $quota : defined($quota)) &&
 	  &usage("Quotas cannot be changed when editing a domain owner");
 	(@adddbs || @deldbs) &&
 	  &usage("Databases cannot be changed when editing a domain owner");
@@ -312,6 +360,8 @@ if ($user->{'domainowner'}) {
 	  &usage("The username cannot be changed when editing a domain owner");
 	$shell &&
 	  &usage("The shell cannot be changed when editing a domain owner");
+	!$is_master && ($disable || $enable) &&
+	  &usage("The account status cannot be changed when editing a domain owner");
 	}
 
 # Make the changes to the user object
@@ -321,6 +371,11 @@ if (defined($pass)) {
 	$user->{'plainpass'} = $pass;
 	$user->{'pass'} = &encrypt_user_password($user, $pass);
 	&set_pass_change($user);
+	# Apply the user interface password policy to non-master callers
+	if (!$is_master) {
+		$err = &check_password_restrictions($user, 0, $d);
+		&usage($err) if ($err);
+		}
 	}
 if ($disable) {
 	&set_pass_disable($user, 1);
@@ -382,6 +437,17 @@ foreach $e (@addemails) {
 	if ($e !~ /^(\S*)\@(\S+)$/) {
 		&usage("Email address $e is not valid");
 		}
+	# Additional addresses must belong to an accessible mail domain
+	if (!$is_master) {
+		my ($eu, $ed) = ($1, &parse_domain_name($2));
+		my $edom = &get_remote_api_domain("dom", $ed);
+		$edom->{'mail'} || &usage(&text('user_eextra2', $ed));
+		!$edom->{'alias'} || !$edom->{'aliascopy'} ||
+			&usage(&text('user_eextra7', $ed));
+		$e = "$eu\@$ed";
+		&check_clash($eu, $ed) &&
+			&usage(&text('user_eextra4', $e));
+		}
 	($got) = grep { $_ eq $e } @{$user->{'extraemail'}};
 	$got && &usage("Email address $e is already associated with this user");
 	$user->{'email'} eq $e && &usage("Email address $e is already the user's primary address");
@@ -391,6 +457,14 @@ foreach $e (@delemails) {
 	($got) = grep { $_ eq $e } @{$user->{'extraemail'}};
 	$got || &usage("Email address $e does not belong to this user");
 	@{$user->{'extraemail'}} = grep { $_ ne $e } @{$user->{'extraemail'}};
+	}
+
+# Prevent non-master callers from exceeding their alias limit
+if (!$is_master) {
+	($mleft) = &count_feature("aliases");
+	$mleft >= 0 &&
+	  $mleft - @{$user->{'extraemail'}} + $oldextracount < 0 &&
+		&usage($text{'alias_ealiaslimit'});
 	}
 if (defined($recovery)) {
 	$user->{'recovery'} = $recovery;
@@ -549,12 +623,16 @@ else {
 	# Update SSH key if given
 	if ($sshpubkey) {
 		my $pubkey;
-		my $sshpubkeyfile = -r $sshpubkey ? $sshpubkey : undef;
+		# Only the master administrator can load a key from a server file
+		my $sshpubkeyfile =
+			$is_master && -r $sshpubkey ? $sshpubkey : undef;
 		if ($sshpubkeyfile) {
+			# Select the requested key from the server-side file
 			$pubkey = &get_ssh_pubkey_from_file(
 				$sshpubkeyfile, $sshpubkeyid);
 			}
 		else {
+			# Treat direct input as literal public key content
 			$pubkey = $sshpubkey;
 			}
 		my $pubkeyerr = &validate_ssh_pubkey($pubkey);

--- a/t/remote-api-access.t
+++ b/t/remote-api-access.t
@@ -1,0 +1,150 @@
+#!/usr/bin/perl
+
+use strict;
+use warnings;
+use Test::More;
+use File::Basename qw(dirname);
+use File::Spec;
+use Cwd qw(abs_path);
+
+my $root = abs_path(File::Spec->catdir(dirname(__FILE__), '..'));
+my $lib = File::Spec->catfile($root, 'commands-lib.pl');
+my $loaded = do $lib;
+die $@ if ($@);
+die "Failed to load $lib: $!" if (!defined($loaded));
+
+{
+	no warnings qw(once redefine);
+	local @main::plugins = ();
+	local *main::master_admin = sub { 0 };
+	ok(&can_remote_as_user('list-databases'),
+		'database listing is allowed for non-master API users');
+	ok(&can_remote_as_user('list-proxies.pl'),
+		'allowed command names are normalized');
+	ok(&can_remote_as_user('list-redirects'),
+		'redirect listing is allowed for non-master API users');
+	ok(&can_remote_as_user('modify-user'),
+		'user modification is allowed for non-master API users');
+	ok(!&can_remote_as_user('list-users'),
+		'unaudited core commands remain denied');
+	is(&get_user_remote_api_command('list-databases'),
+		'can_edit_databases', 'database capability is registered');
+	is(&get_user_remote_api_command('list-proxies'),
+		'can_edit_forward', 'proxy capability is registered');
+	is(&get_user_remote_api_command('list-redirects'),
+		'can_edit_redirect', 'redirect capability is registered');
+	is(&get_user_remote_api_command('modify-user'),
+		'can_edit_users', 'user modification capability is registered');
+	}
+
+{
+	no warnings qw(once redefine);
+	local *main::master_admin = sub { 0 };
+	local *main::can_edit_domain = sub { $_[0]->{'allowed'} };
+	local *main::can_edit_databases = sub { 1 };
+	local *main::can_edit_users = sub { 1 };
+	local *main::text = sub {
+		my ($key, $domain) = @_;
+		return $key eq 'remote_ecannotcap' ?
+			"You are not allowed to run this command for virtual server $domain" :
+			"Virtual server $domain does not exist";
+		};
+
+	ok(&remote_api_can_domain(
+		{ 'allowed' => 1 }, 'list-databases.pl'),
+		'owned domain passes its command capability check');
+	ok(!&remote_api_can_domain(
+		{ 'allowed' => 0 }, 'list-databases.pl'),
+		'foreign domain is denied');
+	ok(&remote_api_can_domain(
+		{ 'allowed' => 1 }, 'modify-user.pl'),
+		'owned domain passes the user modification capability check');
+
+	local *main::can_edit_databases = sub { 0 };
+	ok(!&remote_api_can_domain(
+		{ 'allowed' => 1 }, 'list-databases.pl'),
+		'owned domain is denied without the required capability');
+	ok(!&remote_api_can_domain(
+		{ 'allowed' => 1 }, 'list-users.pl'),
+		'unaudited command is denied at the domain boundary');
+
+	local *main::can_edit_users = sub { 0 };
+	ok(!&remote_api_can_domain(
+		{ 'allowed' => 1 }, 'modify-user.pl'),
+		'owned domain is denied without user management capability');
+
+	my ($status, $out) = &run_domain_guard(
+		{ 'allowed' => 1 }, 'example.test', 'list-databases.pl');
+	ok($status, 'missing capability exits with a failure');
+	is($out,
+		"You are not allowed to run this command for virtual server example.test\n",
+		'missing capability returns a clear permission error');
+
+	($status, $out) = &run_domain_guard(
+		{ 'allowed' => 0 }, 'foreign.test', 'list-databases.pl');
+	ok($status, 'foreign domain exits with a failure');
+	is($out, "Virtual server foreign.test does not exist\n",
+		'foreign domain remains hidden');
+	}
+
+{
+	no warnings qw(redefine);
+	local *main::master_admin = sub { 1 };
+	ok(&remote_api_can_domain(undef, 'not-allowed.pl'),
+		'master API and standalone root behavior remains unrestricted');
+	}
+
+{
+	no warnings qw(once redefine);
+	my @guard;
+	my $domain = { 'dom' => 'example.test' };
+	local *main::get_domain_by = sub {
+		is_deeply(\@_, [ 'dom', 'example.test' ],
+			'remote domain helper performs one lookup');
+		return $domain;
+		};
+	local *main::require_remote_api_domain = sub { @guard = @_ };
+	is(&get_remote_api_domain('dom', 'example.test'), $domain,
+		'remote domain helper returns the resolved domain');
+	is($guard[0], $domain, 'resolved domain is authorized');
+	is($guard[1], 'example.test', 'requested domain is preserved');
+	like($guard[2], qr/remote-api-access\.t$/,
+		'calling command is passed to the authorization guard');
+	}
+
+foreach my $command (
+	qw(list-databases.pl list-proxies.pl list-redirects.pl modify-user.pl)
+	) {
+	my $path = File::Spec->catfile($root, $command);
+	open(my $fh, '<', $path) || die "Cannot read $path: $!";
+	local $/ = undef;
+	my $source = <$fh>;
+	close($fh);
+	like($source, qr/get_remote_api_domain\s*\("dom",\s*\$domain\)/,
+		"$command uses the shared domain boundary");
+	}
+
+done_testing();
+
+# run_domain_guard(&domain, requested-domain, program-name)
+# Runs the terminating domain guard in a child and returns its status and output.
+sub run_domain_guard
+{
+my ($domain, $requested, $program) = @_;
+pipe(my $reader, my $writer) || die "pipe failed: $!";
+my $pid = fork();
+defined($pid) || die "fork failed: $!";
+if (!$pid) {
+	close($reader);
+	open(STDOUT, '>&', $writer) || die "redirect failed: $!";
+	close($writer);
+	&require_remote_api_domain($domain, $requested, $program);
+	exit(0);
+	}
+close($writer);
+local $/ = undef;
+my $output = <$reader>;
+close($reader);
+waitpid($pid, 0);
+return ($?, $output);
+}

--- a/t/remote-api-access.t
+++ b/t/remote-api-access.t
@@ -16,7 +16,21 @@ die "Failed to load $lib: $!" if (!defined($loaded));
 {
 	no warnings qw(once redefine);
 	local @main::plugins = ();
+	local %main::access = ();
+	my $reseller = 0;
 	local *main::master_admin = sub { 0 };
+	local *main::reseller_admin = sub { $reseller };
+	ok(!&can_use_remote_api(),
+		'remote API access is denied by default');
+	ok(!&can_remote_as_user('list-databases'),
+		'allowed commands remain denied without API permission');
+	ok(!&can_remote_as_user('configure-script'),
+		'existing user API commands also require permission');
+	$main::access{'edit_remote_api'} = 1;
+	ok(&can_use_remote_api(),
+		'domain owner can use the remote API when granted permission');
+	ok(&can_remote_as_user('configure-script'),
+		'existing user API commands remain available when permitted');
 	ok(&can_remote_as_user('list-databases'),
 		'database listing is allowed for non-master API users');
 	ok(&can_remote_as_user('list-proxies.pl'),
@@ -27,6 +41,10 @@ die "Failed to load $lib: $!" if (!defined($loaded));
 		'user modification is allowed for non-master API users');
 	ok(!&can_remote_as_user('list-users'),
 		'unaudited core commands remain denied');
+	delete($main::access{'edit_remote_api'});
+	$reseller = 1;
+	ok(&can_use_remote_api(),
+		'reseller remote API behavior remains unchanged');
 	is(&get_user_remote_api_command('list-databases'),
 		'can_edit_databases', 'database capability is registered');
 	is(&get_user_remote_api_command('list-proxies'),
@@ -39,7 +57,9 @@ die "Failed to load $lib: $!" if (!defined($loaded));
 
 {
 	no warnings qw(once redefine);
+	local %main::access = ( 'edit_remote_api' => 1 );
 	local *main::master_admin = sub { 0 };
+	local *main::reseller_admin = sub { 0 };
 	local *main::can_edit_domain = sub { $_[0]->{'allowed'} };
 	local *main::can_edit_databases = sub { 1 };
 	local *main::can_edit_users = sub { 1 };

--- a/t/remote-api-access.t
+++ b/t/remote-api-access.t
@@ -73,12 +73,13 @@ die "Failed to load $lib: $!" if (!defined($loaded));
 		{ 'allowed' => 1 }, 'modify-user.pl'),
 		'owned domain is denied without user management capability');
 
+	local $0 = File::Spec->catfile($root, 'list-databases.pl');
 	my ($status, $out) = &run_domain_guard(
-		{ 'allowed' => 1 }, 'example.test', 'list-databases.pl');
+		{ 'allowed' => 1 }, 'example.test', undef);
 	ok($status, 'missing capability exits with a failure');
 	is($out,
 		"You are not allowed to run this command for virtual server example.test\n",
-		'missing capability returns a clear permission error');
+		'current API program is taken from $0');
 
 	($status, $out) = &run_domain_guard(
 		{ 'allowed' => 0 }, 'foreign.test', 'list-databases.pl');
@@ -108,8 +109,8 @@ die "Failed to load $lib: $!" if (!defined($loaded));
 		'remote domain helper returns the resolved domain');
 	is($guard[0], $domain, 'resolved domain is authorized');
 	is($guard[1], 'example.test', 'requested domain is preserved');
-	like($guard[2], qr/remote-api-access\.t$/,
-		'calling command is passed to the authorization guard');
+	is(scalar(@guard), 2,
+		'remote domain helper leaves program detection to the guard');
 	}
 
 foreach my $command (

--- a/virtual-server-lib-funcs.pl
+++ b/virtual-server-lib-funcs.pl
@@ -398,7 +398,8 @@ sub list_automatic_capabilities
 {
 my ($cancreate) = @_;
 if ($cancreate) {
-	return @edit_limits;
+	# Remote API access must always be explicitly granted
+	return grep { $_ ne 'remote_api' } @edit_limits;
 	}
 else {
 	return ( 'users', 'aliases', 'html', 'passwd' );

--- a/virtual-server-lib.pl
+++ b/virtual-server-lib.pl
@@ -181,7 +181,7 @@ $saved_aliases_dir = &cache_file_path("saved-aliases");
 		'spam', 'phpver', 'phpmode',
 		'mail', 'backup', 'sched', 'restore', 'sharedips', 'catchall',
 		'html', 'allowedhosts', 'passwd', 'spf', 'records',
-		'disable', 'delete');
+		'disable', 'delete', 'remote_api');
 if (!$virtualmin_pro) {
 	@edit_limits = grep { $_ ne 'html' } @edit_limits;
 	}


### PR DESCRIPTION
Howdy, Jamie!

This is an intentionally small first step to demonstrate and validate the approach for allowing non-master users to access audited commands through `remote.cgi`, as we discussed in the chat a few days ago.

Please take a look.