### PR TITLE
Add complete domain owners to use the remote API

### DIFF
--- a/backup-domain.pl
+++ b/backup-domain.pl
@@ -379,8 +379,9 @@ if ($keyid) {
 		  	$_->{'key'} eq $keyid ||
 		  	$_->{'desc'} eq $keyid } &list_backup_keys();
 	$key || &usage("No backup key with ID or description $keyid exists");
-	# A non-master may only use their own keys, as restore-domain enforces
-	!defined(&can_backup_key) || &master_admin() || &can_backup_key($key) ||
+	# A non-master may use their own keys or keys shared for backups
+	!defined(&can_use_backup_key) || &master_admin() ||
+		&can_use_backup_key($key) ||
 		&usage("No backup key with ID or description $keyid exists");
 	}
 if ($onebyone && !$newformat) {

--- a/backup-domain.pl
+++ b/backup-domain.pl
@@ -129,17 +129,26 @@ while(@ARGV > 0) {
 		push(@bdoms, shift(@ARGV));
 		}
 	elsif ($a eq "--user") {
+		&master_admin() ||
+			&usage("--user is only available to the master ".
+			       "administrator");
 		push(@users, shift(@ARGV));
 		}
 	elsif ($a eq "--parent") {
 		$includesubs = 1;
 		}
 	elsif ($a eq "--reseller") {
+		&master_admin() ||
+			&usage("--reseller is only available to the master ".
+			       "administrator");
 		defined(&list_resellers) ||
 			&usage("Your system does not support resellers");
 		push(@resellers, shift(@ARGV));
 		}
 	elsif ($a eq "--plan") {
+		&master_admin() ||
+			&usage("--plan is only available to the master ".
+			       "administrator");
 		$planname = shift(@ARGV);
 		($plan) = grep { lc($_->{'name'}) eq lc($planname) ||
 				 $_->{'id'} eq $planname } @allplans;
@@ -156,6 +165,9 @@ while(@ARGV > 0) {
 		@bfeats = grep { $_ ne $f } @bfeats;
 		}
 	elsif ($a eq "--all-domains") {
+		&master_admin() ||
+			&usage("--all-domains is only available to the master ".
+			       "administrator");
 		$all_doms = 1;
 		}
 	elsif ($a eq "--test") {
@@ -168,6 +180,9 @@ while(@ARGV > 0) {
 		$separate = 1;
 		}
 	elsif ($a eq "--mkdir") {
+		&master_admin() ||
+			&usage("--mkdir is only available to the master ".
+			       "administrator");
 		$mkdir = 1;
 		}
 	elsif ($a eq "--onebyone") {
@@ -203,6 +218,9 @@ while(@ARGV > 0) {
 		$asowner = 1;
 		}
 	elsif ($a eq "--virtualmin") {
+		&can_backup_virtualmin() ||
+			&usage("--virtualmin is only available to the master ".
+			       "administrator");
 		$v = shift(@ARGV);
 		if (&indexof($v, @virtualmin_backups) < 0) {
 			print STDERR "Unknown --virtualmin option $v. Available options are : ".join(" ", @virtualmin_backups)."\n";
@@ -212,6 +230,9 @@ while(@ARGV > 0) {
 			}
 		}
 	elsif ($a eq "--all-virtualmin") {
+		&can_backup_virtualmin() ||
+			&usage("--all-virtualmin is only available to the master ".
+			       "administrator");
 		@vbs = @virtualmin_backups;
 		}
 	elsif ($a eq "--except-virtualmin") {
@@ -226,6 +247,9 @@ while(@ARGV > 0) {
 		$increment = 2;
 		}
 	elsif ($a eq "--incremental-of" || $a eq "--differential-of") {
+		&master_admin() ||
+			&usage("--differential-of is only available to the ".
+			       "master administrator");
 		&has_incremental_tar() || &usage("The tar command on this system does not support differential backups");
 		$increment = shift(@ARGV);
 		$increment eq "1" &&
@@ -236,6 +260,10 @@ while(@ARGV > 0) {
 			&usage("Scheduled backup with ID $increment is not a full backup");
 		}
 	elsif ($a eq "--purge") {
+		# Purging deletes files outside any domain
+		&master_admin() ||
+			&usage("--purge is only available to the master ".
+			       "administrator");
 		$purge = shift(@ARGV);
 		$purge =~ /^[0-9\.]+$/ || &usage("--purge must be followed by a number");
 		}
@@ -296,6 +324,21 @@ if (@resellers) {
 if (@bdoms || @users || $all_doms) {
 	@bfeats || usage("No features specified");
 	}
+# Domain owners may only write to their own backup directory, and always
+# have the backup run as themselves
+$cbmode = &can_backup_domain();
+$cbmode || &usage("You are not allowed to backup virtual servers");
+if ($cbmode != 1) {
+	$asowner = 1;
+	my $od = &get_domain_by_user($base_remote_user);
+	foreach my $i (0 .. $#dests) {
+		my ($newdest, $err) = &confine_backup_dest(
+			$dests[$i], $cbmode, $od);
+		$err && &usage($err);
+		$dests[$i] = $newdest;
+		}
+	}
+
 foreach $dest (@dests) {
 	# Validate destination URL
 	($bmode, $derr, undef, $host, $path) = &parse_backup_url($dest);
@@ -349,6 +392,7 @@ else {
 	@doms = &get_domains_by_names_users(\@bdoms, \@users, \&usage, \@plans,
 					    $includesubs);
 	}
+@doms = &get_remote_api_domains(\@doms, $all_doms);
 
 if ($test) {
 	# Just tell the user what will be done

--- a/backup-domain.pl
+++ b/backup-domain.pl
@@ -207,6 +207,10 @@ while(@ARGV > 0) {
 			$optv = shift(@ARGV);
 			}
 		$optf && $optn && $optv || &usage("Invalid option specification");
+		# The dir feature's include/exclude values are paths run as root
+		&require_remote_api_relative_path($optv)
+			if ($optf eq "dir" &&
+			    ($optn eq "include" || $optn eq "exclude"));
 		$opts{$optf}->{$optn} = $optv;
 		}
 	elsif ($a eq "--mailfiles") {
@@ -281,10 +285,12 @@ while(@ARGV > 0) {
 		}
 	elsif ($a eq "--exclude") {
 		$exclude = shift(@ARGV);
+		&require_remote_api_relative_path($exclude);
 		push(@exclude, $exclude);
 		}
 	elsif ($a eq "--include") {
 		$include = shift(@ARGV);
+		&require_remote_api_relative_path($include);
 		push(@include, $include);
 		}
 	elsif ($a eq "--multiline") {
@@ -373,6 +379,9 @@ if ($keyid) {
 		  	$_->{'key'} eq $keyid ||
 		  	$_->{'desc'} eq $keyid } &list_backup_keys();
 	$key || &usage("No backup key with ID or description $keyid exists");
+	# A non-master may only use their own keys, as restore-domain enforces
+	!defined(&can_backup_key) || &master_admin() || &can_backup_key($key) ||
+		&usage("No backup key with ID or description $keyid exists");
 	}
 if ($onebyone && !$newformat) {
 	&usage("--onebyone option can only be used in conjunction ".

--- a/backups-lib.pl
+++ b/backups-lib.pl
@@ -4708,6 +4708,33 @@ elsif ($mode == 5) {
 return $rv;
 }
 
+# confine_backup_dest(dest, backup-mode, [&domain])
+# Given a destination for a backup, returns it restricted to what the current
+# user is allowed to write to, or an error message. Mirrors the limits that
+# parse_backup_destination applies in the user interface - domain owners can
+# only write under their own backup directory, and resellers cannot write to
+# any local file.
+sub confine_backup_dest
+{
+my ($dest, $mode, $d) = @_;
+return ($dest, undef) if ($mode == 1);
+my ($proto, undef, undef, undef, $path) = &parse_backup_url($dest);
+return ($dest, undef) if ($proto != 0);
+if ($mode == 3) {
+	# Resellers can only back up to a remote destination
+	return (undef, $text{'backup_emode'});
+	}
+$d || return (undef, $text{'backup_edest'});
+# Force the file to be under the domain's own backup directory
+my $file = $dest;
+$file =~ s/^\Q$d->{'home'}\E\/\Q$home_virtualmin_backup\E\/*//;
+$file =~ s/^\/+//;
+$file =~ s/\/+$//;
+$file =~ /^\S+$/ || return (undef, $text{'backup_edest2'});
+$file =~ /\.\./ && return (undef, $text{'backup_edest3'});
+return ("$d->{'home'}/$home_virtualmin_backup/$file", undef);
+}
+
 # nice_backup_url(string, [caps-first], [show-backup-path-opts])
 # Converts a backup URL to a nice human-readable format
 sub nice_backup_url

--- a/clone-domain.pl
+++ b/clone-domain.pl
@@ -61,10 +61,15 @@ while(@ARGV > 0) {
 		$newpass = shift(@ARGV);
 		}
 	elsif ($a eq "--ip") {
+		# Selecting an IP address is only for those allowed to
+		&master_admin() || &can_select_ip() ||
+			&usage("You are not allowed to select an IP address");
 		$ip = shift(@ARGV);
 		&check_ipaddress($ip) || &usage("Invalid IP address");
 		}
 	elsif ($a eq "--ip-already") {
+		&master_admin() || &can_select_ip() ||
+			&usage("You are not allowed to select an IP address");
 		$virtalready = 1;
 		}
 	elsif ($a eq "--multiline") {
@@ -81,8 +86,26 @@ while(@ARGV > 0) {
 # Find the domain
 $domain || usage("Missing --domain flag");
 $newdomain || usage("Missing --newdomain flag");
-$d = &get_domain_by("dom", $domain);
+$d = &get_remote_api_domain("dom", $domain);
 $d || usage("Virtual server $domain does not exist.");
+
+# Cloning creates a new virtual server, so enforce the same restrictions as
+# the user interface for non-master callers
+if (!&master_admin()) {
+	($d->{'parent'} ? &can_create_sub_servers()
+			: &can_create_master_servers()) ||
+		&usage("You are not allowed to create virtual servers of ".
+		       "this type");
+	my ($dleft, $dreason, $dmax) = &count_domains(
+		$d->{'alias'} ? "aliasdoms" :
+		$d->{'parent'} ? "realdoms" : "topdoms");
+	$dleft == 0 && &usage("You have reached the maximum of $dmax ".
+			      "virtual servers that can be created");
+	# Check any restriction on the names he can use
+	my $parent = $d->{'parent'} ? &get_domain($d->{'parent'}) : undef;
+	my $derr = &allowed_domain_name($parent, $newdomain);
+	&usage($derr) if ($derr);
+	}
 if (!$d->{'parent'}) {
 	if (!$newuser) {
 		($newuser, $try1, $try2) = &unixuser_name($newdomain);

--- a/clone-domain.pl
+++ b/clone-domain.pl
@@ -61,7 +61,7 @@ while(@ARGV > 0) {
 		$newpass = shift(@ARGV);
 		}
 	elsif ($a eq "--ip") {
-		# Selecting an IP address is only for those allowed to
+		# Only users allowed to select an address may request one
 		&master_admin() || &can_select_ip() ||
 			&usage("You are not allowed to select an IP address");
 		$ip = shift(@ARGV);
@@ -86,6 +86,9 @@ while(@ARGV > 0) {
 # Find the domain
 $domain || usage("Missing --domain flag");
 $newdomain || usage("Missing --newdomain flag");
+$newdomain = lc(&parse_domain_name($newdomain));
+my $dnerr = &valid_domain_name($newdomain);
+&usage($dnerr) if ($dnerr);
 $d = &get_remote_api_domain("dom", $domain);
 $d || usage("Virtual server $domain does not exist.");
 

--- a/commands-lib.pl
+++ b/commands-lib.pl
@@ -655,6 +655,19 @@ print &text('remote_ecannotcap',
 exit(1);
 }
 
+# require_remote_api_relative_path(path)
+# Exits if a non-master caller gives a path that escapes the domain's own
+# directory, such as an absolute path or one containing "..". Backup include
+# and exclude lists are relative to the domain home and run as root, so this
+# keeps a domain owner from reaching another server's or the system's files.
+sub require_remote_api_relative_path
+{
+my ($path) = @_;
+return if (&master_admin());
+$path !~ /^\// && $path !~ /(^|\/)\.\.(\/|$)/ ||
+	&usage("File paths must be under the virtual server's home directory");
+}
+
 # get_remote_api_domains(&domains, [owned-only], [program-name])
 # Enforces remote API access for an existing list of target domains. When
 # owned-only is set, domains outside the current user's scope are filtered out.

--- a/commands-lib.pl
+++ b/commands-lib.pl
@@ -420,11 +420,145 @@ return 1;
 # Core command-line API scripts audited for non-master remote use, and the
 # capability required for each one.
 my %user_remote_api_commands = (
+	"create-admin" => "can_edit_admins",
+	"create-alias" => "can_edit_aliases",
+	"create-database" => "can_edit_databases",
+	"create-domain" => "can_create_sub_servers",
+	"create-proxy" => "can_edit_forward",
+	"create-redirect" => "can_edit_redirect",
+	"create-simple-alias" => "can_edit_aliases",
+	"backup-domain" => "can_backup_domain",
+	"check-connectivity" => "can_edit_domain",
+	"clone-domain" => "can_create_sub_servers",
+	"create-scheduled-backup" => "can_backup_domain",
+	"create-user" => "can_edit_users",
+	"delete-admin" => "can_edit_admins",
+	"delete-alias" => "can_edit_aliases",
+	"delete-backup" => "can_backup_log",
+	"delete-database" => "can_edit_databases",
+	"delete-domain" => "can_delete_domain",
+	"delete-php-directory" => "can_edit_phpver",
+	"delete-scheduled-backup" => "can_backup_sched",
+	"delete-proxy" => "can_edit_forward",
+	"delete-redirect" => "can_edit_redirect",
+	"delete-script" => "can_edit_scripts",
+	"delete-user" => "can_edit_users",
+	"detect-scripts" => "can_edit_scripts",
+	"disable-domain" => "can_disable_domain",
+	"disable-feature" => "can_config_domain",
+	"enable-feature" => "can_config_domain",
+	"reset-feature" => "can_config_domain",
+	"restore-domain" => "can_restore_domain",
+	"disconnect-database" => "can_remote_import_databases",
+	"enable-domain" => "can_disable_domain",
+	"fix-domain-permissions" => "can_config_domain",
+	"fix-domain-quota" => "can_edit_quotas",
+	"generate-cert" => "can_edit_ssl",
+	"generate-acme-cert" => "can_remote_edit_acme",
+	"generate-letsencrypt-cert" => "can_remote_edit_acme",
+	"get-dns" => "can_edit_records",
+	"get-command" => "can_use_remote_api",
+	"get-logs" => "can_edit_domain",
+	"get-ssl" => "can_edit_ssl",
+	"import-database" => "can_remote_import_databases",
+	"install-cert" => "can_edit_ssl",
+	"install-script" => "can_edit_scripts",
+	"list-admins" => "can_edit_admins",
+	"list-aliases" => "can_edit_aliases",
+	"list-available-scripts" => "can_edit_scripts",
+	"list-available-shells" => "can_edit_users",
+	"list-backup-keys" => "can_backup_keys",
+	"list-bandwidth" => "can_edit_domain",
+	"list-certs" => "can_edit_ssl",
+	"list-certs-expiry" => "can_edit_ssl",
+	"list-commands" => "can_use_remote_api",
+	"list-custom" => "can_edit_domain",
 	"list-databases" => "can_edit_databases",
+	"list-domains" => "can_edit_domain",
+	"list-features" => "can_edit_domain",
+	"list-backup-logs" => "can_backup_log",
+	"list-mailbox" => "can_remote_read_mailbox",
+	"list-php-directories" => "can_edit_phpver",
+	"list-php-ini" => "can_edit_phpmode",
+	"list-php-versions" => "can_edit_phpver",
+	"list-ports" => "can_edit_domain",
 	"list-proxies" => "can_edit_forward",
 	"list-redirects" => "can_edit_redirect",
+	"list-scheduled-backups" => "can_backup_sched",
+	"list-scripts" => "can_edit_scripts",
+	"list-service-certs" => "can_edit_ssl",
+	"list-simple-aliases" => "can_edit_aliases",
+	"list-users" => "can_edit_users",
+	"modify-admin" => "can_edit_admins",
+	"modify-custom" => "can_config_domain",
+	"modify-domain" => "can_config_domain",
+	"modify-database-hosts" => "can_remote_edit_database_hosts",
+	"modify-database-pass" => "can_edit_databases",
+	"modify-database-user" => "can_edit_databases",
+	"modify-dns" => "can_remote_edit_dns",
+	"modify-mail" => "can_edit_mail",
+	"modify-php-ini" => "can_edit_phpmode",
+	"modify-proxy" => "can_edit_forward",
+	"modify-scheduled-backup" => "can_backup_sched",
+	"modify-spam" => "can_edit_spam",
 	"modify-user" => "can_edit_users",
+	"modify-web" => "can_remote_edit_web",
+	"resend-email" => "can_edit_users",
+	"rename-domain" => "can_rename_domains",
+	"reset-pass" => "can_edit_users",
+	"search-maillogs" => "can_view_maillog",
+	"set-php-directory" => "can_edit_phpver",
+	"start-stop-script" => "can_edit_scripts",
+	"syncmx-domain" => "can_edit_mail",
+	"unalias-domain" => "can_config_domain",
+	"unsub-domain" => "can_config_domain",
+	"validate-domains" => "can_use_validation",
 	);
+
+# can_remote_edit_database_hosts(&domain)
+# Returns 1 if the current user can edit databases and their allowed hosts.
+sub can_remote_edit_database_hosts
+{
+return &can_edit_databases($_[0]) && &can_allowed_db_hosts();
+}
+
+# can_remote_read_mailbox(&domain)
+# Returns 1 if the current user can manage users and read their mail, which in
+# the user interface additionally requires access to the mailboxes module.
+sub can_remote_read_mailbox
+{
+return &can_edit_users($_[0]) && &foreign_available("mailboxes");
+}
+
+# can_remote_import_databases(&domain)
+# Returns 1 if the current user can import and disconnect databases.
+sub can_remote_import_databases
+{
+return &can_edit_databases($_[0]) && &can_import_servers();
+}
+
+# can_remote_edit_acme(&domain)
+# Returns 1 if the current user can manage SSL and request ACME certificates.
+sub can_remote_edit_acme
+{
+return &can_edit_ssl($_[0]) && &can_edit_letsencrypt($_[0]);
+}
+
+# can_remote_edit_dns(&domain)
+# Returns 1 if the current user can change any DNS setting for a domain.
+sub can_remote_edit_dns
+{
+return &can_edit_dns($_[0]) || &can_edit_records($_[0]) || &can_dnsip();
+}
+
+# can_remote_edit_web(&domain)
+# Returns 1 if the current user can change any website setting for a domain.
+sub can_remote_edit_web
+{
+return &can_edit_phpmode($_[0]) || &can_edit_phpver($_[0]) ||
+	&can_edit_html($_[0]) || &can_edit_redirect($_[0]) ||
+	&can_edit_ssl($_[0]) || &can_default_website($_[0]);
+}
 
 # can_use_remote_api()
 # Returns 1 if the current user has permission to call the remote API.
@@ -456,6 +590,19 @@ return 0 if (!$capfunc || !$d || !&can_edit_domain($d));
 return &$capfunc($d);
 }
 
+# require_remote_api_command([program-name])
+# Exits if the current user cannot run a registered command without a domain.
+sub require_remote_api_command
+{
+my ($program) = @_;
+$program ||= $0;
+return if (&master_admin());
+my $capfunc = &get_user_remote_api_command($program);
+return if (&can_use_remote_api() && $capfunc && &$capfunc());
+print $text{'remote_ecannotcmd'},"\n";
+exit(1);
+}
+
 # require_remote_api_domain(&domain, requested-domain, [program-name])
 # Exits with a non-leaking error if the current user cannot run the calling
 # API command for the requested domain.
@@ -482,6 +629,45 @@ my $d = &get_domain_by($field, $value);
 &require_remote_api_domain(
 	$d, defined($requested) ? $requested : $value);
 return $d;
+}
+
+# get_remote_api_owned_domain(field, value, [requested-domain])
+# Looks up an ancillary domain without applying the calling command's feature
+# capability, while still preventing access outside the current user's ACL.
+sub get_remote_api_owned_domain
+{
+my ($field, $value, $requested) = @_;
+my $d = &get_domain_by($field, $value);
+return $d if (&master_admin() || $d && &can_edit_domain($d));
+print &text('remote_ecannotdom',
+	defined($requested) ? $requested : $value),"\n";
+exit(1);
+}
+
+# require_remote_api_capability(&domain, allowed, [requested-domain])
+# Exits if the current user lacks a command-specific capability for a domain.
+sub require_remote_api_capability
+{
+my ($d, $allowed, $requested) = @_;
+return if (&master_admin() || $allowed);
+print &text('remote_ecannotcap',
+	defined($requested) ? $requested : $d->{'dom'}),"\n";
+exit(1);
+}
+
+# get_remote_api_domains(&domains, [owned-only], [program-name])
+# Enforces remote API access for an existing list of target domains. When
+# owned-only is set, domains outside the current user's scope are filtered out.
+sub get_remote_api_domains
+{
+my ($doms, $owned_only, $program) = @_;
+$program ||= $0;
+my @rv = $owned_only && !&master_admin() ?
+	grep { &can_edit_domain($_) } @$doms : @$doms;
+foreach my $d (@rv) {
+	&require_remote_api_domain($d, $d->{'dom'}, $program);
+	}
+return @rv;
 }
 
 # can_remote(program-name)

--- a/commands-lib.pl
+++ b/commands-lib.pl
@@ -458,7 +458,7 @@ my %user_remote_api_commands = (
 	"generate-letsencrypt-cert" => "can_remote_edit_acme",
 	"get-dns" => "can_edit_records",
 	"get-command" => "can_use_remote_api",
-	"get-logs" => "can_edit_domain",
+	"get-logs" => "can_remote_read_logs",
 	"get-ssl" => "can_edit_ssl",
 	"import-database" => "can_remote_import_databases",
 	"install-cert" => "can_edit_ssl",
@@ -468,7 +468,7 @@ my %user_remote_api_commands = (
 	"list-available-scripts" => "can_edit_scripts",
 	"list-available-shells" => "can_edit_users",
 	"list-backup-keys" => "can_backup_keys",
-	"list-bandwidth" => "can_edit_domain",
+	"list-bandwidth" => "can_remote_read_bandwidth",
 	"list-certs" => "can_edit_ssl",
 	"list-certs-expiry" => "can_edit_ssl",
 	"list-commands" => "can_use_remote_api",
@@ -528,6 +528,21 @@ return &can_edit_databases($_[0]) && &can_allowed_db_hosts();
 sub can_remote_read_mailbox
 {
 return &can_edit_users($_[0]) && &foreign_available("mailboxes");
+}
+
+# can_remote_read_logs(&domain)
+# Returns 1 if the current user can access the domain's Webmin log viewer.
+sub can_remote_read_logs
+{
+return &can_edit_domain($_[0]) && &foreign_available("logviewer");
+}
+
+# can_remote_read_bandwidth(&domain)
+# Returns 1 if bandwidth monitoring is enabled for the domain.
+sub can_remote_read_bandwidth
+{
+return &can_edit_domain($_[0]) && $config{'bw_active'} &&
+	&can_monitor_bandwidth($_[0]);
 }
 
 # can_remote_import_databases(&domain)

--- a/create-admin.pl
+++ b/create-admin.pl
@@ -55,6 +55,7 @@ if (!$module_name) {
 	}
 &licence_status();
 @OLDARGV = @ARGV;
+my $is_master = &master_admin();
 
 # Parse command-line args
 $norename = 1;
@@ -79,6 +80,8 @@ while(@ARGV > 0) {
 		$pass = shift(@ARGV);
 		}
 	elsif ($a eq "--passfile") {
+		$is_master ||
+			&usage("--passfile is only available to the master administrator");
 		$pass = &read_file_contents(shift(@ARGV));
 		$pass =~ s/\r|\n//g;
 		}
@@ -121,11 +124,23 @@ while(@ARGV > 0) {
 	}
 
 $domain && $name || &usage("Missing domain name or login name");
-$d = &get_domain_by("dom", $domain);
+$d = &get_remote_api_domain("dom", $domain);
 $d || usage("Virtual server $domain does not exist");
 $d->{'parent'} && &usage("Virtual server $domain is not a parent server");
 $d->{'webmin'} || &usage("Virtual server $domain does not have a Webmin login enabled");
 @admins = &list_extra_admins($d);
+if (!$is_master) {
+	$email && $email !~ /^\S+\@\S+$/ &&
+		&usage("Invalid extra administrator email address");
+	$create && !$d->{'domslimit'} &&
+		&usage("This virtual server cannot create sub-servers");
+	!$norename && $d->{'norename'} &&
+		&usage("This virtual server cannot rename servers");
+	foreach my $edit (@edits) {
+		$d->{'edit_'.$edit} ||
+			&usage("Capability $edit is not available to this virtual server");
+		}
+	}
 
 # Check for a clash
 $name eq "webmin" && &usage("The login name webmin is reserved");
@@ -143,7 +158,7 @@ $clash && &usage("The Webmin username $name is already in use");
 # Validate allowed domains
 @allowed = ( );
 foreach $aname (@allowednames) {
-	$a = &get_domain_by("dom", $aname);
+	$a = &get_remote_api_owned_domain("dom", $aname);
 	$a || &usage("The allowed virtual server $aname does not exist");
 	$a->{'user'} eq $d->{'user'} ||
 		&usage("The allowed virtual server $a->{'dom'} is not owned ".

--- a/create-alias.pl
+++ b/create-alias.pl
@@ -75,14 +75,28 @@ while(@ARGV > 0) {
 	}
 $from || &usage("No from address specified");
 @to || &usage("No destination addresses specified");
+$domain || &usage("No domain specified");
 
-$d = &get_domain_by("dom", $domain);
+$d = &get_remote_api_domain("dom", $domain);
 $d || usage("Virtual server $domain does not exist");
 $d->{'mail'} || usage("Virtual server $domain does not have email enabled");
 $from =~ /\@/ && &usage("No domain name is needed in the --from parameter");
 $err = &valid_alias_name($from);
 $err && &usage("Invalid alias name : $err");
 $d->{'aliascopy'} && &usage("Aliases cannot be edited in alias domains in copy mode");
+if (!&master_admin()) {
+	my ($aleft) = &count_feature("aliases");
+	$aleft == 0 && &usage($text{'alias_ealiaslimit'});
+	$from eq "*" && !&can_edit_catchall() &&
+		&usage("You are not allowed to create catchall aliases");
+	foreach my $to (@to) {
+		$to =~ /^([^\|\:\"\' \t\/\\\%]\S*)$/ ||
+			&usage(&text('alias_etype1', $to));
+		&can_forward_alias($to) ||
+			&usage(&text('alias_etype1f', $to));
+		$to eq "$from\@$domain" && &usage($text{'alias_eloop'});
+		}
+	}
 
 # Check for clash
 &obtain_lock_mail($d);
@@ -90,6 +104,8 @@ $d->{'aliascopy'} && &usage("Aliases cannot be edited in alias domains in copy m
 $email = $from eq "*" ? "\@$domain" : "$from\@$domain";
 ($clash) = grep { $_->{'from'} eq $email } @aliases;
 $clash && &usage("An alias for the same email address already exists");
+!&master_admin() && &check_clash($from, $domain) &&
+	&usage($text{'alias_eclash'});
 
 # Create it
 $virt = { 'from' => $email,

--- a/create-database.pl
+++ b/create-database.pl
@@ -75,10 +75,15 @@ while(@ARGV > 0) {
 $domain || &usage("No domain specified");
 $name || &usage("No database name specified");
 $type || &usage("No database type specified");
-$d = &get_domain_by("dom", $domain);
+$d = &get_remote_api_domain("dom", $domain);
 $d || usage("Virtual server $domain does not exist");
 @dbs = &domain_databases($d);
 $d->{$type} || &usage("The specified database type is not enabled in this virtual server");
+if (!&master_admin()) {
+	%opts && &usage("--opt is only available to the master administrator");
+	my ($dleft) = &count_feature("dbs");
+	$dleft == 0 && &usage($text{'database_emax'});
+	}
 
 # Append prefix, if any
 $tmpl = &get_template($d->{'template'});

--- a/create-domain.pl
+++ b/create-domain.pl
@@ -347,6 +347,9 @@ while(@ARGV > 0) {
 			}
 		}
 	elsif ($a eq "--plan") {
+		$is_master ||
+			&usage("--plan is only available to the master ".
+			       "administrator");
 		$planname = shift(@ARGV);
 		foreach $p (&list_plans()) {
 			if ($p->{'id'} eq $planname ||
@@ -392,6 +395,9 @@ while(@ARGV > 0) {
 		$subdomain = $parentdomain = lc(shift(@ARGV));
 		}
 	elsif ($a eq "--reseller") {
+		$is_master ||
+			&usage("--reseller is only available to the master ".
+			       "administrator");
 		$resel = shift(@ARGV);
 		}
 	elsif ($a eq "--content") {
@@ -551,6 +557,47 @@ while(@ARGV > 0) {
 		&usage("Unknown parameter $a");
 		}
 	}
+# Enforce option-specific permissions before looking up global configuration
+if (!$is_master) {
+	defined($jail) &&
+		&usage("--enable-jail and --disable-jail are only available to ".
+		       "the master administrator");
+	($myserver || $pgserver) &&
+		&usage("--mysql-server and --postgres-server are only available ".
+		       "to the master administrator");
+	($noslaves || $nosecondaries || defined($dns_submode) || $dns_subany) &&
+		&usage("DNS server placement options are only available to the ".
+		       "master administrator");
+	(defined($dns_ip) || defined($dns_ip6)) && !&can_dnsip() &&
+		&usage("You are not allowed to change the DNS IP address");
+	defined($db) && !&can_edit_databases() &&
+		&usage("You are not allowed to select the initial database name");
+	$fwdto && !&can_edit_catchall() &&
+		&usage("You are not allowed to configure catch-all forwarding");
+	defined($content) && !&can_edit_html() &&
+		&usage("You are not allowed to set website content");
+	($clouddns || $clouddns_import || defined($remotedns)) &&
+	  !&can_edit_dns() &&
+		&usage("You are not allowed to select the DNS server");
+	defined($letsencrypt) &&
+	  (!&can_edit_ssl() || !&can_edit_letsencrypt()) &&
+		&usage("You are not allowed to request an SSL certificate");
+	(defined($linkcert) || defined($always_ssl) || $default_cert_owner) &&
+	  !&can_edit_ssl() &&
+		&usage("You are not allowed to configure SSL certificates");
+	($sshmode || defined($append_style) || defined($defaultshell)) &&
+	  !&can_edit_users() &&
+		&usage("You are not allowed to configure domain users");
+	defined($phpmode) && !&can_edit_phpmode() &&
+		&usage("You are not allowed to select the PHP execution mode");
+	$proxy_pass_mode && !&can_edit_forward() &&
+		&usage("You are not allowed to configure proxying");
+	$proxy_pass_mode && $proxy_pass !~ /^(http|https):\/\/\S+$/ &&
+		&usage("Proxy URLs must start with http:// or https://");
+	(defined($auto_redirect) || defined($aliasredir)) &&
+	  !&can_edit_redirect() &&
+		&usage("You are not allowed to configure redirects");
+	}
 # Non-master callers may only ever create a sub-server, so bail out early
 # before any settings that only apply to top-level servers are looked up
 if (!$is_master) {
@@ -679,7 +726,7 @@ if ($subdomain) {
 
 # Validate args and work out defaults for those unset
 $domain = lc(&parse_domain_name($domain));
-if (!$skipwarnings) {
+if (!$skipwarnings || !$is_master) {
 	$err = &valid_domain_name($domain);
 	&usage($err) if ($err);
 	}
@@ -1113,9 +1160,14 @@ $cerr = &virtual_server_clashes(\%dom);
 &usage($cerr) if ($cerr);
 
 # Check if features are not forbidden
-if (!$skipwarnings) {
+if (!$skipwarnings || !$is_master) {
 	foreach my $ff (&forbidden_domain_features(\%dom, 1)) {
-		$dom{$ff} && &usage("The feature $ff is not allowed for virtual server matching the hostname unless the --skip-warnings flag is given.");
+		if ($dom{$ff}) {
+			my $msg = &text('setup_efeatforbidhostdef', $ff);
+			$msg .= " unless the --skip-warnings flag is given"
+				if ($is_master);
+			&usage($msg);
+			}
 		}
 	}
 

--- a/create-domain.pl
+++ b/create-domain.pl
@@ -722,12 +722,7 @@ if (!$is_master) {
 	# Check any restriction on the names he can use
 	my $derr = &allowed_domain_name($parent, $domain);
 	&usage($derr) if ($derr);
-	# Only features the owner has been granted can be enabled
-	foreach my $f (keys %feature, keys %plugin) {
-		&can_use_feature($f) ||
-			&usage("You are not allowed to enable the $f feature");
-		}
-	# Selecting an IP address is only for those allowed to
+	# Only users allowed to select an address may request one
 	($virt || $sharedip) && !&can_select_ip() &&
 		&usage($text{'setup_eip'});
 	($virt6 || $sharedip6) && !&can_select_ip6() &&
@@ -798,6 +793,16 @@ elsif ($deffeatures || $planfeatures && !$tfl) {
 		}
 	}
 scalar(keys %feature) || &usage("No virtual server features enabled");
+
+# Only features the owner has been granted can be enabled. This runs after the
+# set is final, as it may be rebuilt above from a template or plan.
+if (!$is_master) {
+	foreach my $f (grep { $feature{$_} } keys %feature,
+		       grep { $plugin{$_} } keys %plugin) {
+		&can_use_feature($f) ||
+			&usage("You are not allowed to enable the $f feature");
+		}
+	}
 
 if (!$parent) {
 	# Make sure alias, database, etc limits are set properly

--- a/create-domain.pl
+++ b/create-domain.pl
@@ -145,6 +145,8 @@ $name6 = 1;
 $virt6 = 0;
 $anylimits = 0;
 $email = $config{'contact_email'};
+# Remote API callers that are not the master admin may only create sub-servers
+my $is_master = &master_admin();
 while(@ARGV > 0) {
 	my $a = shift(@ARGV);
 	if ($a eq "--domain") {
@@ -172,6 +174,10 @@ while(@ARGV > 0) {
 		$pass = shift(@ARGV);
 		}
 	elsif ($a eq "--passfile") {
+		# Prevent non-master callers from reading server-side files
+		$is_master ||
+			&usage("--passfile is only available to the master ".
+			       "administrator");
 		$pass = &read_file_contents(shift(@ARGV));
 		$pass =~ s/\r|\n//g;
 		}
@@ -281,7 +287,7 @@ while(@ARGV > 0) {
 		}
 	elsif ($a eq "--shared-ip6") {
 		# IPv6 on shared address
-		$ip6 = shift(@ARGV);
+		$ip6 = $sharedip6 = shift(@ARGV);
 		$virt6 = 0;
 		$name6 = 1;
 		&indexof($ip6, &list_shared_ip6s()) >= 0 ||
@@ -401,9 +407,15 @@ while(@ARGV > 0) {
 		$nosecondaries = 1;
 		}
 	elsif ($a eq "--pre-command") {
+		$is_master ||
+			&usage("--pre-command is only available to the master ".
+			       "administrator");
 		$precommand = shift(@ARGV);
 		}
 	elsif ($a eq "--post-command") {
+		$is_master ||
+			&usage("--post-command is only available to the master ".
+			       "administrator");
 		$postcommand = shift(@ARGV);
 		}
 	elsif ($a eq "--skip-warnings") {
@@ -464,6 +476,11 @@ while(@ARGV > 0) {
 		$sshmode = 2;
 		$sshkey = shift(@ARGV);
 		if ($sshkey =~ /^\//) {
+			# Only the master administrator can load a key from a
+			# server-side file
+			$is_master ||
+				&usage("--use-ssh-key must be followed by key ".
+				       "data rather than a file");
 			$sshkey = &read_file_contents($sshkey);
 			}
 		$sshkey =~ /\S/ || &usage("--use-ssh-key must be followed by a key file or data");
@@ -523,6 +540,8 @@ while(@ARGV > 0) {
 		@fields = &list_custom_fields();
 		($f) = grep { $_->{'name'} eq $fn } @fields;
 		$f || &usage("Custom field $fn does not exist");
+		$is_master || $f->{'visible'} == 0 ||
+			&usage("Custom field $fn cannot be edited by domain owners");
 		$fields{'field_'.$fn} = $fv;
 		}
 	elsif ($a eq "--help") {
@@ -532,12 +551,22 @@ while(@ARGV > 0) {
 		&usage("Unknown parameter $a");
 		}
 	}
+# Non-master callers may only ever create a sub-server, so bail out early
+# before any settings that only apply to top-level servers are looked up
+if (!$is_master) {
+	$parentdomain || &usage("Only sub-servers can be created, so the ".
+				"--parent, --alias or --subdom flag must ".
+				"be given");
+	}
 if ($template eq "") {
 	$template = &get_init_template($parentdomain);
 	}
 $tmpl = &get_template($template);
+$is_master || &can_use_template($tmpl) || &usage($text{'setup_etmpl'});
 $plan = $planid ne '' ? &get_plan($planid) : &get_default_plan();
-$plan || &usage("Plan does not exist");
+# Sub-servers always inherit the plan from their parent, and domain owners
+# have no plans of their own to default to
+$plan || $parentdomain || &usage("Plan does not exist");
 $defip = &get_default_ip($resel);
 $defip6 = &get_default_ip6($resel);
 if ($sharedip) {
@@ -676,6 +705,33 @@ if ($parentdomain) {
 			&usage("Sub-domain $domain must be under the parent domain $subdomain");
 		$subprefix ||= $1;
 		}
+	}
+
+# Enforce the same restrictions as the user interface for non-master callers,
+# who may only ever create a sub-server under a domain that they own
+if (!$is_master) {
+	&can_create_sub_servers() ||
+		&usage("You are not allowed to create sub-servers");
+	&can_edit_domain($parent) ||
+		&usage(&text('remote_ecannotdom', $parentdomain));
+	# Check the sub-server limit that applies to this parent
+	my ($dleft, $dreason, $dmax) = &count_domains(
+		$aliasdomain ? "aliasdoms" : "realdoms");
+	$dleft == 0 && &usage("You have reached the maximum of $dmax ".
+			      "virtual servers that can be created");
+	# Check any restriction on the names he can use
+	my $derr = &allowed_domain_name($parent, $domain);
+	&usage($derr) if ($derr);
+	# Only features the owner has been granted can be enabled
+	foreach my $f (keys %feature, keys %plugin) {
+		&can_use_feature($f) ||
+			&usage("You are not allowed to enable the $f feature");
+		}
+	# Selecting an IP address is only for those allowed to
+	($virt || $sharedip) && !&can_select_ip() &&
+		&usage($text{'setup_eip'});
+	($virt6 || $sharedip6) && !&can_select_ip6() &&
+		&usage($text{'setup_eip6'});
 	}
 
 # Allow user and group names
@@ -878,10 +934,14 @@ if ($clouddns) {
 			&usage("Cloudmin Services for DNS is not enabled");
 		}
 	elsif ($clouddns ne "local") {
-		my @cnames = map { $_->{'name'} } &list_dns_clouds();
+		my @clouds = &list_dns_clouds();
+		my @cnames = map { $_->{'name'} } @clouds;
 		&indexof($clouddns, @cnames) >= 0 ||
 			&usage("Valid cloud DNS providers are : ".
 			       join(" ", @cnames));
+		my ($cloud) = grep { $_->{'name'} eq $clouddns } @clouds;
+		$is_master || &can_dns_cloud($cloud) ||
+			&usage("You are not allowed to use DNS provider $clouddns");
 		}
 	}
 

--- a/create-proxy.pl
+++ b/create-proxy.pl
@@ -78,9 +78,20 @@ $path || &usage("No proxy path specified");
 @urls || $none || &usage("At least one URL must be specified");
 $path =~ /^\/\S*$/ || &error("Path must be like / or /foo");
 
-$d = &get_domain_by("dom", $domain);
+$d = &get_remote_api_domain("dom", $domain);
 $d || usage("Virtual server $domain does not exist");
 $has = &has_proxy_balancer($d);
+
+if (!&master_admin()) {
+	$balancer && $balancer !~ /^[a-z0-9_\-]+$/i &&
+		&usage("Invalid proxy balancer name");
+	foreach my $url (@urls) {
+		$url =~ /^(http|https):\/\/\S+$/ ||
+			&usage("Proxy URLs must start with http:// or https://");
+		}
+	$websockets && (@urls != 1 || $urls[0] !~ /^(http|https):\/\//) &&
+		&usage("WebSockets proxying requires one HTTP or HTTPS URL");
+	}
 
 $has || &usage("Proxies cannot be configured for this virtual server");
 $has == 2 || $none || @urls == 1 || &usage("Multiple URL proxy balancers cannot be configured for this virtual server");

--- a/create-redirect.pl
+++ b/create-redirect.pl
@@ -135,7 +135,9 @@ if ($url) {
 		       "a URL path");
 	}
 elsif ($dir) {
-	$dir =~ /^\/\S+$/ && -d $dir ||
+	$dir =~ /^\/\S+$/ ||
+		&usage("The --alias flag must be followed by a directory");
+	&master_admin() && !-d $dir &&
 		&usage("The --alias flag must be followed by a directory");
 	!$stripfile && !$stripquery ||
 		&usage("--strip-file and --strip-query cannot be used with --alias");
@@ -150,8 +152,21 @@ if (!$http && !$https) {
 	$http = $https = 1;
 	}
 
-$d = &get_domain_by("dom", $domain);
+$d = &get_remote_api_domain("dom", $domain);
 $d || usage("Virtual server $domain does not exist");
+if (!&master_admin()) {
+	$path =~ /^\/\S*$/ || $regexp && $path =~ /^\^\S*$/ ||
+		&usage("The redirect path must start with / or ^");
+	$host && $host !~ /^\S+$/ &&
+		&usage("The redirect host must not contain whitespace");
+	if ($dir) {
+		my $rroot = &get_redirect_root($d);
+		&is_under_directory($rroot, $dir) ||
+			&usage("Alias directories must be under $rroot");
+		-d $dir ||
+			&usage("The --alias flag must be followed by a directory");
+		}
+	}
 &has_web_redirects($d) ||
 	&usage("Virtual server $domain does not support redirects");
 !$host || &has_web_host_redirects($d) ||

--- a/create-scheduled-backup.pl
+++ b/create-scheduled-backup.pl
@@ -138,11 +138,17 @@ while(@ARGV > 0) {
 		$includesubs = 1;
 		}
 	elsif ($a eq "--reseller") {
+		&master_admin() ||
+			&usage("--reseller is only available to the master ".
+			       "administrator");
 		defined(&list_resellers) ||
 			&usage("Your system does not support resellers");
 		push(@resellers, shift(@ARGV));
 		}
 	elsif ($a eq "--plan") {
+		&master_admin() ||
+			&usage("--plan is only available to the master ".
+			       "administrator");
 		$planname = shift(@ARGV);
 		($plan) = grep { lc($_->{'name'}) eq lc($planname) ||
 				 $_->{'id'} eq $planname } @allplans;
@@ -153,6 +159,9 @@ while(@ARGV > 0) {
 		$all_bfeats = 1;
 		}
 	elsif ($a eq "--all-domains") {
+		&master_admin() ||
+			&usage("--all-domains is only available to the master ".
+			       "administrator");
 		$all_doms = 1;
 		}
 	elsif ($a eq "--ignore-errors") {
@@ -162,6 +171,9 @@ while(@ARGV > 0) {
 		$separate = 1;
 		}
 	elsif ($a eq "--mkdir") {
+		&master_admin() ||
+			&usage("--mkdir is only available to the master ".
+			       "administrator");
 		$mkdir = 1;
 		}
 	elsif ($a eq "--onebyone") {
@@ -197,6 +209,9 @@ while(@ARGV > 0) {
 		$asowner = 1;
 		}
 	elsif ($a eq "--virtualmin") {
+		&master_admin() ||
+			&usage("--virtualmin is only available to the master ".
+			       "administrator");
 		$v = shift(@ARGV);
 		if (&indexof($v, @virtualmin_backups) < 0) {
 			print STDERR "Unknown --virtualmin option $v. Available options are : ".join(" ", @virtualmin_backups)."\n";
@@ -206,6 +221,9 @@ while(@ARGV > 0) {
 			}
 		}
 	elsif ($a eq "--all-virtualmin") {
+		&master_admin() ||
+			&usage("--all-virtualmin is only available to the master ".
+			       "administrator");
 		@vbs = @virtualmin_backups;
 		}
 	elsif ($a eq "--except-virtualmin") {
@@ -220,6 +238,9 @@ while(@ARGV > 0) {
 		$increment = 2;
 		}
 	elsif ($a eq "--incremental-of" || $a eq "--differential-of") {
+		&master_admin() ||
+			&usage("--differential-of is only available to the master ".
+			       "administrator");
 		&has_incremental_tar() || &usage("The tar command on this system does not support differential backups");
 		$increment = shift(@ARGV);
 		$increment eq "1" &&
@@ -230,6 +251,9 @@ while(@ARGV > 0) {
 			&usage("Scheduled backup with ID $increment is not a full backup");
 		}
 	elsif ($a eq "--purge") {
+		&master_admin() ||
+			&usage("--purge is only available to the master ".
+			       "administrator");
 		$purge = shift(@ARGV);
 		$purge =~ /^[0-9\.]+$/ || &usage("--purge must be followed by a number");
 		}
@@ -295,6 +319,27 @@ foreach my $dname (@bdoms) {
 	$d || &usage("Virtual server $dname does not exist");
 	push(@doms, $d);
 	}
+@doms = &get_remote_api_domains(\@doms);
+
+# Record who owns this schedule, which controls the account it runs as, and
+# keep its destinations inside what that owner may write to
+my $cbmode = &can_backup_domain();
+$cbmode || &usage("You are not allowed to backup virtual servers");
+&can_backup_sched() ||
+	&usage("You are not allowed to create scheduled backups");
+my $schedowner;
+if ($cbmode != 1) {
+	my $od = &get_domain_by_user($base_remote_user);
+	$schedowner = &reseller_admin() ? $base_remote_user :
+		$od ? $od->{'id'} : undef;
+	$schedowner || &usage("You are not allowed to create scheduled backups");
+	foreach my $i (0 .. $#dests) {
+		my ($newdest, $err) = &confine_backup_dest(
+			$dests[$i], $cbmode, $od);
+		$err && &usage($err);
+		$dests[$i] = $newdest;
+		}
+	}
 foreach $dest (@dests) {
 	# Validate destination URL
 	($bmode, $derr, undef, $host, $path) = &parse_backup_url($dest);
@@ -341,6 +386,7 @@ if ($increment) {
 # Create a backup schedule object
 my $sched = { };
 $sched->{'desc'} = $desc;
+$sched->{'owner'} = $schedowner if ($schedowner);
 for(my $i=0; $i<@dests; $i++) {
 	$sched->{'dest'.$i} = $dests[$i];
 	}

--- a/create-scheduled-backup.pl
+++ b/create-scheduled-backup.pl
@@ -198,6 +198,10 @@ while(@ARGV > 0) {
 			$optv = shift(@ARGV);
 			}
 		$optf && $optn && $optv || &usage("Invalid option specification");
+		# The dir feature's include/exclude values are paths run as root
+		&require_remote_api_relative_path($optv)
+			if ($optf eq "dir" &&
+			    ($optn eq "include" || $optn eq "exclude"));
 		$opts{$optf}->{$optn} = $optv;
 		}
 	elsif ($a eq "--mailfiles") {
@@ -262,10 +266,12 @@ while(@ARGV > 0) {
 		}
 	elsif ($a eq "--exclude") {
 		$exclude = shift(@ARGV);
+		&require_remote_api_relative_path($exclude);
 		push(@exclude, $exclude);
 		}
 	elsif ($a eq "--include") {
 		$include = shift(@ARGV);
+		&require_remote_api_relative_path($include);
 		push(@include, $include);
 		}
 	elsif ($a eq "--multiline") {
@@ -374,6 +380,9 @@ if ($keyid) {
 		  	$_->{'key'} eq $keyid ||
 		  	$_->{'desc'} eq $keyid } &list_backup_keys();
 	$key || &usage("No backup key with ID or description $keyid exists");
+	# A non-master may only use their own keys, as restore-domain enforces
+	!defined(&can_backup_key) || &master_admin() || &can_backup_key($key) ||
+		&usage("No backup key with ID or description $keyid exists");
 	}
 if ($onebyone && !$newformat) {
 	&usage("--onebyone option can only be used in conjunction ".

--- a/create-scheduled-backup.pl
+++ b/create-scheduled-backup.pl
@@ -380,8 +380,9 @@ if ($keyid) {
 		  	$_->{'key'} eq $keyid ||
 		  	$_->{'desc'} eq $keyid } &list_backup_keys();
 	$key || &usage("No backup key with ID or description $keyid exists");
-	# A non-master may only use their own keys, as restore-domain enforces
-	!defined(&can_backup_key) || &master_admin() || &can_backup_key($key) ||
+	# A non-master may use their own keys or keys shared for backups
+	!defined(&can_use_backup_key) || &master_admin() ||
+		&can_use_backup_key($key) ||
 		&usage("No backup key with ID or description $keyid exists");
 	}
 if ($onebyone && !$newformat) {

--- a/create-simple-alias.pl
+++ b/create-simple-alias.pl
@@ -71,7 +71,7 @@ while(@ARGV > 0) {
 		}
 	elsif ($a eq "--local") {
 		$local = shift(@ARGV);
-		defined(getpwnam($local)) ||
+		&master_admin() && !defined(getpwnam($local)) &&
 			&usage("Missing or invalid local user for --local");
 		}
 	elsif ($a eq "--everyone") {
@@ -107,12 +107,36 @@ while(@ARGV > 0) {
 	}
 $bounce || $local || @forward || $autotext || $everyone ||
 	&usage("No destination specified");
+$domain || &usage("No domain specified");
+$from || &usage("No from address specified");
 
-$d = &get_domain_by("dom", $domain);
+$d = &get_remote_api_domain("dom", $domain);
 $d || usage("Virtual server $domain does not exist");
 $d->{'mail'} || usage("Virtual server $domain does not have email enabled");
 $from =~ /\@/ && &usage("No domain name is needed in the --from parameter");
 $d->{'aliascopy'} && &usage("Aliases cannot be edited in alias domains in copy mode");
+if (!&master_admin()) {
+	$err = &valid_alias_name($from);
+	$err && &usage("Invalid alias name : $err");
+	my ($aleft) = &count_feature("aliases");
+	$aleft == 0 && &usage($text{'alias_ealiaslimit'});
+	$from eq "*" && !&can_edit_catchall() &&
+		&usage("You are not allowed to create catchall aliases");
+	foreach my $to (@forward) {
+		$to =~ /^([^\|\:\"\' \t\/\\\%]\S*)$/ ||
+			&usage(&text('alias_etype1', $to));
+		&can_forward_alias($to) ||
+			&usage(&text('alias_etype1f', $to));
+		$to eq "$from\@$domain" && &usage($text{'alias_eloop'});
+		}
+	if ($local) {
+		my ($u) = grep { $_->{'user'} eq $local ||
+			&remove_userdom($_->{'user'}, $d) eq $local }
+			&list_domain_users($d, 0, 0, 0, 0);
+		$u || &usage("Local delivery user does not belong to this domain");
+		$local = $u->{'user'};
+		}
+	}
 
 # Check for clash
 &obtain_lock_mail($d);
@@ -120,6 +144,8 @@ $d->{'aliascopy'} && &usage("Aliases cannot be edited in alias domains in copy m
 $email = $from eq "*" ? "\@$domain" : "$from\@$domain";
 ($clash) = grep { $_->{'from'} eq $email } @aliases;
 $clash && &usage("An alias for the same email address already exists");
+!&master_admin() && &check_clash($from, $domain) &&
+	&usage($text{'alias_eclash'});
 
 # Create the simple object
 $simple = { };

--- a/create-user.pl
+++ b/create-user.pl
@@ -87,6 +87,7 @@ if (!$module_name) {
 # Get shells
 ($nologin_shell, $ftp_shell, $jailed_shell, $shell) =
 	&get_common_available_shells();
+my $is_master = &master_admin();
 
 # Parse command-line args
 while(@ARGV > 0) {
@@ -104,6 +105,8 @@ while(@ARGV > 0) {
 		$pass = shift(@ARGV);
 		}
 	elsif ($a eq "--passfile") {
+		$is_master ||
+			&usage("--passfile is only available to the master administrator");
 		$pass = &read_file_contents(shift(@ARGV));
 		$pass =~ s/\r|\n//g;
 		}
@@ -111,12 +114,16 @@ while(@ARGV > 0) {
 		$pass = &random_password();
 		}
 	elsif ($a eq "--encpass") {
+		$is_master ||
+			&usage("--encpass is only available to the master administrator");
 		$encpass = shift(@ARGV);
 		}
 	elsif ($a eq "--ssh-pubkey") {
 		$sshpubkey = shift(@ARGV);
 		}
 	elsif ($a eq "--ssh-pubkey-id") {
+		$is_master ||
+			&usage("--ssh-pubkey-id is only available to the master administrator");
 		$sshpubkeyid = shift(@ARGV);
 		}
 	elsif ($a eq "--real" || $a eq "--desc") {
@@ -132,12 +139,15 @@ while(@ARGV > 0) {
 		}
 	elsif ($a eq "--ftp") {
 		$shell = $ftp_shell;
+		$custom_shell = 1;
 		}
 	elsif ($a eq "--jailed-ftp") {
 		$shell = $jailed_shell;
+		$custom_shell = 1;
 		}
 	elsif ($a eq "--shell") {
 		$shell = { 'shell' => shift(@ARGV) };
+		$custom_shell = 1;
 		}
 	elsif ($a eq "--noemail") {
 		$noemail++;
@@ -189,6 +199,8 @@ while(@ARGV > 0) {
 		    &usage("--recovery must be followed by an email address");
 		}
 	elsif ($a eq "--noappend") {
+		$is_master ||
+			&usage("--noappend is only available to the master administrator");
 		$noappend = 1;
 		}
 	elsif ($a eq "--multiline") {
@@ -206,12 +218,36 @@ $username || &usage("No username specified");
 $pass || $encpass || &usage("No password specified");
 
 # Get the initial user
-$d = &get_domain_by("dom", $domain);
+$d = &get_remote_api_domain("dom", $domain);
 $d || usage("Virtual server $domain does not exist");
 &obtain_lock_unix($d);
 &obtain_lock_mail($d);
 $user = &create_initial_user($d, 0, $web);
 $username = &remove_userdom($username, $d);
+
+# Enforce the same owner limits as the user interface
+if (!$is_master) {
+	($mleft) = &count_feature("mailboxes");
+	$mleft == 0 && &usage($text{'user_emailboxlimit'});
+	if ($custom_shell && (!&can_mailbox_ftp() ||
+	    !&check_available_shell($shell->{'shell'}, 'mailbox'))) {
+		&usage($text{'user_eshell'});
+		}
+	defined($quota) && !&can_mailbox_quota() &&
+		&usage("You are not allowed to set mailbox quotas");
+	if (defined($home)) {
+		&can_mailbox_home($user) ||
+			&usage("You are not allowed to set mailbox home directories");
+		$home =~ /\.\.\// && &usage($text{'user_ehome'});
+		$home =~ /^\// && &usage($text{'user_ehome2'});
+		}
+	foreach my $webdir (@webdirs) {
+		$webdir = &public_html_dir($d)."/".$webdir
+			if ($webdir !~ /^\//);
+		&is_under_directory(&public_html_dir($d), $webdir) ||
+			&usage("Webserver user directories must be under the website root");
+		}
+	}
 
 # Make sure all needed args are set
 if (!$user->{'noquota'}) {
@@ -221,7 +257,15 @@ if (!$user->{'noquota'}) {
 	}
 $err = &valid_mailbox_name($username);
 &usage($err) if ($err);
-$real =~ /^[^:]*$/ || usage($text{'user_ereal'});
+($is_master ? $real =~ /^[^:]*$/ : $real =~ /^[^:\r\n]*$/) ||
+	usage($text{'user_ereal'});
+if (!$is_master) {
+	defined($firstname) && $firstname !~ /^[^:\r\n]*$/ &&
+		&usage($text{'user_efirstname'});
+	defined($surname) && $surname !~ /^[^:\r\n]*$/ &&
+		&usage($text{'user_esurname'});
+	}
+%donextra = ( );
 foreach $e (@extra) {
 	$user->{'noextra'} && &usage("This user cannot have extra email addresses");
 	$e = lc($e);
@@ -231,11 +275,18 @@ foreach $e (@extra) {
 	if ($e !~ /^(\S+)\@(\S+)$/) {
 		usage(&text('user_eextra1', $e));
 		}
-	my ($eu, $ed) = ($1, $2);
-	my $edom = &get_domain_by("dom", $ed);
+	my ($eu, $ed) = ($1, $is_master ? $2 : &parse_domain_name($2));
+	my $edom = $is_master ? &get_domain_by("dom", $ed) :
+		&get_remote_api_owned_domain("dom", $ed);
 	$edom && $edom->{'mail'} || usage(&text('user_eextra2', $ed));
 	!$edom->{'alias'} || !$edom->{'aliascopy'} ||
 		&usage(&text('user_eextra7', $ed));
+	if (!$is_master) {
+		$e = "$eu\@$ed";
+		$e eq "$username\@$d->{'dom'}" &&
+			&usage(&text('user_eextra5', $e));
+		$donextra{lc($e)}++ && &usage(&text('user_eextra6', $e));
+		}
 	}
 
 @alldbs = &domain_databases($d);
@@ -298,7 +349,7 @@ else {
 # SSH public key
 my $pubkey;
 if ($sshpubkey) {
-	my $sshpubkeyfile = -r $sshpubkey ? $sshpubkey : undef;
+	my $sshpubkeyfile = $is_master && -r $sshpubkey ? $sshpubkey : undef;
 	if ($sshpubkeyfile) {
 		$pubkey = &get_ssh_pubkey_from_file($sshpubkeyfile, $sshpubkeyid);
 		}
@@ -331,6 +382,10 @@ if (!$user->{'noprimary'}) {
 	}
 if (defined($recovery)) {
 	$user->{'recovery'} = $recovery;
+	}
+if (!$is_master && $pass) {
+	$err = &check_password_restrictions($user, 0, $d);
+	&usage($err) if ($err);
 	}
 if (!$user->{'noquota'}) {
 	# Set quotas, if not using the defaults
@@ -366,6 +421,12 @@ if (!$user->{'noextra'}) {
 			usage(&text('user_eextra4', $e));
 			}
 		}
+	}
+
+if (!$is_master) {
+	($mleft) = &count_feature("aliases");
+	$mleft >= 0 && $mleft - @extra < 0 &&
+		&usage($text{'alias_ealiaslimit'});
 	}
 
 # Check if the name is too long

--- a/delete-admin.pl
+++ b/delete-admin.pl
@@ -50,7 +50,7 @@ while(@ARGV > 0) {
 
 $domain || &usage("No domain specified");
 $name || &usage("No username specified");
-$d = &get_domain_by("dom", $domain);
+$d = &get_remote_api_domain("dom", $domain);
 $d || usage("Virtual server $domain does not exist");
 
 # Find the admin, and delete him

--- a/delete-alias.pl
+++ b/delete-alias.pl
@@ -56,7 +56,7 @@ while(@ARGV > 0) {
 $domain || &usage("No domain specified");
 $from || &usage("No from address specified");
 
-$d = &get_domain_by("dom", $domain);
+$d = &get_remote_api_domain("dom", $domain);
 $d || usage("Virtual server $domain does not exist");
 $d->{'aliascopy'} && &usage("Aliases cannot be edited in alias domains in copy mode");
 

--- a/delete-backup.pl
+++ b/delete-backup.pl
@@ -36,6 +36,11 @@ while(@ARGV > 0) {
 		$id = shift(@ARGV);
 		}
 	elsif ($a eq "--dest") {
+		# Deleting by destination has no user interface equivalent, and
+		# would remove files outside any virtual server
+		&master_admin() ||
+			&usage("--dest is only available to the master ".
+			       "administrator");
 		$dest = shift(@ARGV);
 		}
 	elsif ($a eq "--multiline") {
@@ -54,6 +59,17 @@ $id || $dest || &usage("One of the --id or --dest flags must be given");
 if ($id) {
 	$log = &get_backup_log($id);
 	$log || &usage("No logged backup with ID $id was found");
+	if (!&master_admin()) {
+		# Only backups made by this user, covering only his own
+		# domains, can be deleted
+		&can_backup_log($log) == 1 ||
+			&usage("No logged backup with ID $id was found");
+		my @alldnames = split(/\s+/, $log->{'doms'});
+		my @owndnames = &backup_log_own_domains($log);
+		scalar(@alldnames) == scalar(@owndnames) ||
+			&usage("This backup covers virtual servers that you ".
+			       "do not own");
+		}
 	$dest = $log->{'dest'};
 	}
 

--- a/delete-database.pl
+++ b/delete-database.pl
@@ -55,7 +55,7 @@ while(@ARGV > 0) {
 $domain || &usage("No domain specified");
 $name || &usage("No database name specified");
 $type || &usage("No database type specified");
-$d = &get_domain_by("dom", $domain);
+$d = &get_remote_api_domain("dom", $domain);
 $d || usage("Virtual server $domain does not exist");
 @dbs = &domain_databases($d);
 
@@ -63,6 +63,10 @@ $d || usage("Virtual server $domain does not exist");
 ($db) = grep { $_->{'name'} eq $name &&
 	       $_->{'type'} eq $type } @dbs;
 $db || &usage("The specified database is not associated with this server");
+if (!&master_admin() && $name eq $d->{'db'} &&
+    !&can_edit_database_name()) {
+	&usage($text{'database_edbdef'});
+	}
 
 # Do it
 &set_all_null_print();

--- a/delete-domain.pl
+++ b/delete-domain.pl
@@ -51,15 +51,30 @@ while(@ARGV > 0) {
 		push(@users, shift(@ARGV));
 		}
 	elsif ($a eq "--only") {
+		# Leaves the underlying objects on the system, which has no
+		# equivalent in the user interface
+		&master_admin() ||
+			&usage("--only is only available to the master ".
+			       "administrator");
 		$only = 1;
 		}
 	elsif ($a eq "--preserve-remote") {
+		&master_admin() || &can_import_servers() ||
+			&usage("--preserve-remote is only available to the ".
+			       "master administrator");
 		$preserve = 1;
 		}
 	elsif ($a eq "--pre-command") {
+		# Commands are run as root, so only the master can set them
+		&master_admin() ||
+			&usage("--pre-command is only available to the ".
+			       "master administrator");
 		$precommand = shift(@ARGV);
 		}
 	elsif ($a eq "--post-command") {
+		&master_admin() ||
+			&usage("--post-command is only available to the ".
+			       "master administrator");
 		$postcommand = shift(@ARGV);
 		}
 	elsif ($a eq "--multiline") {
@@ -81,6 +96,7 @@ foreach $d (@doms) {
 	}
 @doms = grep { !$_->{'parent'} || !$idmap{$_->{'parent'}} } @doms;
 @doms = sort { $b->{'dns_subof'} <=> $a->{'dns_subof'} } @doms;
+@doms = &get_remote_api_domains(\@doms);
 
 # Kill them
 $config{'pre_command'} = $precommand if ($precommand);

--- a/delete-php-directory.pl
+++ b/delete-php-directory.pl
@@ -53,11 +53,13 @@ while(@ARGV > 0) {
 # Validate inputs
 $domain || &usage("No domain specified");
 $dir || &usage("No directory specified");
-$d = &get_domain_by("dom", $domain);
+$d = &get_remote_api_domain("dom", $domain);
 $d || usage("Virtual server $domain does not exist");
 if ($dir !~ /^\//) {
 	$dir = &public_html_dir($d)."/".$dir;
 	}
+!&master_admin() && !&is_under_directory(&public_html_dir($d), $dir) &&
+	&usage("The PHP directory must be under the website root");
 if ($dir eq &public_html_dir($d)) {
 	usage("The PHP version cannot be removed for public_html");
 	}

--- a/delete-proxy.pl
+++ b/delete-proxy.pl
@@ -48,7 +48,7 @@ while(@ARGV > 0) {
 	}
 $domain || &usage("No domain specified");
 $path || &usage("No proxy path specified");
-$d = &get_domain_by("dom", $domain);
+$d = &get_remote_api_domain("dom", $domain);
 $d || usage("Virtual server $domain does not exist");
 &has_proxy_balancer($d) || &usage("Proxy balancers cannot be configured for this virtual server");
 

--- a/delete-redirect.pl
+++ b/delete-redirect.pl
@@ -56,7 +56,7 @@ while(@ARGV > 0) {
 	}
 $domain || &usage("No domain specified");
 $path || &usage("No redirect path specified");
-$d = &get_domain_by("dom", $domain);
+$d = &get_remote_api_domain("dom", $domain);
 $d || usage("Virtual server $domain does not exist");
 &has_web_redirects($d) ||
 	&usage("Virtual server $domain does not support redirects");

--- a/delete-scheduled-backup.pl
+++ b/delete-scheduled-backup.pl
@@ -58,11 +58,19 @@ if ($id) {
 	$sched || &usage("No backup with ID $id exists");
 	}
 elsif ($dest) {
+	# Matching by destination would reveal other users' schedules
+	&master_admin() ||
+		&usage("--dest is only available to the master administrator");
 	($sched) = grep { &indexof($dest, &get_scheduled_backup_dests($_)) >= 0 } @allscheds;
 	$sched || &usage("No backup with destination $dest exists");
 	}
 else {
 	&usage("Missing --id or --dest parameters");
+	}
+if (!&master_admin()) {
+	# Only schedules owned by this user can be removed
+	&can_backup_sched($sched) && $sched->{'id'} ne '1' ||
+		&usage("No scheduled backup with the given ID exists");
 	}
 my @iusers = grep { $_->{'increment'} == $sched->{'id'} } @allscheds;
 @iusers && &usage("This scheduled full backup is being used by other differential backups");

--- a/delete-script.pl
+++ b/delete-script.pl
@@ -74,7 +74,7 @@ while(@ARGV > 0) {
 
 # Validate args
 $domain || &usage("No domain specified");
-$d = &get_domain_by("dom", $domain);
+$d = &get_remote_api_domain("dom", $domain);
 $d || usage("Virtual server $domain does not exist");
 
 # Find the script
@@ -98,6 +98,11 @@ else {
 	}
 
 $script = &get_script($sinfo->{'name'});
+# Global defaults affect other virtual servers
+if (!&master_admin() && $sinfo->{'opts'}->{'global_def'}) {
+	&usage("Global default scripts can only be removed by the ".
+	       "master administrator");
+	}
 if ($dereg) {
 	# Just un-register it
 	&$first_print(&text('scripts_deregistering', $script->{'desc'},

--- a/delete-user.pl
+++ b/delete-user.pl
@@ -51,7 +51,7 @@ while(@ARGV > 0) {
 # Make sure all needed args are set
 $domain || &usage("No domain specified");
 $username || &usage("No username specified");
-$d = &get_domain_by("dom", $domain);
+$d = &get_remote_api_domain("dom", $domain);
 $d || usage("Virtual server $domain does not exist");
 &obtain_lock_mail($d);
 &obtain_lock_unix($d);

--- a/detect-scripts.pl
+++ b/detect-scripts.pl
@@ -62,8 +62,13 @@ while(@ARGV > 0) {
 
 # Validate args
 $dname || &usage("No domain specified");
-$d = &get_domain_by("dom", $dname);
+$d = &get_remote_api_domain("dom", $dname);
 $d || &usage("Domain $dname does not exist!");
+if ($dir && !&master_admin()) {
+	$dir = &public_html_dir($d)."/".$dir if ($dir !~ /^\//);
+	&is_under_directory(&public_html_dir($d), $dir) ||
+		&usage("The search directory must be under the website root");
+	}
 
 # Search for scripts
 &$first_print("Searching for installed scripts".

--- a/disable-domain.pl
+++ b/disable-domain.pl
@@ -80,7 +80,7 @@ while(@ARGV > 0) {
 
 # Find the domain
 $domain || usage("No domain specified");
-$d = &get_domain_by("dom", $domain);
+$d = &get_remote_api_domain("dom", $domain);
 $d || &usage("Virtual server $domain does not exist");
 $d->{'disabled'} && &usage("Virtual server $domain is already disabled");
 @doms = ( $d );
@@ -121,6 +121,7 @@ else {
 				}
 			}
 		}
+	@doms = &get_remote_api_domains(\@doms, 1);
 
 	foreach $d (@doms) {
 		print "Disabling virtual server $d->{'dom'} ..\n\n";

--- a/disable-feature.pl
+++ b/disable-feature.pl
@@ -90,6 +90,17 @@ else {
 if ($dnssub) {
 	@doms = &expand_dns_subdomains(\@doms);
 	}
+@doms = &get_remote_api_domains(\@doms, $all_doms);
+
+# Disconnecting objects from a domain is always a master-only operation
+if (!&master_admin()) {
+	$disassociate && &usage("The --disassociate flag is only available ".
+				"to the master administrator");
+	foreach my $f (keys %feature, keys %plugin) {
+		&can_use_feature($f) ||
+			&usage("You are not allowed to disable the $f feature");
+		}
+	}
 
 # Do it for all domains, aliases first
 $failed = 0;

--- a/disconnect-database.pl
+++ b/disconnect-database.pl
@@ -55,7 +55,7 @@ while(@ARGV > 0) {
 $domain || &usage("No domain specified");
 $name || &usage("No database name specified");
 $type || &usage("No database type specified");
-$d = &get_domain_by("dom", $domain);
+$d = &get_remote_api_domain("dom", $domain);
 $d || usage("Virtual server $domain does not exist");
 @dbs = &domain_databases($d);
 

--- a/enable-domain.pl
+++ b/enable-domain.pl
@@ -55,7 +55,7 @@ while(@ARGV > 0) {
 
 # Find the domain
 $domain || usage("No domain specified");
-$d = &get_domain_by("dom", $domain);
+$d = &get_remote_api_domain("dom", $domain);
 $d || &usage("Virtual server $domain does not exist");
 !$d->{'disabled'} && &usage("Virtual server $domain is not disabled");
 @doms = ( $d );
@@ -68,6 +68,7 @@ if ($subservers && !$d->{'parent'}) {
 			}
 		}
 	}
+@doms = &get_remote_api_domains(\@doms, 1);
 
 foreach $d (@doms) {
 	print "Enabling virtual server $d->{'dom'} ..\n\n";

--- a/enable-feature.pl
+++ b/enable-feature.pl
@@ -96,7 +96,8 @@ else {
 
 # Only features the caller has been granted can be enabled, and connecting
 # existing objects to a domain is always a master-only operation
-if (!&master_admin()) {
+my $is_master = &master_admin();
+if (!$is_master) {
 	$associate && &usage("The --associate flag is only available to the ".
 			     "master administrator");
 	foreach my $f (keys %feature, keys %plugin) {
@@ -119,9 +120,12 @@ foreach $d (sort { ($a->{'alias'} ? 2 : $a->{'parent'} ? 1 : 0) <=>
 	my $f;
 	foreach $f (&list_ordered_features(\%newdom)) {
 		if ($feature{$f} || $plugin{$f}) {
-			if (!$skipwarnings &&
+			if ((!$skipwarnings || !$is_master) &&
 			    grep {$_ eq $f} @forbidden_domain_features) {
-				&$second_print(".. the feature $f cannot be enabled for this type of virtual server unless the --skip-warnings flag is given");
+				my $msg = ".. the feature $f cannot be enabled for this type of virtual server";
+				$msg .= " unless the --skip-warnings flag is given"
+					if ($is_master);
+				&$second_print($msg);
 				$failed = 1;
 				next DOMAIN;
 				}

--- a/enable-feature.pl
+++ b/enable-feature.pl
@@ -92,6 +92,18 @@ else {
 	# Get domains by name and user
 	@doms = &get_domains_by_names_users(\@dnames, \@users, \&usage);
 	}
+@doms = &get_remote_api_domains(\@doms, $all_doms);
+
+# Only features the caller has been granted can be enabled, and connecting
+# existing objects to a domain is always a master-only operation
+if (!&master_admin()) {
+	$associate && &usage("The --associate flag is only available to the ".
+			     "master administrator");
+	foreach my $f (keys %feature, keys %plugin) {
+		&can_use_feature($f) ||
+			&usage("You are not allowed to enable the $f feature");
+		}
+	}
 
 # Do it for all domains, non-aliases first
 $failed = 0;

--- a/fix-domain-permissions.pl
+++ b/fix-domain-permissions.pl
@@ -68,6 +68,7 @@ else {
 			}
 		}
 	}
+@doms = &get_remote_api_domains(\@doms, $all_doms);
 
 # Lock them all
 foreach $d (@doms) {

--- a/fix-domain-quota.pl
+++ b/fix-domain-quota.pl
@@ -64,6 +64,7 @@ else {
 		push(@doms, $d);
 		}
 	}
+@doms = &get_remote_api_domains(\@doms, $all_doms);
 
 # Lock them all
 foreach $d (@doms) {

--- a/functional-test.pl
+++ b/functional-test.pl
@@ -9696,17 +9696,19 @@ if ($web eq 'virtualmin-nginx' &&
 		($ENV{'WEBMIN_CONFIG'} || "/etc/webmin").
 		"/virtualmin-nginx/config";
 	my $nginx_config_backup =
-		"/tmp/functional-test-virtualmin-nginx-config";
+		&transname("functional-test-virtualmin-nginx-config");
+	my $q_nginx_config = &quote_path($nginx_config);
+	my $q_nginx_config_backup = &quote_path($nginx_config_backup);
 	$nginxlisten_tests = [
 		# Use wildcard listeners for this test
-		{ 'command' => 'cp -p '.$nginx_config.' '.
-			       $nginx_config_backup,
+		{ 'command' => 'cp -p '.$q_nginx_config.' '.
+			       $q_nginx_config_backup,
 		},
 		{ 'command' => "perl -pi -e ".
 			       "'s/^listen_mode=.*/listen_mode=0/' ".
-			       $nginx_config,
+			       $q_nginx_config,
 		},
-		{ 'command' => 'grep "^listen_mode=0$" '.$nginx_config,
+		{ 'command' => 'grep "^listen_mode=0$" '.$q_nginx_config,
 		},
 
 		# Create an IPv6-only domain with HTTP and HTTPS listeners
@@ -9732,20 +9734,21 @@ if ($web eq 'virtualmin-nginx' &&
 			      [ 'default-ip' ] ],
 		},
 
-		# Check the generated listeners
-		{ 'command' => 'nginx -T',
-		  'grep' => [ 'listen\s+8888;',
-			      'listen\s+\[::\]:8888;' ],
-		  'antigrep' => [
-			'listen\s+80:8888;',
-			'listen\s+'.quotemeta($test_ip_address).':8888;',
-			],
+		# Validate the domain after changing its listeners
+		{ 'command' => 'validate-domains.pl',
+		  'args' => [ [ 'domain', $test_domain ],
+			      [ 'all-features' ] ],
 		},
 
 		# Check that the website is actually reachable
 		{ 'command' => $wget_command.
 			       '--header="Host: '.$test_domain.'" '.
 			       'http://127.0.0.1:8888',
+		  'grep' => 'Test Nginx wildcard page',
+		},
+		{ 'command' => $wget_command.
+			       '--inet6 --header="Host: '.$test_domain.'" '.
+			       '"http://[::1]:8888"',
 		  'grep' => 'Test Nginx wildcard page',
 		},
 
@@ -9755,9 +9758,9 @@ if ($web eq 'virtualmin-nginx' &&
 		  'cleanup' => 1,
 		  'ignorefail' => 1,
 		},
-		{ 'command' => 'cp -p '.$nginx_config_backup.' '.
-			       $nginx_config.' && rm -f '.
-			       $nginx_config_backup,
+		{ 'command' => 'cp -p '.$q_nginx_config_backup.' '.
+			       $q_nginx_config.' && rm -f '.
+			       $q_nginx_config_backup,
 		  'cleanup' => 1,
 		},
 		];

--- a/functional-test.pl
+++ b/functional-test.pl
@@ -6991,6 +6991,326 @@ if (!$webmin_user || !$webmin_pass) {
 	$remote_tests = [ { 'command' => 'echo Missing user or password ; false' } ];
 	}
 
+$ownerremote_tests = [
+	# Create two test domains with different owners
+	{ 'command' => 'create-domain.pl',
+	  'args' => [ [ 'domain', $test_domain ],
+		      [ 'desc', 'Remote API owner test' ],
+		      [ 'pass', 'smeg' ],
+		      [ 'dir' ], [ 'unix' ], [ 'mail' ], [ 'mysql' ],
+		      [ 'webmin' ],
+		      @create_args, ],
+	},
+	{ 'command' => 'create-domain.pl',
+	  'args' => [ [ 'domain', $test_target_domain ],
+		      [ 'desc', 'Remote API foreign domain test' ],
+		      [ 'pass', 'smeg' ],
+		      [ 'dir' ], [ 'unix' ], [ 'mysql' ], [ 'webmin' ],
+		      @create_args, ],
+	},
+
+	# Remote API access is denied to the domain owner by default
+	{ 'command' => &owner_remote_api_command(
+		       "program=list-databases&domain=$test_domain"),
+	  'grep' => 'ERROR: You are not allowed to run remote commands',
+	  'ignorefail' => 1,
+	},
+
+	# Grant remote API access, but not the database capability yet
+	{ 'command' => 'modify-limits.pl',
+	  'args' => [ [ 'domain', $test_domain ],
+		      [ 'can-edit', 'remote_api' ], ],
+	},
+
+	# Each API command still requires its matching owner capability
+	{ 'command' => &owner_remote_api_command(
+		       "program=list-databases&domain=$test_domain"),
+	  'grep' => 'You are not allowed to run this command for virtual server '.
+		    $test_domain,
+	  'ignorefail' => 1,
+	},
+
+	# Commands outside the audited registry remain unavailable
+	{ 'command' => &owner_remote_api_command(
+		       "program=modify-limits&domain=$test_domain&can-edit=dbs"),
+	  'grep' => 'ERROR: You are not allowed to run remote commands',
+	  'ignorefail' => 1,
+	},
+
+	# Grant the capabilities and limits needed by the remaining tests
+	{ 'command' => 'modify-limits.pl',
+	  'args' => [ [ 'domain', $test_domain ],
+		      [ 'can-edit', 'dbs' ],
+		      [ 'can-edit', 'users' ],
+		      [ 'can-edit', 'delete' ],
+		      [ 'max-dbs', 'UNLIMITED' ],
+		      [ 'max-mailboxes', 'UNLIMITED' ],
+		      [ 'max-doms', 'UNLIMITED' ],
+		      [ 'max-realdoms', 'UNLIMITED' ], ],
+	},
+
+	# An all-domain listing only returns domains owned by the caller
+	{ 'command' => &owner_remote_api_command(
+		       "program=list-domains&name-only="),
+	  'grep' => '^'.quotemeta($test_domain).'$',
+	  'antigrep' => '^'.quotemeta($test_target_domain).'$',
+	  'ignorefail' => 1,
+	},
+
+	# Detailed domain output does not expose stored passwords
+	{ 'command' => &owner_remote_api_command(
+		       "program=list-domains&domain=$test_domain&multiline="),
+	  'grep' => [ '^'.quotemeta($test_domain).'$',
+		      '^    Username: '.quotemeta($test_domain_user).'$' ],
+	  'antigrep' => [ '^    Password:', '^    Hashed password:',
+			  '^    Password for ' ],
+	  'ignorefail' => 1,
+	},
+
+	# The domain owner can call an allowed API command for their own domain
+	{ 'command' => &owner_remote_api_command(
+		       "program=list-databases&domain=$test_domain"),
+	  'grep' => [ '^'.$test_domain_db.'\\s+mysql', 'Exit status: 0' ],
+	  'ignorefail' => 1,
+	},
+
+	# The same command cannot access another owner's domain
+	{ 'command' => &owner_remote_api_command(
+		       "program=list-databases&domain=$test_target_domain"),
+	  'grep' => 'Virtual server '.$test_target_domain.' does not exist',
+	  'ignorefail' => 1,
+	},
+
+	# Create, list and delete a database through the owner API
+	{ 'command' => &owner_remote_api_command(
+		       "program=create-database&domain=$test_domain&".
+		       "name=${test_domain_db}_remote&type=mysql"),
+	  'grep' => 'Database '.$test_domain_db.'_remote created successfully',
+	  'ignorefail' => 1,
+	},
+	{ 'command' => &owner_remote_api_command(
+		       "program=list-databases&domain=$test_domain&name-only="),
+	  'grep' => '^'.quotemeta($test_domain_db.'_remote').'$',
+	  'ignorefail' => 1,
+	},
+	{ 'command' => &owner_remote_api_command(
+		       "program=delete-database&domain=$test_domain&".
+		       "name=${test_domain_db}_remote&type=mysql"),
+	  'grep' => 'Database '.$test_domain_db.'_remote deleted successfully',
+	  'ignorefail' => 1,
+	},
+	{ 'command' => &owner_remote_api_command(
+		       "program=list-databases&domain=$test_domain&name-only="),
+	  'grep' => 'Exit status: 0',
+	  'antigrep' => '^'.quotemeta($test_domain_db.'_remote').'$',
+	  'ignorefail' => 1,
+	},
+
+	# Server-side password files remain restricted to the master administrator
+	{ 'command' => &owner_remote_api_command(
+		       "program=create-user&domain=$test_domain&user=$test_user&".
+		       "passfile=/etc/shadow&real=Remote+API+User"),
+	  'grep' => '--passfile is only available to the master administrator',
+	  'ignorefail' => 1,
+	},
+
+	# Create and inspect a mailbox without exposing password or SSH key data
+	{ 'command' => &owner_remote_api_command(
+		       "program=create-user&domain=$test_domain&user=$test_user&".
+		       "pass=smeg&real=Remote+API+User&no-creation-mail="),
+	  'grep' => 'created successfully',
+	  'ignorefail' => 1,
+	},
+	{ 'command' => &owner_remote_api_command(
+		       "program=list-users&domain=$test_domain&user=$test_user&".
+		       "multiline="),
+	  'grep' => [ '^    User: '.quotemeta($test_user).'$',
+		      '^    Real name: Remote API User$', 'Exit status: 0' ],
+	  'antigrep' => [ '^    Password:', '^    Encrypted password:',
+			  '^    SSH public key:' ],
+	  'ignorefail' => 1,
+	},
+
+	# Modify the mailbox and verify the persisted result
+	{ 'command' => &owner_remote_api_command(
+		       "program=modify-user&domain=$test_domain&user=$test_user&".
+		       "real=Updated+Remote+API+User"),
+	  'grep' => 'updated successfully',
+	  'ignorefail' => 1,
+	},
+	{ 'command' => &owner_remote_api_command(
+		       "program=list-users&domain=$test_domain&user=$test_user&".
+		       "multiline="),
+	  'grep' => '^    Real name: Updated Remote API User$',
+	  'ignorefail' => 1,
+	},
+
+	# Delete the mailbox and verify that it is no longer returned
+	{ 'command' => &owner_remote_api_command(
+		       "program=delete-user&domain=$test_domain&user=$test_user"),
+	  'grep' => 'deleted successfully',
+	  'ignorefail' => 1,
+	},
+	{ 'command' => &owner_remote_api_command(
+		       "program=list-users&domain=$test_domain&user=$test_user&".
+		       "multiline="),
+	  'grep' => 'Exit status: 0',
+	  'antigrep' => '^    User: '.quotemeta($test_user).'$',
+	  'ignorefail' => 1,
+	},
+
+	# Domain owners cannot create top-level servers or use a foreign parent
+	{ 'command' => &owner_remote_api_command(
+		       "program=create-domain&domain=api.$test_domain&dir="),
+	  'grep' => 'Only sub-servers can be created',
+	  'ignorefail' => 1,
+	},
+	{ 'command' => &owner_remote_api_command(
+		       "program=create-domain&domain=api.$test_target_domain&".
+		       "parent=$test_target_domain&dir="),
+	  'grep' => 'Virtual server '.$test_target_domain.' does not exist',
+	  'ignorefail' => 1,
+	},
+
+	# Create and delete a permitted sub-server under the owned domain
+	{ 'command' => &owner_remote_api_command(
+		       "program=create-domain&domain=api.$test_domain&".
+		       "parent=$test_domain&dir="),
+	  'grep' => [ 'All done!', 'Exit status: 0' ],
+	  'ignorefail' => 1,
+	},
+	{ 'command' => &owner_remote_api_command(
+		       "program=list-domains&domain=api.$test_domain&name-only="),
+	  'grep' => '^api.'.quotemeta($test_domain).'$',
+	  'ignorefail' => 1,
+	},
+	{ 'command' => &owner_remote_api_command(
+		       "program=delete-domain&domain=api.$test_domain"),
+	  'grep' => [ 'Deleting virtual server api.'.quotemeta($test_domain),
+		      'Exit status: 0' ],
+	  'ignorefail' => 1,
+	  'cleanup' => 1,
+	},
+
+	# Commands that would run as root are never accepted from an owner
+	{ 'command' => &owner_remote_api_command(
+		       "program=create-domain&domain=rce.$test_domain".
+		       "&parent=$test_domain&dir=&web=".
+		       "&pre-command=touch+/tmp/virtualmin-api-test"),
+	  'grep' => '--pre-command is only available to the master administrator',
+	  'ignorefail' => 1,
+	},
+	{ 'command' => &owner_remote_api_command(
+		       "program=delete-domain&domain=$test_domain".
+		       "&post-command=touch+/tmp/virtualmin-api-test"),
+	  'grep' => '--post-command is only available to the master administrator',
+	  'ignorefail' => 1,
+	},
+	{ 'command' => 'ls /tmp/virtualmin-api-test',
+	  'fail' => 1,
+	},
+
+	# Reading a server-side file through a certificate flag is blocked
+	{ 'command' => &owner_remote_api_command(
+		       "program=install-cert&domain=$test_domain".
+		       "&cert=/etc/shadow&key=/etc/shadow"),
+	  'grep' => 'only available to the master administrator',
+	  'antigrep' => '^root:',
+	  'ignorefail' => 1,
+	},
+
+	# Owners cannot raise their own quota or bandwidth limits
+	{ 'command' => &owner_remote_api_command(
+		       "program=modify-domain&domain=$test_domain&quota=99999999"),
+	  'grep' => 'not allowed to change quotas',
+	  'ignorefail' => 1,
+	},
+	{ 'command' => 'list-domains.pl',
+	  'args' => [ [ 'domain', $test_domain ], [ 'multiline' ] ],
+	  'antigrep' => '^    Server quota: 99999999',
+	},
+
+	# Grant the backup capabilities needed by the checks below, so that the
+	# limits being tested are the destination and feature ones
+	{ 'command' => 'modify-limits.pl',
+	  'args' => [ [ 'domain', $test_domain ],
+		      [ 'can-edit', 'backup' ],
+		      [ 'can-edit', 'sched' ],
+		      [ 'can-edit', 'restore' ], ],
+	},
+
+	# Backups can only be written under the owner's own backup directory
+	{ 'command' => &owner_remote_api_command(
+		       "program=backup-domain&domain=$test_domain".
+		       "&dest=/etc/cron.d/virtualmin-api-test&all-features="),
+	  'antigrep' => 'completed',
+	  'ignorefail' => 1,
+	},
+	{ 'command' => 'ls /etc/cron.d/virtualmin-api-test',
+	  'fail' => 1,
+	},
+	{ 'command' => &owner_remote_api_command(
+		       "program=backup-domain&domain=$test_domain".
+		       "&dest=apitest.tar.gz&all-features="),
+	  'grep' => 'Exit status: 0',
+	  'ignorefail' => 1,
+	},
+
+	# Restores are limited to features that cannot change the server setup
+	{ 'command' => &owner_remote_api_command(
+		       "program=restore-domain&domain=$test_domain".
+		       "&source=apitest.tar.gz&feature=virtualmin"),
+	  'grep' => 'cannot be restored by anyone other than the master',
+	  'ignorefail' => 1,
+	},
+	{ 'command' => &owner_remote_api_command(
+		       "program=restore-domain&domain=$test_domain".
+		       "&source=apitest.tar.gz&feature=dir"),
+	  'grep' => 'Exit status: 0',
+	  'ignorefail' => 1,
+	},
+
+	# Scheduled backups are recorded against their owner, so they never
+	# run with master privileges, and other schedules stay out of reach
+	{ 'command' => &owner_remote_api_command(
+		       "program=create-scheduled-backup&domain=$test_domain".
+		       "&dest=apisched.tar.gz&all-features=&schedule=0+3+*+*+*"),
+	  'grep' => 'Exit status: 0',
+	  'ignorefail' => 1,
+	},
+	{ 'command' => 'list-scheduled-backups.pl --multiline',
+	  'grep' => 'apisched.tar.gz',
+	},
+	{ 'command' => &owner_remote_api_command(
+		       "program=modify-scheduled-backup&id=1&disable="),
+	  'grep' => 'No scheduled backup with ID',
+	  'ignorefail' => 1,
+	},
+	{ 'command' => &owner_remote_api_command(
+		       "program=delete-backup&dest=/etc/passwd"),
+	  'grep' => '--dest is only available to the master administrator',
+	  'ignorefail' => 1,
+	},
+	{ 'command' => 'ls /etc/passwd',
+	},
+	{ 'command' => 'delete-scheduled-backup.pl',
+	  'args' => [ [ 'dest', $test_domain_home.
+			        '/virtualmin-backup/apisched.tar.gz' ] ],
+	  'ignorefail' => 1,
+	  'cleanup' => 1,
+	},
+
+	# Cleanup both domains
+	{ 'command' => 'delete-domain.pl',
+	  'args' => [ [ 'domain', $test_domain ] ],
+	  'cleanup' => 1,
+	},
+	{ 'command' => 'delete-domain.pl',
+	  'args' => [ [ 'domain', $test_target_domain ] ],
+	  'cleanup' => 1,
+	},
+	];
+
 $owner_tests = [
 	# Create a test domain
 	{ 'command' => 'create-domain.pl',
@@ -14030,6 +14350,7 @@ $alltests = { '_config' => $_config_tests,
 	      'xml' => $xml_tests,
 	      'assoc' => $assoc_tests,
 	      'owner' => $owner_tests,
+	      'ownerremote' => $ownerremote_tests,
 	    };
 if (!$virtualmin_pro) {
 	# Some tests don't work on GPL
@@ -14144,6 +14465,16 @@ if ($total_failed) {
 	print "!!!!!!!!!!!!! FAILURES : ",join(" ", @failed_tests,),"\n";
 	}
 exit($total_failed);
+
+# owner_remote_api_command(query-string)
+# Returns a bounded remote API request authenticated as the test domain owner.
+sub owner_remote_api_command
+{
+my ($query) = @_;
+return $owner_webmin_wget_command.'--tries=1 --timeout=30 '.
+	"'${webmin_proto}://localhost:${webmin_port}".
+	"/virtual-server/remote.cgi?$query'";
+}
 
 sub run_test
 {

--- a/functional-test.pl
+++ b/functional-test.pl
@@ -7281,6 +7281,20 @@ $ownerremote_tests = [
 	  'antigrep' => '^    Server quota: 99999999',
 	},
 
+	# Grant access to general domain settings, but not backups yet
+	{ 'command' => 'modify-limits.pl',
+	  'args' => [ [ 'domain', $test_domain ],
+		      [ 'can-edit', 'domain' ], ],
+	},
+
+	# Backup exclusions require the backup capability
+	{ 'command' => &owner_remote_api_command(
+		       "program=modify-domain&domain=$test_domain".
+		       "&add-exclude=logs"),
+	  'grep' => 'not allowed to edit backup exclusions',
+	  'ignorefail' => 1,
+	},
+
 	# Grant the backup capabilities needed by the checks below, so that the
 	# limits being tested are the destination and feature ones
 	{ 'command' => 'modify-limits.pl',
@@ -7288,6 +7302,26 @@ $ownerremote_tests = [
 		      [ 'can-edit', 'backup' ],
 		      [ 'can-edit', 'sched' ],
 		      [ 'can-edit', 'restore' ], ],
+	},
+
+	# Backup exclusions use the same validation as the owner UI
+	{ 'command' => &owner_remote_api_command(
+		       "program=modify-domain&domain=$test_domain".
+		       "&add-exclude=../etc"),
+	  'grep' => "Directory '../etc' cannot contain ..",
+	  'ignorefail' => 1,
+	},
+	{ 'command' => &owner_remote_api_command(
+		       "program=modify-domain&domain=$test_domain".
+		       "&add-exclude=logs"),
+	  'grep' => 'Exit status: 0',
+	  'ignorefail' => 1,
+	},
+	{ 'command' => &owner_remote_api_command(
+		       "program=modify-domain&domain=$test_domain".
+		       "&remove-exclude=logs"),
+	  'grep' => 'Exit status: 0',
+	  'ignorefail' => 1,
 	},
 
 	# Backups can only be written under the owner's own backup directory

--- a/functional-test.pl
+++ b/functional-test.pl
@@ -7222,6 +7222,25 @@ $owner_tests = [
 		}
 		} @other_webmin_modules),
 
+	# Per-domain Webmin module access can be revoked and restored without
+	# changing the server template
+	{ 'command' => 'modify-limits.pl',
+	  'args' => [ [ 'domain', $test_domain ],
+		      [ 'remove-webmin-module', 'proc' ] ],
+	},
+	{ 'command' => $owner_webmin_wget_command.
+		       "${webmin_proto}://localhost:${webmin_port}/proc/",
+	  'grep' => [ '>Failed to|is not allowed' ],
+	},
+	{ 'command' => 'modify-limits.pl',
+	  'args' => [ [ 'domain', $test_domain ],
+		      [ 'add-webmin-module', 'proc=2' ] ],
+	},
+	{ 'command' => $owner_webmin_wget_command.
+		       "${webmin_proto}://localhost:${webmin_port}/proc/",
+	  'antigrep' => [ '>Failed to|is not allowed' ],
+	},
+
 	# Check a module that they should not have access to ever
 	{ 'command' => $owner_webmin_wget_command.
 		       "${webmin_proto}://localhost:${webmin_port}/acl/",

--- a/functional-test.pl
+++ b/functional-test.pl
@@ -7043,6 +7043,10 @@ $ownerremote_tests = [
 		      [ 'can-edit', 'dbs' ],
 		      [ 'can-edit', 'users' ],
 		      [ 'can-edit', 'delete' ],
+		      [ 'cannot-edit', 'forward' ],
+		      [ 'cannot-edit', 'html' ],
+		      [ 'cannot-edit', 'dnsip' ],
+		      [ 'cannot-edit', 'catchall' ],
 		      [ 'max-dbs', 'UNLIMITED' ],
 		      [ 'max-mailboxes', 'UNLIMITED' ],
 		      [ 'max-doms', 'UNLIMITED' ],
@@ -7169,6 +7173,53 @@ $ownerremote_tests = [
 		       "program=create-domain&domain=api.$test_target_domain&".
 		       "parent=$test_target_domain&dir="),
 	  'grep' => 'Virtual server '.$test_target_domain.' does not exist',
+	  'ignorefail' => 1,
+	},
+
+	# Warning overrides cannot bypass hard validation for domain owners
+	{ 'command' => &owner_remote_api_command(
+		       "program=create-domain&domain=invalid..$test_domain&".
+		       "parent=$test_domain&dir=&skip-warnings="),
+	  'grep' => 'Domain names cannot contain consecutive dots',
+	  'ignorefail' => 1,
+	},
+
+	# Creation options retain the permissions and master-only boundaries
+	# enforced by their corresponding user interface settings
+	{ 'command' => &owner_remote_api_command(
+		       "program=create-domain&domain=dbhost.$test_domain&".
+		       "parent=$test_domain&dir=&mysql-server=remote.test"),
+	  'grep' => '--mysql-server and --postgres-server are only available',
+	  'ignorefail' => 1,
+	},
+	{ 'command' => &owner_remote_api_command(
+		       "program=create-domain&domain=jail.$test_domain&".
+		       "parent=$test_domain&dir=&disable-jail="),
+	  'grep' => '--enable-jail and --disable-jail are only available',
+	  'ignorefail' => 1,
+	},
+	{ 'command' => &owner_remote_api_command(
+		       "program=create-domain&domain=proxy.$test_domain&".
+		       "parent=$test_domain&dir=&proxy=http%3A%2F%2F127.0.0.1"),
+	  'grep' => 'You are not allowed to configure proxying',
+	  'ignorefail' => 1,
+	},
+	{ 'command' => &owner_remote_api_command(
+		       "program=create-domain&domain=content.$test_domain&".
+		       "parent=$test_domain&dir=&content=Owner+content"),
+	  'grep' => 'You are not allowed to set website content',
+	  'ignorefail' => 1,
+	},
+	{ 'command' => &owner_remote_api_command(
+		       "program=create-domain&domain=dnsip.$test_domain&".
+		       "parent=$test_domain&dir=&dns-ip=192.0.2.10"),
+	  'grep' => 'You are not allowed to change the DNS IP address',
+	  'ignorefail' => 1,
+	},
+	{ 'command' => &owner_remote_api_command(
+		       "program=create-domain&domain=forward.$test_domain&".
+		       "parent=$test_domain&dir=&fwdto=test%40example.test"),
+	  'grep' => 'You are not allowed to configure catch-all forwarding',
 	  'ignorefail' => 1,
 	},
 

--- a/generate-acme-cert.pl
+++ b/generate-acme-cert.pl
@@ -155,10 +155,15 @@ while(@ARGV > 0) {
 
 # Validate inputs
 $dname || &usage("Missing --domain parameter");
-$d = &get_domain_by("dom", $dname);
+$d = &get_remote_api_domain("dom", $dname);
 $d || &usage("No virtual server named $dname found");
 $d->{'ssl_same'} && &usage("This server shares it's SSL certificate ".
 			   "with another domain");
+# Only the master administrator can enable notifications to the master
+if (!&master_admin() && defined($email_master)) {
+	&usage("Master administrator notifications can only be changed by ".
+	       "the master administrator");
+	}
 if ($ctype =~ /^ec/) {
 	&letsencrypt_supports_ec() ||
 		&usage("The ACME client on your system does ".
@@ -215,6 +220,8 @@ elsif (defined(&list_acme_providers)) {
 	($acme) = grep { $_->{'id'} eq $d->{'letsencrypt_id'} }
 		       &list_acme_providers();
 	}
+!&master_admin() && $acme && !&can_acme_provider($acme) &&
+	&usage("The selected ACME provider is not available to this user");
 
 # Build a list of the domains being validated
 my @cdoms = ( $d );

--- a/generate-cert.pl
+++ b/generate-cert.pl
@@ -110,10 +110,23 @@ while(@ARGV > 0) {
 	}
 $dname || &usage("Missing --domain parameter");
 $self || $csr || &usage("One of the --self or --csr parameters must be given");
-$d = &get_domain_by("dom", $dname);
+$d = &get_remote_api_domain("dom", $dname);
 $d || &usage("No virtual server named $dname found");
 $d->{'ssl_same'} && &usage("This server shares it's SSL certificate ".
 			   "with another domain");
+if (!&master_admin()) {
+	defined($size) && $size !~ /^\d+$/ &&
+		&usage("Certificate key size must be a number");
+	defined($days) && $days !~ /^\d+$/ &&
+		&usage("Certificate validity must be a number of days");
+	defined($subject{'cn'}) &&
+	  $subject{'cn'} !~ /^[a-z0-9\.\-\*]+$/i &&
+		&usage("Invalid certificate common name");
+	foreach my $alt (@alts) {
+		$alt =~ /^(\*\.)?[a-z0-9\.\_\-]+$/i ||
+			&usage("Invalid certificate alternate name $alt");
+		}
+	}
 
 # Run the before command
 &set_domain_envs($d, "SSL_DOMAIN");

--- a/get-command.pl
+++ b/get-command.pl
@@ -42,6 +42,11 @@ while(@ARGV > 0) {
 # Find the command
 $cmd || &usage("Missing --command parameter");
 $cmd =~ s/\.pl$//;
+!&master_admin() && $cmd !~ /^[a-z0-9_\-]+$/i &&
+	&usage("API command $cmd was not found");
+&require_remote_api_command();
+!&master_admin() && !&can_remote_as_user($cmd) &&
+	&usage("API command $cmd was not found");
 if (my $msg = &api_command_unavailable_message($cmd)) {
 	print "$msg\n";
 	exit(1);

--- a/get-dns.pl
+++ b/get-dns.pl
@@ -82,7 +82,7 @@ while(@ARGV > 0) {
 
 # Validate inputs and get the domain
 $dname || &usage("Missing --domain parameter");
-$d = &get_domain_by("dom", $dname);
+$d = &get_remote_api_domain("dom", $dname);
 $d || &usage("Virtual server $dname does not exist");
 $d->{'dns'} || &usage("Virtual server $dname does not have DNS enabled");
 $cloud = &get_domain_dns_cloud($d);

--- a/get-logs.pl
+++ b/get-logs.pl
@@ -23,7 +23,7 @@ if (!$module_name) {
 	else {
 		chop($pwd = `pwd`);
 		}
-	$0 = "$pwd/get-ssl.pl";
+	$0 = "$pwd/get-logs.pl";
 	require './virtual-server-lib.pl';
 	$< == 0 || die "get-ssl.pl must be run as root";
 	}
@@ -60,7 +60,7 @@ while(@ARGV > 0) {
 
 # Validate inputs and get the domain
 $dname || &usage("Missing --domain parameter");
-$d = &get_domain_by("dom", $dname);
+$d = &get_remote_api_domain("dom", $dname);
 $d || &usage("Virtual server $dname does not exist");
 
 # Find the log file

--- a/get-logs.pl
+++ b/get-logs.pl
@@ -25,7 +25,7 @@ if (!$module_name) {
 		}
 	$0 = "$pwd/get-logs.pl";
 	require './virtual-server-lib.pl';
-	$< == 0 || die "get-ssl.pl must be run as root";
+	$< == 0 || die "get-logs.pl must be run as root";
 	}
 
 # Parse command line

--- a/get-ssl.pl
+++ b/get-ssl.pl
@@ -50,7 +50,7 @@ while(@ARGV > 0) {
 
 # Validate inputs and get the domain
 $dname || &usage("Missing --domain parameter");
-$d = &get_domain_by("dom", $dname);
+$d = &get_remote_api_domain("dom", $dname);
 $d || &usage("Virtual server $dname does not exist");
 &domain_has_ssl_cert($d) ||
 	&usage("Virtual server $dname does not have an SSL cert");

--- a/import-database.pl
+++ b/import-database.pl
@@ -60,7 +60,7 @@ while(@ARGV > 0) {
 $domain || &usage("No domain specified");
 $name || &usage("No database name specified");
 $type || &usage("No database type specified");
-$d = &get_domain_by("dom", $domain);
+$d = &get_remote_api_domain("dom", $domain);
 $d || usage("Virtual server $domain does not exist");
 @dbs = &domain_databases($d);
 $d->{$type} || &usage("The specified database type is not enabled in this virtual server");
@@ -74,7 +74,11 @@ $db->{'special'} && &usage("The $type database named $name is special and cannot
 foreach $dd (&list_domains()) {
 	foreach $dddb (&domain_databases($dd)) {
 		if ($dddb->{'name'} eq $name && $dddb->{'type'} eq $type) {
-			&usage("The $type database named $name is already owned by virtual server $dd->{'dom'}");
+			my $owner = &master_admin() ?
+				"virtual server $dd->{'dom'}" :
+				"another virtual server";
+			&usage("The $type database named $name is already owned ".
+			       "by $owner");
 			}
 		}
 	}

--- a/install-cert.pl
+++ b/install-cert.pl
@@ -46,6 +46,7 @@ if (!$module_name) {
 	}
 @OLDARGV = @ARGV;
 &set_all_text_print();
+my $is_master = &master_admin();
 
 # Parse command-line args
 while(@ARGV > 0) {
@@ -59,6 +60,8 @@ while(@ARGV > 0) {
 		$f = shift(@ARGV);
 		if ($f =~ /^\//) {
 			# In some file on the server
+			$is_master ||
+				&usage("Certificate files are only available to the master administrator");
 			$data = &read_file_contents($f);
 			$data || &usage("File $f does not exist");
 			push(@got, [ $g, $data ]);
@@ -90,7 +93,7 @@ while(@ARGV > 0) {
 		}
 	}
 $dname || &usage("Missing --domain parameter");
-$d = &get_domain_by("dom", $dname);
+$d = &get_remote_api_domain("dom", $dname);
 $d || &usage("No virtual server named $dname found");
 $d->{'ssl_same'} && &usage("This server shares it's SSL certificate ".
 			   "with another domain");

--- a/install-script.pl
+++ b/install-script.pl
@@ -169,13 +169,29 @@ while(@ARGV > 0) {
 # Validate args
 $domain || &usage("No domain specified");
 $sname || &usage("No script name specified");
-$d = &get_domain_by("dom", $domain);
+$d = &get_remote_api_domain("dom", $domain);
 $d || usage("Virtual server $domain does not exist");
 @scripts = &list_domain_scripts($d);
 $script = &get_script($sname);
 $script || &usage("Script type $sname is not known");
 ($script->{'migrated'} && !$virtualmin_pro) &&
 	&usage("Script type $sname is not known");
+if (!&master_admin()) {
+	$script->{'avail'} && $script->{'enabled'} ||
+		&usage("Script type $sname is not available to this user");
+	$unsupported && !&can_unsupported_scripts() &&
+		&usage("Unsupported script versions cannot be installed");
+	$logonly &&
+		&usage("--log-only is only available to the master administrator");
+	if ($forcedir) {
+		&is_under_directory(&public_html_dir($d), $forcedir) ||
+			&usage("The forced install directory must be under the website root");
+		}
+	if ($opts->{'newdb'}) {
+		my ($dleft) = &count_feature("dbs");
+		$dleft == 0 && &usage($text{'database_emax'});
+		}
+	}
 @vers = defined($id) ? @{$script->{'versions'}}
 		     : @{$script->{'install_versions'}};
 $ver || &usage("Missing version number. Available versions are : ".
@@ -207,6 +223,8 @@ else {
 		      "Available versions are : ".
 		      join(" ", @{$script->{'versions'}}));
 	}
+!&master_admin() && !&can_script_version($script, $ver) &&
+	&usage("Version $ver is not available to this user");
 if (defined($id)) {
 	# Find script being upgraded
 	if ($id) {
@@ -242,6 +260,12 @@ if (defined($id)) {
 else {
 	$domuser ||= $d->{'user'};
 	$dompass = $dompass || $d->{'pass'} || &random_password(8);
+	}
+
+# Global defaults affect other virtual servers
+if (!&master_admin() && $opts->{'global_def'}) {
+	&usage("Global default scripts can only be installed by the ".
+	       "master administrator");
 	}
 
 # Check domain features
@@ -295,6 +319,11 @@ if ($opts->{'path'}) {
 		$perr = &validate_script_path($opts, $script, $d);
 		&usage($perr) if ($perr);
 		}
+	}
+# Keep domain-owner installs inside their website
+if (!&master_admin() && $opts->{'dir'} &&
+    !&is_under_directory(&public_html_dir($d), $opts->{'dir'})) {
+	&usage("The install directory must be under the website root");
 	}
 if ($opts->{'db'} && $sname !~ /^php\S+admin$/i) {
 	($dbtype, $dbname) = split(/_/, $opts->{'db'}, 2);

--- a/lang/en
+++ b/lang/en
@@ -5007,6 +5007,7 @@ sysinfo_pythonpath=Path to Python
 remote_ecannot=You are not allowed to run remote commands
 remote_ecannotcap=You are not allowed to run this command for virtual server $1
 remote_ecannotdom=Virtual server $1 does not exist
+remote_ecannotcmd=You are not allowed to run this command
 remote_eprogram=Invalid remote program name
 remote_eprogram2=Remote program $1 does not exist
 

--- a/list-admins.pl
+++ b/list-admins.pl
@@ -41,7 +41,7 @@ while(@ARGV > 0) {
 	}
 
 $domain || &usage("No domain specified");
-$d = &get_domain_by("dom", $domain);
+$d = &get_remote_api_domain("dom", $domain);
 $d || usage("Virtual server $domain does not exist");
 @admins = &list_extra_admins($d);
 if ($multiline) {
@@ -53,7 +53,7 @@ if ($multiline) {
 			print "    Email: $admin->{'email'}\n";
 			}
 		print "    Base username: $admin->{'origname'}\n";
-		print "    Password: $admin->{'pass'}\n";
+		print "    Password: $admin->{'pass'}\n" if (&master_admin());
 		print "    Create servers: ",($admin->{'create'} ? "Yes" : "No"),"\n";
 		print "    Rename servers: ",($admin->{'norename'} ? "No" : "Yes"),"\n";
 		print "    Configure features: ",($admin->{'features'} ? "Yes" : "No"),"\n";

--- a/list-admins.pl
+++ b/list-admins.pl
@@ -23,7 +23,7 @@ if (!$module_name) {
 	else {
 		chop($pwd = `pwd`);
 		}
-	$0 = "$pwd/list-databases.pl";
+	$0 = "$pwd/list-admins.pl";
 	require './virtual-server-lib.pl';
 	$< == 0 || die "list-admins.pl must be run as root";
 	}

--- a/list-aliases.pl
+++ b/list-aliases.pl
@@ -74,6 +74,7 @@ if ($all) {
 else {
 	@doms = &get_domains_by_names_users(\@dnames, \@users, \&usage);
 	}
+@doms = &get_remote_api_domains(\@doms, $all || @users);
 
 foreach $d (@doms) {
 	@aliases = &list_domain_aliases($d, !$plugins);

--- a/list-available-scripts.pl
+++ b/list-available-scripts.pl
@@ -56,12 +56,13 @@ while(@ARGV > 0) {
 	}
 
 # Get and filter scripts
+&require_remote_api_command();
 @types = &list_scripts($coreonly) if (!@types);
 @scripts = map { &get_script($_, $coreonly) } @types;
 if ($source) {
 	@scripts = grep { $_->{'source'} eq $source } @scripts;
 	}
-if ($availonly) {
+if ($availonly || !&master_admin()) {
 	@scripts = grep { $_->{'avail'} } @scripts;
 	}
 

--- a/list-available-shells.pl
+++ b/list-available-shells.pl
@@ -55,7 +55,9 @@ while(@ARGV > 0) {
 	}
 
 # Get the shells
+&require_remote_api_command();
 @shells = &list_available_shells();
+@shells = grep { $_->{'avail'} } @shells if (!&master_admin());
 if ($type) {
 	@shells = grep { $_->{$type} } @shells;
 	}

--- a/list-backup-logs.pl
+++ b/list-backup-logs.pl
@@ -133,9 +133,15 @@ if ($multiline) {
 	%schedmap = map { $_->{'id'}, $_ } &list_scheduled_backups();
 	foreach my $l (@logs) {
 		print "$l->{'id'}\n";
-		print "    Domains: $l->{'doms'}\n";
+		print "    Domains: ",
+		      (&master_admin() ? $l->{'doms'}
+				       : join(" ", &backup_log_own_domains($l))),
+		      "\n";
 		if ($l->{'errdoms'}) {
-			print "    Failed domains: $l->{'errdoms'}\n";
+			print "    Failed domains: ",
+			      (&master_admin() ? $l->{'errdoms'}
+				: join(" ", &backup_log_own_domains($l, 1))),
+			      "\n";
 			}
 		print "    Destination: ",
 		      (&master_admin() ? $l->{'dest'}

--- a/list-backup-logs.pl
+++ b/list-backup-logs.pl
@@ -52,6 +52,9 @@ while(@ARGV > 0) {
 		$domain = shift(@ARGV);
 		}
 	elsif ($a eq "--user") {
+		&master_admin() ||
+			&usage("--user is only available to the master ".
+			       "administrator");
 		$user = shift(@ARGV);
 		}
 	elsif ($a eq "--mode") {
@@ -79,8 +82,16 @@ while(@ARGV > 0) {
 $failed && $succeeded &&
 	&usage("The --failed and --succeeded flags are mutually exclusive");
 
+# Check that any requested domain can be seen by the caller
+if ($domain) {
+	my $d = &get_remote_api_owned_domain("dom", $domain);
+	$d || &usage("Virtual server $domain does not exist");
+	}
+
 # Get all the backup logs, then filter down
 @alllogs = &list_backup_logs($start);
+# Only show logs for backups the caller is allowed to see
+@alllogs = grep { &can_backup_log($_) } @alllogs;
 @logs = ( );
 foreach $l (@alllogs) {
 	if ($domain) {
@@ -126,7 +137,9 @@ if ($multiline) {
 		if ($l->{'errdoms'}) {
 			print "    Failed domains: $l->{'errdoms'}\n";
 			}
-		print "    Destination: $l->{'dest'}\n";
+		print "    Destination: ",
+		      (&master_admin() ? $l->{'dest'}
+				       : &nice_backup_url($l->{'dest'}, 1)),"\n";
 		if ($l->{'increment'} >= 3) {
 			print "    Differential: ",
 			      "Yes, from backup $l->{'increment'}\n";
@@ -166,7 +179,8 @@ if ($multiline) {
 				@dests = get_scheduled_backup_dests($sched);
 				for(my $i=0; $i<@dests; $i++) {
 					print "    Scheduled destination: ",
-					      "$dests[$i]\n";
+					      (&master_admin() ? $dests[$i]
+							 : &nice_backup_url($dests[$i], 1)),"\n";
 					}
 				}
 			else {

--- a/list-bandwidth.pl
+++ b/list-bandwidth.pl
@@ -65,7 +65,7 @@ while(@ARGV > 0) {
 # Get the domains
 if (@domains) {
 	foreach $dname (@domains) {
-		$d = &get_domain_by("dom", $dname);
+		$d = &get_remote_api_domain("dom", $dname);
 		$d || &usage("Virtual server $dname does not exist");
 		push(@doms, $d);
 		}
@@ -78,6 +78,7 @@ if ($subs) {
 	@doms = grep { !$_->{'parent'} } @doms;
 	@doms || &usage("None of the selected virtual servers are top-level");
 	}
+@doms = &get_remote_api_domains(\@doms, $all_domains);
 
 # Show the bandwidth report for each
 foreach my $d (@doms) {
@@ -86,6 +87,7 @@ foreach my $d (@doms) {
 	# Get the relevant domains
 	@subdoms = $subs ? ( $d, &get_domain_by("parent", $d->{'id'}) )
 			 : ( $d );
+	@subdoms = &get_remote_api_domains(\@subdoms, 1);
 
 	# Build per-day maps
 	%daymap = ( );

--- a/list-certs-expiry.pl
+++ b/list-certs-expiry.pl
@@ -123,10 +123,10 @@ if (@domains) {
 		my $domain = $d->{'dom'};
 		my $cfile = $d->{'ssl_cert'};
 		if ($cfile && -r $cfile) {
-			my $expiration_date = &backquote_command(
-				"openssl x509 -enddate -noout -in ".quotemeta($cfile));
-			($expiration_date) = $expiration_date =~ /notAfter=(.*)\sGMT/;
+			my $info = &cert_file_info($cfile);
+			my $expiration_date = $info && $info->{'notafter'};
 			next if (!$expiration_date);
+			$expiration_date =~ s/\sGMT$//;
 			my $valid_until    = Time::Piece->strptime($expiration_date, $fpm_in);
 			my $valid_until_st = $valid_until->strftime("%s");
 			my $now_st         = $now->strftime("%s");

--- a/list-certs-expiry.pl
+++ b/list-certs-expiry.pl
@@ -31,9 +31,9 @@ if (!$module_name) {
 	else {
 		chop($pwd = `pwd`);
 		}
-	$0 = "$pwd/list-certs.pl";
+	$0 = "$pwd/list-certs-expiry.pl";
 	require './virtual-server-lib.pl';
-	$< == 0 || die "list-certs.pl must be run as root";
+	$< == 0 || die "list-certs-expiry.pl must be run as root";
 	}
 
 # Parse command-line args
@@ -57,10 +57,20 @@ while (@ARGV > 0) {
 		}
 	}
 
+# Check that the caller is allowed to see certificates at all. The
+# certificate list itself is gathered by list-certs, which applies the
+# caller's own access rights.
+&require_remote_api_command();
+
 # Sanity check
 ($domain || $all_doms) || &usage("Missing --domain flag");
 (!$sort || ($sort && ($sort eq 'name' || $sort eq 'expiry'))) || &usage("Incorrect --sort flag value");
 (!$sort_type || ($sort_type && ($sort_type eq 'asc' || $sort_type eq 'desc'))) || &usage("Incorrect --sort-order flag value");
+my $domain_re;
+if ($domain) {
+	eval { $domain_re = qr/$domain/ };
+	$@ && &usage("Invalid domain regular expression");
+	}
 
 # Check for dependencies
 &foreign_require("software");
@@ -74,6 +84,12 @@ foreach my $mod (keys %mods) {
 		$poss{ $mods{$mod}[0] } = $mod if ($software::update_system eq "apt");
 		$poss{ $mods{$mod}[1] } = $mod if ($software::update_system eq "yum");
 		}
+	}
+
+# Installing packages is a system-wide change, so never do it for an owner
+if (%poss && !&master_admin()) {
+	&usage("Required Perl modules are not installed: ".
+	       join(" ", sort values %poss));
 	}
 
 # Try installing missing dependencies
@@ -93,21 +109,24 @@ foreach my $pkg (keys %poss) {
 
 exit if ($error);
 
-# Get all domains known to Virtualmin
-my $out = `virtualmin list-certs --all-domains --cert`;
-my (@data) = $out =~ /(.*):\n.*\n.*File:\s+(.*?)\n/g;
+# Get only certificates belonging to domains visible to the caller
+my @domains = grep { &domain_has_ssl_cert($_) } &list_domains();
+@domains = &get_remote_api_domains(\@domains, 1);
+@domains = grep { $_->{'dom'} =~ $domain_re } @domains
+	if ($domain_re && !$all_doms);
 my %rows;
-if (@data) {
+if (@domains) {
 	my $fpm_in  = "%b  %d %H:%M:%S %Y";
 	my $fpm_out = "%b %d, %Y";
 	my $now     = Time::Piece->new();
-	my $i = 1;
-	foreach my $d (@data) {
-		if ($i % 2 == 1) {
-			my $domain          = $d;
-			my $cfile           = $data[$i];
-			my $expiration_date = `openssl x509 -enddate -noout -in "$cfile"`;
+	foreach my $d (@domains) {
+		my $domain = $d->{'dom'};
+		my $cfile = $d->{'ssl_cert'};
+		if ($cfile && -r $cfile) {
+			my $expiration_date = &backquote_command(
+				"openssl x509 -enddate -noout -in ".quotemeta($cfile));
 			($expiration_date) = $expiration_date =~ /notAfter=(.*)\sGMT/;
+			next if (!$expiration_date);
 			my $valid_until    = Time::Piece->strptime($expiration_date, $fpm_in);
 			my $valid_until_st = $valid_until->strftime("%s");
 			my $now_st         = $now->strftime("%s");
@@ -144,14 +163,13 @@ if (@data) {
 			$rows{($sort eq 'name' ? $domain : $valid_until_st)} = 
 				[$domain, $cfile, $valid_until->strftime($fpm_out), $diff, $status];
 			}
-		$i++;
 		}
 
 	# Sort results
 	my @rows = $sort_type eq 'desc' ? reverse sort keys %rows : sort keys %rows;
 	if ($multiline) {
 		foreach my $column (@rows) {
-			if ($all_doms || $rows{$column}[0] =~ /$domain/) {
+			if ($all_doms || $rows{$column}[0] =~ $domain_re) {
 				print "$rows{$column}[0]\n";
 				print "  Path to certificate file: $rows{$column}[1]\n";
 				print "  Valid until: $rows{$column}[2]\n";
@@ -164,7 +182,7 @@ if (@data) {
 		my $table   = Text::ASCIITable->new({ headingText => 'SSL CERTIFICATES EXPIRATION DATES' });
 		$table->setCols('DOMAIN NAME', 'PATH TO CERTIFICATE FILE', 'VALID UNTIL', 'EXPIRES IN', 'STATUS');
 		foreach my $column (@rows) {
-			if ($all_doms || $rows{$column}[0] =~ /$domain/) {
+			if ($all_doms || $rows{$column}[0] =~ $domain_re) {
 				$table->addRow($rows{$column}[0],
 					       $rows{$column}[1], 
 					       $rows{$column}[2],

--- a/list-certs.pl
+++ b/list-certs.pl
@@ -73,12 +73,17 @@ if ($all) {
 else {
 	@doms = &get_domains_by_names_users(\@dnames, \@users, \&usage);
 	}
+@doms = &get_remote_api_domains(\@doms, $all || @users);
 @doms || &usage("No virtual servers matching the domain names and usernames ".
 		"given were found");
 @doms = grep { &domain_has_ssl_cert($_) } @doms;
 @doms || &usage("None of the specified virtual servers have an SSL cert");
 if (!@types) {
 	@types = @alltypes;
+	}
+if (!&master_admin()) {
+	@types = grep { $_ ne 'key' && $_ ne 'newkey' } @types;
+	@types || &usage("Private keys cannot be retrieved by domain owners");
 	}
 
 # Output the certs

--- a/list-commands.pl
+++ b/list-commands.pl
@@ -44,10 +44,13 @@ while(@ARGV > 0) {
 	}
 
 # Work out the max command length, for formatting
+&require_remote_api_command();
 my $maxlen = 0;
 foreach my $c (&list_api_categories()) {
 	my ($cname, @cglobs) = @$c;
 	foreach my $cmd (map { glob($_) } @cglobs) {
+		(my $remote_cmd = $cmd) =~ s/^.*\///;
+		next if (!&can_remote($remote_cmd));
 		my $scmd = $cmd;
 		$scmd =~ s/\.pl$// if ($short);
 		$maxlen = length($scmd) if (length($scmd) > $maxlen);
@@ -69,6 +72,8 @@ foreach my $c (&list_api_categories()) {
 	foreach my $cmd (@cmds) {
 		next if (-l $cmd);
 		next if (&indexof($cmd, @skips) >= 0);
+		(my $remote_cmd = $cmd) =~ s/^.*\///;
+		next if (!&can_remote($remote_cmd));
 		my $spellcmd = $cmd;
 		$spellcmd =~ s/licence/license/g;
 		next if ($done{$spellcmd}++);

--- a/list-commands.pl
+++ b/list-commands.pl
@@ -22,7 +22,7 @@ if (!$module_name) {
 	else {
 		chop($pwd = `pwd`);
 		}
-	$0 = "$pwd/list-features.pl";
+	$0 = "$pwd/list-commands.pl";
 	require './virtual-server-lib.pl';
 	$< == 0 || die "list-commands.pl must be run as root";
 	}

--- a/list-custom.pl
+++ b/list-custom.pl
@@ -56,7 +56,7 @@ while(@ARGV > 0) {
 if (@domains) {
 	# Just showing listed domains
 	foreach $domain (@domains) {
-		$d = &get_domain_by("dom", $domain);
+		$d = &get_remote_api_domain("dom", $domain);
 		$d || &usage("Virtual server $domain does not exist");
 		push(@doms, $d);
 		}
@@ -64,11 +64,13 @@ if (@domains) {
 else {
 	# Showing all domains
 	@doms = &list_domains();
+	@doms = &get_remote_api_domains(\@doms, 1);
 	}
 @doms = sort { $a->{'user'} cmp $b->{'user'} ||
 	       $a->{'created'} <=> $b->{'created'} } @doms;
 
 @fields = &list_custom_fields();
+@fields = grep { $_->{'visible'} < 2 } @fields if (!&master_admin());
 if ($field) {
 	@fields = grep { $_->{'name'} eq $field } @fields;
 	}

--- a/list-domains.pl
+++ b/list-domains.pl
@@ -191,6 +191,7 @@ if (@ids) {
 	foreach $id (@ids) {
 		$d = &get_domain($id);
 		$d || &usage("No virtual server with ID $id exists");
+		&require_remote_api_domain($d, $id);
 		push(@doms, $d);
 		}
 	}
@@ -213,14 +214,17 @@ else {
 	# Showing all domains, with some limits
 	@doms = &list_domains();
 	}
+my $all_domains = !(@ids || @domains || @users || @plans || @mailusers);
+@doms = &get_remote_api_domains(\@doms,
+	$all_domains || @users || @plans || @mailusers);
 
 # Get alias/parent domains
 if ($aliasof) {
-	$aliasofdom = &get_domain_by("dom", $aliasof);
+	$aliasofdom = &get_remote_api_domain("dom", $aliasof);
 	$aliasofdom || &usage("No alias target named $aliasof found");
 	}
 if ($parentof) {
-	$parentofdom = &get_domain_by("dom", $parentof);
+	$parentofdom = &get_remote_api_domain("dom", $parentof);
 	$parentofdom || &usage("No parent named $parentof found");
 	}
 
@@ -361,11 +365,13 @@ if ($multiline) {
 		print "    Mailbox username prefix: $d->{'prefix'}\n";
 		print "    Password storage: ",
 		      ($d->{'hashpass'} ? "Hashed" : "Plain text"),"\n";
-		if ($d->{'pass'}) {
-			print "    Password: $d->{'pass'}\n";
-			}
-		elsif ($d->{'enc_pass'}) {
-			print "    Hashed password: $d->{'enc_pass'}\n";
+		if (&master_admin()) {
+			if ($d->{'pass'}) {
+				print "    Password: $d->{'pass'}\n";
+				}
+			elsif ($d->{'enc_pass'}) {
+				print "    Hashed password: $d->{'enc_pass'}\n";
+				}
 			}
 		foreach my $f (grep { $d->{$_} } @database_features) {
 			my $ufunc = "${f}_user";
@@ -374,7 +380,7 @@ if ($multiline) {
 				print "    Username for ${f}: $u\n";
 				}
 			my $pfunc = "${f}_pass";
-			if (defined(&$pfunc)) {
+			if (&master_admin() && defined(&$pfunc)) {
 				my $p = &$pfunc($d);
 				print "    Password for ${f}: $p\n";
 				}

--- a/list-features.pl
+++ b/list-features.pl
@@ -57,20 +57,22 @@ while(@ARGV > 0) {
 	}
 
 # Get the domain objects
+!&master_admin() && !$parentname && !$aliasname && !$subname &&
+	&usage("One of --parent, --subdom or --alias is required for domain owners");
 if ($parentname) {
-	$parentdom = &get_domain_by("dom", $parentname);
+	$parentdom = &get_remote_api_domain("dom", $parentname);
 	$parentdom ||
 	  &usage("Parent virtual server $parentname does not exist");
 	}
 if ($aliasname) {
-	$aliasdom = &get_domain_by("dom", $aliasname);
+	$aliasdom = &get_remote_api_domain("dom", $aliasname);
 	$aliasdom ||
 	  &usage("Alias target virtual server $aliasname does not exist");
 	$parentdom = $aliasdom->{'parent'} ? &get_domain($aliasdom->{'parent'})
 					   : $aliasdom;
 	}
 if ($subname) {
-	$subdom = &get_domain_by("dom", $subname);
+	$subdom = &get_remote_api_domain("dom", $subname);
 	$subdom ||
 	  &usage("Super-domain virtual server $subname does not exist");
 	$parentdom = $subdom->{'parent'} ? &get_domain($subdom->{'parent'})

--- a/list-mailbox.pl
+++ b/list-mailbox.pl
@@ -74,7 +74,7 @@ $first && $last && &usage("Only one of --first and --last can be given");
 # Parse args and get domain
 $dname || &usage("No domain specified");
 $uname || &usage("No username specified");
-$d = &get_domain_by("dom", $dname);
+$d = &get_remote_api_domain("dom", $dname);
 $d || &usage("No domain name $dname found");
 @users = &list_domain_users($d, 0, 1, 1, 1);
 ($user) = grep { $_->{'user'} eq $uname ||

--- a/list-php-directories.pl
+++ b/list-php-directories.pl
@@ -26,7 +26,7 @@ if (!$module_name) {
 	else {
 		chop($pwd = `pwd`);
 		}
-	$0 = "$pwd/list-users.pl";
+	$0 = "$pwd/list-php-directories.pl";
 	require './virtual-server-lib.pl';
 	$< == 0 || die "list-php-directories.pl must be run as root";
 	}

--- a/list-php-directories.pl
+++ b/list-php-directories.pl
@@ -48,7 +48,7 @@ while(@ARGV > 0) {
 	}
 
 $domain || &usage("No domain specified");
-$d = &get_domain_by("dom", $domain);
+$d = &get_remote_api_domain("dom", $domain);
 $d || usage("Virtual server $domain does not exist");
 @dirs = &list_domain_php_directories($d);
 

--- a/list-php-ini.pl
+++ b/list-php-ini.pl
@@ -72,6 +72,7 @@ if (@domains || @users) {
 else {
 	@doms = &list_domains();
 	}
+@doms = &get_remote_api_domains(\@doms, $all_doms || @users);
 
 # Get from domain
 foreach my $d (@doms) {

--- a/list-php-versions.pl
+++ b/list-php-versions.pl
@@ -53,8 +53,10 @@ while(@ARGV > 0) {
 	}
 
 $dname && $forcemode && &usage("Only one of --domain or --mode can be set");
+!&master_admin() && !$dname &&
+	&usage("The --domain parameter is required for domain owners");
 if ($dname) {
-	$d = &get_domain_by("dom", $dname);
+	$d = &get_remote_api_domain("dom", $dname);
 	$d || &usage("Virtual server $dname does not exist");
 	}
 

--- a/list-ports.pl
+++ b/list-ports.pl
@@ -43,7 +43,7 @@ while(@ARGV > 0) {
 	}
 
 $domain || &usage("No domain specified");
-$d = &get_domain_by("dom", $domain);
+$d = &get_remote_api_domain("dom", $domain);
 $d || usage("Virtual server $domain does not exist");
 
 my @useports = &active_domain_server_ports($d);

--- a/list-redirects.pl
+++ b/list-redirects.pl
@@ -32,7 +32,7 @@ if (!$module_name) {
 	else {
 		chop($pwd = `pwd`);
 		}
-	$0 = "$pwd/list-proxies.pl";
+	$0 = "$pwd/list-redirects.pl";
 	require './virtual-server-lib.pl';
 	$< == 0 || die "list-redirects.pl must be run as root";
 	}

--- a/list-scheduled-backups.pl
+++ b/list-scheduled-backups.pl
@@ -41,12 +41,21 @@ while(@ARGV > 0) {
 		$domain = shift(@ARGV);
 		}
 	elsif ($a eq "--reseller") {
+		&master_admin() ||
+			&usage("--reseller is only available to the master ".
+			       "administrator");
 		$reseller = shift(@ARGV);
 		}
 	elsif ($a eq "--user") {
+		&master_admin() ||
+			&usage("--user is only available to the master ".
+			       "administrator");
 		$user = shift(@ARGV);
 		}
 	elsif ($a eq "--dest") {
+		&master_admin() ||
+			&usage("--dest is only available to the master ".
+			       "administrator");
 		$dest = shift(@ARGV);
 		}
 	elsif ($a eq "--id") {
@@ -59,9 +68,11 @@ while(@ARGV > 0) {
 
 # Get them all, then limit by domain
 @scheds = &list_scheduled_backups();
+# Only show schedules the caller is allowed to see
+@scheds = grep { &can_backup_sched($_) } @scheds;
 if ($domain) {
 	# By top-level domain
-	$d = &get_domain_by("dom", $domain);
+	$d = &get_remote_api_owned_domain("dom", $domain);
 	$d || &usage("No domain named $domain exists");
 	$d->{'parent'} && &usage("--domain must be followed by a top-level domain name");
 	@scheds = grep { $_->{'owner'} eq $d->{'id'} } @scheds;
@@ -99,7 +110,9 @@ if ($multiline) {
 		@dests = get_scheduled_backup_dests($s);
 		@purges = &get_scheduled_backup_purges($s);
 		for(my $i=0; $i<@dests; $i++) {
-			print "    Destination: $dests[$i]\n";
+			print "    Destination: ",
+			      (&master_admin() ? $dests[$i]
+					       : &nice_backup_url($dests[$i], 1)),"\n";
 			print "    Delete old backups after: ",
 			    ($purges[$i] ? "$purges[$i] days" : "Never"),"\n";
 			}

--- a/list-scripts.pl
+++ b/list-scripts.pl
@@ -65,6 +65,7 @@ if ($all) {
 else {
 	@doms = &get_domains_by_names_users(\@dnames, \@users, \&usage);
 	}
+@doms = &get_remote_api_domains(\@doms, $all || @users);
 @doms = grep { &can_domain_have_scripts($_) } @doms;
 @doms || &usage("None of the selected virtual servers can have scripts");
 
@@ -114,7 +115,8 @@ foreach my $d (@doms) {
 				}
 			if ($sinfo->{'user'}) {
 				print "    Initial login: $sinfo->{'user'}\n";
-				print "    Initial password: $sinfo->{'pass'}\n";
+				print "    Initial password: $sinfo->{'pass'}\n"
+					if (&master_admin());
 				}
 			if ($script->{'site'}) {
 				print "    Website: @{[&script_link($script->{'site'}, undef, 2)]}\n";

--- a/list-service-certs.pl
+++ b/list-service-certs.pl
@@ -40,7 +40,7 @@ while(@ARGV > 0) {
 
 # Validate inputs and get the domain
 $dname || &usage("Missing --domain parameter");
-$d = &get_domain_by("dom", $dname);
+$d = &get_remote_api_domain("dom", $dname);
 $d || &usage("Virtual server $dname does not exist");
 &domain_has_ssl_cert($d) ||
 	&usage("Virtual server $dname does not have an SSL cert");
@@ -53,7 +53,8 @@ if ($multiline) {
 		print "    Service type: ",
 		      ($svc->{'d'} ? "domain" : "global"),"\n";
 		print "    Cert file: ",$svc->{'cert'},"\n";
-		print "    Key file: ",$svc->{'key'},"\n" if ($svc->{'key'});
+		print "    Key file: ",$svc->{'key'},"\n"
+			if ($svc->{'key'} && &master_admin());
 		print "    CA file: ",$svc->{'ca'},"\n" if ($svc->{'ca'});
 		print "    IP address: ",$svc->{'ip'},"\n" if ($svc->{'ip'});
 		print "    IPv6 address: ",$svc->{'ip6'},"\n" if ($svc->{'ip6'});

--- a/list-service-certs.pl
+++ b/list-service-certs.pl
@@ -21,9 +21,9 @@ if (!$module_name) {
 	else {
 		chop($pwd = `pwd`);
 		}
-	$0 = "$pwd/list-certs.pl";
+	$0 = "$pwd/list-service-certs.pl";
 	require './virtual-server-lib.pl';
-	$< == 0 || die "list-certs.pl must be run as root";
+	$< == 0 || die "list-service-certs.pl must be run as root";
 	}
 
 # Parse command line to get domains

--- a/list-simple-aliases.pl
+++ b/list-simple-aliases.pl
@@ -56,6 +56,7 @@ if ($all) {
 else {
 	@doms = &get_domains_by_names_users(\@dnames, \@users, \&usage);
 	}
+@doms = &get_remote_api_domains(\@doms, $all || @users);
 
 foreach $d (@doms) {
 	@aliases = &list_domain_aliases($d, !$plugins);

--- a/list-users.pl
+++ b/list-users.pl
@@ -91,6 +91,7 @@ if ($all) {
 else {
 	@doms = &get_domains_by_names_users(\@dnames, \@users, \&usage);
 	}
+@doms = &get_remote_api_domains(\@doms, $all || @users);
 @ashells = grep { $_->{'mailbox'} } &list_available_shells();
 
 foreach $d (@doms) {
@@ -141,15 +142,17 @@ foreach $d (@doms) {
 			if (defined($u->{'surname'})) {
 				print "    Surname: ",$u->{'surname'},"\n";
 				}
-			if (defined($u->{'plainpass'})) {
-				print "    Password: ",$u->{'plainpass'},"\n";
-				}
 			$pass = $u->{'pass'};
 			$disable = ($pass =~ s/^\!// ? 1 : 0);
-			print "    Encrypted password: ",$pass,"\n";
-			my $existing_key = &get_domain_user_ssh_pubkey($d, $u);
-			if ($existing_key) {
-				print "    SSH public key: $existing_key\n";
+			if (&master_admin()) {
+				if (defined($u->{'plainpass'})) {
+					print "    Password: ",$u->{'plainpass'},"\n";
+					}
+				print "    Encrypted password: ",$pass,"\n";
+				my $existing_key = &get_domain_user_ssh_pubkey($d, $u);
+				if ($existing_key) {
+					print "    SSH public key: $existing_key\n";
+					}
 				}
 			print "    Disabled: ",($disable ? "Yes" : "No"),"\n";
 			print "    No password accepted: ",

--- a/modify-admin.pl
+++ b/modify-admin.pl
@@ -58,6 +58,7 @@ if (!$module_name) {
 	}
 &licence_status();
 @OLDARGV = @ARGV;
+my $is_master = &master_admin();
 
 # Parse command-line args
 $append = $config{'appendadmin'};
@@ -76,6 +77,8 @@ while(@ARGV > 0) {
 		$pass = shift(@ARGV);
 		}
 	elsif ($a eq "--passfile") {
+		$is_master ||
+			&usage("--passfile is only available to the master administrator");
 		$pass = &read_file_contents(shift(@ARGV));
 		$pass =~ s/\r|\n//g;
 		}
@@ -146,8 +149,22 @@ while(@ARGV > 0) {
 	}
 
 $domain && $name || &usage("No domain or username specified");
-$d = &get_domain_by("dom", $domain);
+$d = &get_remote_api_domain("dom", $domain);
 $d || usage("Virtual server $domain does not exist");
+if (!$is_master) {
+	defined($email) && $email ne "" && $email !~ /^\S+\@\S+$/ &&
+		&usage("Invalid extra administrator email address");
+	defined($newname) && $newname !~ /^[a-z0-9\_\.\-]+$/i &&
+		&usage("Invalid extra administrator name");
+	defined($create) && $create && !$d->{'domslimit'} &&
+		&usage("This virtual server cannot create sub-servers");
+	defined($norename) && !$norename && $d->{'norename'} &&
+		&usage("This virtual server cannot rename servers");
+	foreach my $edit (@canedits) {
+		$d->{'edit_'.$edit} ||
+			&usage("Capability $edit is not available to this virtual server");
+		}
+	}
 
 # Find the admin
 &obtain_lock_webmin();
@@ -210,7 +227,7 @@ if ($allowedall) {
 	@allowed = ( );
 	}
 foreach $aname (@allowednames) {
-	$a = &get_domain_by("dom", $aname);
+	$a = &get_remote_api_owned_domain("dom", $aname);
         $a || &usage("The allowed virtual server $aname does not exist");
 	$a->{'user'} eq $d->{'user'} ||
                 &usage("The allowed virtual server $a->{'dom'} is not owned ".
@@ -218,7 +235,7 @@ foreach $aname (@allowednames) {
 	push(@allowed, $a->{'id'});
 	}
 foreach $aname (@deniednames) {
-	$a = &get_domain_by("dom", $aname);
+	$a = &get_remote_api_owned_domain("dom", $aname);
         $a || &usage("The allowed virtual server $aname does not exist");
 	@allowed = grep { $_ ne $a->{'id'} } @allowed;
 	@allowed || &usage("You cannot remove all allowed virtual servers");

--- a/modify-custom.pl
+++ b/modify-custom.pl
@@ -71,8 +71,10 @@ while(@ARGV > 0) {
 $domain && @set || &usage("No domain or fields to set specified");
 
 # Get the domain
-$dom = &get_domain_by("dom", $domain);
+$dom = &get_remote_api_domain("dom", $domain);
 $dom || usage("Virtual server $domain does not exist.");
+!&master_admin() && $allow_missing &&
+	&usage("--allow-missing is only available to the master administrator");
 $old = { %$dom };
 
 # Run the before script
@@ -88,6 +90,8 @@ foreach $f (@set) {
 			  $_->{'desc'} eq $f->[0] } @fields;
 	$field || $allow_missing ||
 		&usage("No custom field named $f->[0] exists");
+	!$field || &master_admin() || $field->{'visible'} == 0 ||
+		&usage("Custom field $f->[0] cannot be edited by domain owners");
 	$dom->{'field_'.($field->{'name'} || $f->[0])} = $f->[1];
 	}
 &save_domain($dom);

--- a/modify-database-hosts.pl
+++ b/modify-database-hosts.pl
@@ -96,6 +96,7 @@ if ($all_doms) {
 else {
 	foreach $n (@dnames) {
 		$d = &get_remote_api_domain("dom", $n);
+		$d || &usage("Virtual server $n does not exist");
 		$d->{$type} ||
 		  &usage("Virtual server $n does not have a $type database");
 		$d->{'parent'} &&

--- a/modify-database-hosts.pl
+++ b/modify-database-hosts.pl
@@ -80,6 +80,14 @@ $type || &usage("Missing --type parameter");
 if (@sethosts) {
 	(@addhosts || @delhosts) && &usage("--set-host cannot be combined with --add-host and --remove-host");
 	}
+if (!&master_admin()) {
+	foreach my $h (@addhosts, @delhosts, @sethosts) {
+		$h =~ /^[a-z0-9\.\-\_\%\\:]+$/i ||
+		  $h =~ /^([0-9\.]+)\/([0-9\.]+)$/ &&
+		  &check_ipaddress($1) && &check_ipaddress($2) ||
+			&usage("Invalid remote database host $h");
+		}
+	}
 
 # Get domains to update
 if ($all_doms) {
@@ -87,8 +95,7 @@ if ($all_doms) {
 	}
 else {
 	foreach $n (@dnames) {
-		$d = &get_domain_by("dom", $n);
-		$d || &usage("Domain $n does not exist");
+		$d = &get_remote_api_domain("dom", $n);
 		$d->{$type} ||
 		  &usage("Virtual server $n does not have a $type database");
 		$d->{'parent'} &&
@@ -96,6 +103,7 @@ else {
 		push(@doms, $d);
 		}
 	}
+@doms = &get_remote_api_domains(\@doms, $all_doms);
 @doms || &usage("No domains to set remote $type hosts on specified");
 
 # Do all the domains

--- a/modify-database-pass.pl
+++ b/modify-database-pass.pl
@@ -65,7 +65,7 @@ $type || &usage("Missing --type parameter");
 	       join(" ", @database_features));
 $pass || &usage("Missing --pass parameter");
 $dname || &usage("Missing --domain parameter");
-$d = &get_domain_by("dom", $dname);
+$d = &get_remote_api_domain("dom", $dname);
 $d || &usage("No domain named $dname exists");
 $d->{'parent'} && &usage("The database password can only be changed for a top ".
 			 "level virtual server");

--- a/modify-database-user.pl
+++ b/modify-database-user.pl
@@ -65,7 +65,7 @@ $type || &usage("Missing --type parameter");
 	       join(" ", @database_features));
 defined($user) || &usage("Missing --user parameter");
 $dname || &usage("Missing --domain parameter");
-$d = &get_domain_by("dom", $dname);
+$d = &get_remote_api_domain("dom", $dname);
 $d || &usage("No domain named $dname exists");
 $d->{'parent'} && &usage("The database username can only be changed for a top ".
 			 "level virtual server");

--- a/modify-dns.pl
+++ b/modify-dns.pl
@@ -366,13 +366,43 @@ elsif ($all_doms == 2) {
 	}
 else {
 	foreach $n (@dnames) {
-		$d = &get_domain_by("dom", $n);
+		$d = &get_remote_api_domain("dom", $n);
 		$d || &usage("Domain $n does not exist");
 		$d->{'dns'} || &usage("Virtual server $n does not have a DNS domain");
 		push(@doms, $d);
 		}
 	}
+@doms = &get_remote_api_domains(\@doms, $all_doms);
 @doms || &usage("No domains to update found!");
+
+# Enforce the capability for each kind of requested DNS change
+my $records_change = @addrecs || @delrecs || @uprecs || $ttl || $allttl ||
+	$bumpsoa;
+my $ip_change = defined($dns_ip) || defined($dns_ip6);
+my $master_change = @addslaves || @delslaves || $addallslaves ||
+	$syncallslaves || defined($submode);
+my $options_change = defined($spf) || %add || %rem ||
+	defined($spfall) || @addslaves || @delslaves || $addallslaves ||
+	$syncallslaves || defined($dmarc) || $dmarcp || defined($dmarcpct) ||
+	defined($dmarcrua) || defined($dmarcruf) || defined($dnssec) ||
+	defined($tlsa) || defined($submode) || $clouddns ||
+	defined($remotedns) || defined($parentds) || $clouddns_import ||
+	defined($dkim_enabled) || defined($aliasdns);
+foreach my $d (@doms) {
+	&require_remote_api_capability($d, &can_edit_records($d))
+		if ($records_change);
+	&require_remote_api_capability($d, &can_dnsip()) if ($ip_change);
+	&require_remote_api_capability($d, &can_edit_dns($d))
+		if ($options_change);
+	&require_remote_api_capability($d, 0) if ($master_change);
+	if (defined($parentds) && !&master_admin()) {
+		my $pname = $d->{'dom'};
+		$pname =~ s/^[^\.]+\.//;
+		my $parent = &get_domain_by("dom", $pname);
+		&require_remote_api_capability($d,
+			$parent && &can_edit_domain($parent));
+		}
+	}
 
 # Are all domains alias domains?
 @nonalias = grep { !&copy_alias_records($_) } @doms;
@@ -425,10 +455,14 @@ if ($clouddns) {
 			&usage("Cloudmin Services for DNS is not enabled");
 		}
 	elsif ($clouddns ne "local") {
-		my @cnames = map { $_->{'name'} } &list_dns_clouds();
+		my @clouds = &list_dns_clouds();
+		my @cnames = map { $_->{'name'} } @clouds;
 		&indexof($clouddns, @cnames) >= 0 ||
 			&usage("Valid cloud DNS providers are : ".
 			       join(" ", @cnames));
+		my ($cloud) = grep { $_->{'name'} eq $clouddns } @clouds;
+		&master_admin() || &can_dns_cloud($cloud) ||
+			&usage("You are not allowed to use DNS provider $clouddns");
 		}
 	}
 
@@ -614,6 +648,8 @@ foreach $d (@doms) {
 			push(@alld, @d);
 			}
 		foreach my $r (@alld) {
+			!&master_admin() && !&can_delete_record($r, $d) &&
+				&usage("This DNS record cannot be removed by a domain owner");
 			&delete_dns_record($recs, $file, $r);
 			$changed++;
 			}
@@ -655,6 +691,9 @@ foreach $d (@doms) {
 				  'ttl' => $ttl,
 				  'values' => $values,
 				  'proxied' => $proxied };
+			&validate_remote_api_dns_record($d, $r);
+			!&master_admin() && !&can_edit_record($r, $d) &&
+				&usage("This DNS record cannot be created by a domain owner");
 			my ($clash) = grep { $_->{'name'} eq $name &&
 					     &bind8::join_record_values($_) eq
 						&bind8::join_record_values($r) } @$recs;
@@ -684,6 +723,8 @@ foreach $d (@doms) {
 			}
 		foreach my $rn (@uprecs) {
 			my ($oldname, $oldtype, $name, $type, $ttl, $values, $proxied) = @$rn;
+			$values = [ join(" ", @$values) ]
+				if (!&master_admin() && uc($type) eq "TXT");
 			$oldname = &expand_dns_record($oldname, $d);
 			$name = &expand_dns_record($name, $d);
 			my ($r) = grep { $_->{'name'} eq $oldname &&
@@ -692,6 +733,14 @@ foreach $d (@doms) {
 				&$second_print(&text('spf_euprecs', $oldname));
 				}
 			else {
+				my $newr = { %$r, 'name' => $name,
+					     'type' => uc($type),
+					     'values' => $values };
+				&validate_remote_api_dns_record($d, $newr);
+				!&master_admin() &&
+				  (!&can_edit_record($r, $d) ||
+				   !&can_edit_record($newr, $d)) &&
+					&usage("This DNS record cannot be changed by a domain owner");
 				$r->{'name'} = $name;
 				$r->{'type'} = $type;
 				$r->{'ttl'} = $ttl if (defined($ttl));
@@ -961,6 +1010,37 @@ foreach $d (@doms) {
 
 &run_post_actions();
 &virtualmin_api_log(\@OLDARGV);
+
+# validate_remote_api_dns_record(&domain, &record)
+# Applies the DNS record restrictions used by the domain-owner interface.
+sub validate_remote_api_dns_record
+{
+my ($d, $r) = @_;
+return if (&master_admin());
+my ($type) = grep { $_->{'type'} eq uc($r->{'type'}) && $_->{'create'} }
+	&list_dns_record_types($d);
+$type || &usage("Invalid DNS record type $r->{'type'}");
+$r->{'name'} eq $d->{'dom'}."." ||
+	$r->{'name'} =~ /^(?:\*\.)?(?:[a-z0-9_-]+\.)*\Q$d->{'dom'}\E\.$/i ||
+	&usage("DNS record names must be within $d->{'dom'}");
+defined($r->{'ttl'}) && $r->{'ttl'} !~ /^\d+(s|m|h|d)?$/ &&
+	&usage("Invalid DNS record TTL $r->{'ttl'}");
+my @defs = @{$type->{'values'} || [ ]};
+@defs == @{$r->{'values'}} ||
+	&usage("Invalid number of values for DNS record type $r->{'type'}");
+for(my $i = 0; $i < @defs; $i++) {
+	my $value = $r->{'values'}->[$i];
+	my $opts = $defs[$i]->{'opts'};
+	!$opts || (grep { $_->[0] eq $value } @$opts) ||
+		&usage("Invalid value for DNS record type $r->{'type'}");
+	my $regexp = $defs[$i]->{'regexp'};
+	!$regexp || $value =~ /$regexp/ ||
+		&usage("Invalid value for DNS record type $r->{'type'}");
+	my $func = $defs[$i]->{'func'};
+	my $err = $func && &$func($value);
+	&usage($err) if ($err);
+	}
+}
 
 sub usage
 {

--- a/modify-domain.pl
+++ b/modify-domain.pl
@@ -98,6 +98,10 @@ if (!$module_name) {
 @OLDARGV = @ARGV;
 &set_all_text_print();
 
+# Remote API callers that are not the master admin can only change the
+# settings that the user interface offers them
+my $is_master = &master_admin();
+
 # Parse command-line args
 $name = 1;
 $virt = 0;
@@ -111,9 +115,14 @@ while(@ARGV > 0) {
 		$owner =~ /:/ && &usage($text{'setup_eowner'});
 		}
 	elsif ($a eq "--pass") {
+		$is_master || &can_passwd() ||
+			&usage("You are not allowed to change the password");
 		$pass = shift(@ARGV);
 		}
 	elsif ($a eq "--passfile") {
+		$is_master ||
+			&usage("--passfile is only available to the master ".
+			       "administrator");
 		$pass = &read_file_contents(shift(@ARGV));
 		$pass =~ s/\r|\n//g;
 		}
@@ -121,33 +130,51 @@ while(@ARGV > 0) {
 		$email = shift(@ARGV);
 		}
 	elsif ($a eq "--protected") {
+		$is_master ||
+			&usage("--protected is only available to the master ".
+			       "administrator");
 		$protected = 1;
 		}
 	elsif ($a eq "--unprotected") {
+		$is_master ||
+			&usage("--unprotected is only available to the master ".
+			       "administrator");
 		$protected = 0;
 		}
 	elsif ($a eq "--quota") {
+		$is_master || &can_edit_quotas() ||
+			&usage("You are not allowed to change quotas");
 		$quota = shift(@ARGV);
 		$quota = 0 if ($quota eq 'UNLIMITED');
 		$quota =~ /^\d+$/ || &usage("Quota must be a number of blocks");
 		}
 	elsif ($a eq "--uquota") {
+		$is_master || &can_edit_quotas() ||
+			&usage("You are not allowed to change quotas");
 		$uquota = shift(@ARGV);
 		$uquota = 0 if ($uquota eq 'UNLIMITED');
 		$uquota =~ /^\d+$/ || &usage("Quota must be a number of blocks");
 		}
 	elsif ($a eq "--user") {
+		$is_master ||
+			&usage("--user is only available to the master ".
+			       "administrator");
 		$user = shift(@ARGV);
 		$user =~ /^[^\t :]+$/ || &usage($text{'setup_euser2'});
 		defined(getpwnam($user)) &&
 			&usage("A user named $user already exists");
 		}
 	elsif ($a eq "--home") {
+		$is_master ||
+			&usage("--home is only available to the master ".
+			       "administrator");
 		$home = shift(@ARGV);
 		$home =~ /^\/\S+$/ || &usage("Home directory must be an absolute path");
 		-d $home && &usage("New home directory already exists");
 		}
 	elsif ($a eq "--newdomain") {
+		$is_master || &can_rename_domains() ||
+			&usage("You are not allowed to rename virtual servers");
 		$newdomain = shift(@ARGV);
 		$newdomain =~ /^[A-Za-z0-9\.\-]+$/ || &usage("Invalid new domain name");
 		$newdomain = lc($newdomain);
@@ -158,77 +185,114 @@ while(@ARGV > 0) {
 			}
 		}
 	elsif ($a eq "--bw") {
+		$is_master || &can_edit_bandwidth() ||
+			&usage("You are not allowed to change bandwidth limits");
 		# Setting or removing the bandwidth limit
 		$bw = shift(@ARGV);
 		$bw eq "NONE" || $bw =~ /^\d+$/ || &usage("Bandwidth limit must be a number of bytes, or NONE");
 		}
 	elsif ($a eq "--bw-disable") {
+		$is_master || &can_edit_bandwidth() ||
+			&usage("You are not allowed to change bandwidth limits");
 		# Set over-bw limit disable to yes
 		$bw_no_disable = 0;
 		}
 	elsif ($a eq "--bw-no-disable") {
+		$is_master || &can_edit_bandwidth() ||
+			&usage("You are not allowed to change bandwidth limits");
 		# Set over-bw limit disable to no
 		$bw_no_disable = 1;
 		}
 	elsif ($a eq "--no-ip") {
+		$is_master || &can_select_ip() ||
+			&usage($text{'setup_eip'});
 		# Turning off IP address
 		$noip = 1;
 		}
 	elsif ($a eq "--ip") {
+		$is_master || &can_select_ip() ||
+			&usage($text{'setup_eip'});
 		# Changing or adding a virtual IP
 		$ip = shift(@ARGV);
 		&check_ipaddress($ip) || &usage("Invalid IP address");
 		}
 	elsif ($a eq "--shared-ip") {
+		$is_master || &can_select_ip() ||
+			&usage($text{'setup_eip'});
 		# Changing the shared IP
 		$sharedip = shift(@ARGV);
 		&check_ipaddress($sharedip) ||
 			&usage("Invalid shared IP address");
 		}
 	elsif ($a eq "--allocate-ip") {
+		$is_master || &can_select_ip() ||
+			&usage($text{'setup_eip'});
 		# Allocating an IP
 		$ip = "allocate";
 		}
 	elsif ($a eq "--default-ip") {
+		$is_master || &can_select_ip() ||
+			&usage($text{'setup_eip'});
 		# Fall back to the default shared IP
 		$defaultip = 1;
 		}
 	elsif ($a eq "--ip6" && &supports_ip6()) {
+		$is_master || &can_select_ip6() ||
+			&usage($text{'setup_eip6'});
 		# Adding or changing an IPv6 address
 		$ip6 = shift(@ARGV);
 		&check_ip6address($ip6) || &usage("Invalid IPv6 address");
 		}
 	elsif ($a eq "--no-ip6" && &supports_ip6()) {
+		$is_master || &can_select_ip6() ||
+			&usage($text{'setup_eip6'});
 		# Removing an IPv6 address
 		$noip6 = 1;
 		}
 	elsif ($a eq "--allocate-ip6" && &supports_ip6()) {
+		$is_master || &can_select_ip6() ||
+			&usage($text{'setup_eip6'});
 		# Allocating an IPv6 address
 		$ip6 = "allocate";
 		}
 	elsif ($a eq "--default-ip6" && &supports_ip6()) {
+		$is_master || &can_select_ip6() ||
+			&usage($text{'setup_eip6'});
 		# IPv6 on default shared address
 		$defaultip6 = 1;
 		}
 	elsif ($a eq "--shared-ip6") {
+		$is_master || &can_select_ip6() ||
+			&usage($text{'setup_eip6'});
 		# Changing the shared IPv6 address
 		$sharedip6 = shift(@ARGV);
 		&check_ip6address($sharedip6) ||
 			&usage("Invalid shared IPv6 address");
 		}
 	elsif ($a eq "--reseller") {
+		$is_master ||
+			&usage("--reseller is only available to the master ".
+			       "administrator");
 		# Changing the reseller
 		$resel = shift(@ARGV);
 		}
 	elsif ($a eq "--add-reseller") {
+		$is_master ||
+			&usage("--add-reseller is only available to the master ".
+			       "administrator");
 		# Adding a reseller
 		push(@add_resel, shift(@ARGV));
 		}
 	elsif ($a eq "--delete-reseller") {
+		$is_master ||
+			&usage("--delete-reseller is only available to the master ".
+			       "administrator");
 		# Removing a reseller
 		push(@del_resel, shift(@ARGV));
 		}
 	elsif ($a eq "--prefix") {
+		$is_master || &can_rename_domains() ||
+			&usage("You are not allowed to rename virtual servers");
 		# Changing the prefix
 		$prefix = shift(@ARGV);
 		}
@@ -244,6 +308,9 @@ while(@ARGV > 0) {
 		$template eq "" && &usage("Unknown template name");
 		}
 	elsif ($a eq "--plan" || $a eq "--apply-plan") {
+		$is_master ||
+			&usage("--plan is only available to the master ".
+			       "administrator");
 		# Changing the plan
 		$planname = shift(@ARGV);
 		foreach $p (&list_plans()) {
@@ -256,6 +323,9 @@ while(@ARGV > 0) {
 		$planapply = 1 if ($a eq "--apply-plan");
 		}
 	elsif ($a eq "--plan-features") {
+		$is_master ||
+			&usage("--plan-features is only available to the master ".
+			       "administrator");
 		$planfeatures = 1;
 		}
 	elsif ($a eq "--add-exclude") {
@@ -271,17 +341,27 @@ while(@ARGV > 0) {
 		push(@remove_db_excludes, shift(@ARGV));
 		}
 	elsif ($a eq "--pre-command") {
+		$is_master ||
+			&usage("--pre-command is only available to the master ".
+			       "administrator");
 		$precommand = shift(@ARGV);
 		}
 	elsif ($a eq "--post-command") {
+		$is_master ||
+			&usage("--post-command is only available to the master ".
+			       "administrator");
 		$postcommand = shift(@ARGV);
 		}
 	elsif ($a eq "--dns-ip") {
+		$is_master || &can_dnsip() ||
+			&usage("You are not allowed to change the DNS IP address");
 		$dns_ip = shift(@ARGV);
 		&check_ipaddress($dns_ip) ||
 			&usage("--dns-ip must be followed by an IP address");
 		}
 	elsif ($a eq "--no-dns-ip") {
+		$is_master || &can_dnsip() ||
+			&usage("You are not allowed to change the DNS IP address");
 		$dns_ip = "";
 		}
 	elsif ($a eq "--skip-warnings") {
@@ -291,15 +371,27 @@ while(@ARGV > 0) {
 		$multiline = 1;
 		}
 	elsif ($a eq "--enable-jail") {
+		$is_master ||
+			&usage("--enable-jail is only available to the master ".
+			       "administrator");
 		$jail = 1;
 		}
 	elsif ($a eq "--disable-jail") {
+		$is_master ||
+			&usage("--disable-jail is only available to the master ".
+			       "administrator");
 		$jail = 0;
 		}
 	elsif ($a eq "--copy-jail") {
+		$is_master ||
+			&usage("--copy-jail is only available to the master ".
+			       "administrator");
 		$copyjail = 1;
 		}
 	elsif ($a eq "--mysql-server") {
+		$is_master ||
+			&usage("--mysql-server is only available to the master ".
+			       "administrator");
 		$myserver = shift(@ARGV);
 		}
 	elsif ($a eq "--link-domain") {
@@ -309,18 +401,28 @@ while(@ARGV > 0) {
 		$linkdname = "";
 		}
 	elsif ($a eq "--alias-redirect") {
+		$is_master || &can_edit_redirect() ||
+			&usage("You are not allowed to change redirects");
 		$aliasredir = 1;
 		}
 	elsif ($a eq "--no-alias-redirect") {
+		$is_master || &can_edit_redirect() ||
+			&usage("You are not allowed to change redirects");
 		$aliasredir = 0;
 		}
 	elsif ($a eq "--apply-quotas") {
 		$applyquotas = 1;
 		}
 	elsif ($a eq "--apply-all-quotas") {
+		$is_master ||
+			&usage("--apply-all-quotas is only available to the master ".
+			       "administrator");
 		$applyquotas = 2;
 		}
 	elsif ($a eq "--disable-2fa") {
+		$is_master ||
+			&usage("--disable-2fa is only available to the master ".
+			       "administrator");
 		$no2fa = 1;
 		}
 	elsif ($a eq "--help") {
@@ -333,10 +435,28 @@ while(@ARGV > 0) {
 
 # Find the domain
 $domain || usage("No domain specified");
-$dom = &get_domain_by("dom", $domain);
+$dom = &get_remote_api_domain("dom", $domain);
 $dom || usage("Virtual server $domain does not exist.");
 $old = { %$dom };
 $tmpl = &get_template(defined($template) ? $template : $dom->{'template'});
+if (!$is_master && defined($pass)) {
+	my $fakeuser = { 'user' => $dom->{'user'}, 'plainpass' => $pass };
+	my $err = &check_password_restrictions($fakeuser, $dom->{'webmin'});
+	&usage($err) if ($err);
+	}
+if (!$is_master && defined($newdomain)) {
+	my $err = &valid_domain_name($newdomain);
+	&usage($err) if ($err);
+	my $parent = $dom->{'parent'} ? &get_domain($dom->{'parent'}) : undef;
+	$err = &allowed_domain_name($parent, $newdomain);
+	&usage($err) if ($err);
+	}
+if (!$is_master && defined($template)) {
+	# Only templates that are available to this user can be selected
+	&can_use_template($tmpl) &&
+	  (&reseller_admin() || $tmpl->{'for_users'}) ||
+		&usage($text{'setup_etmpl'});
+	}
 
 # Make sure options are valid for domain
 if ($dom->{'parent'}) {
@@ -482,7 +602,7 @@ if ($myserver) {
 
 # Validate link domain
 if ($linkdname) {
-	$linkd = &get_domain_by("dom", $linkdname);
+	$linkd = &get_remote_api_owned_domain("dom", $linkdname);
 	$linkd || &usage("Link domain $linkdname does not exist");
 	$linkd->{'alias'} eq $dom->{'id'} || 
 	    &usage("Link domain $linkdname is not an alias of this domain");
@@ -683,6 +803,12 @@ if (defined($dns_ip)) {
 		# Resetting DNS IP address to default
 		delete($dom->{'dns_ip'});
 		}
+	}
+
+# Apply the same plan and account limits as the domain settings page
+if (!$is_master) {
+	my $err = &virtual_server_limits($dom, $old);
+	&usage($err) if ($err);
 	}
 
 # Change the plan and limits, if given

--- a/modify-domain.pl
+++ b/modify-domain.pl
@@ -457,6 +457,21 @@ if (!$is_master && defined($template)) {
 	  (&reseller_admin() || $tmpl->{'for_users'}) ||
 		&usage($text{'setup_etmpl'});
 	}
+if (!$is_master && (@add_excludes || @remove_excludes ||
+			    @add_db_excludes || @remove_db_excludes)) {
+	# Backup exclusions require the same permission and validation as the UI
+	&can_edit_exclude() ||
+		&usage("You are not allowed to edit backup exclusions");
+	foreach my $e (@add_excludes, @remove_excludes) {
+		$e =~ s/^\///;
+		$e !~ /^\// || &usage(&text('exclude_eabs', $e));
+		$e !~ /\.\./ || &usage(&text('exclude_edot', $e));
+		}
+	foreach my $e (@add_db_excludes, @remove_db_excludes) {
+		$e =~ /^[a-z0-9\.\_\-\*]+$/i ||
+			&usage(&text('exclude_edb', $e));
+		}
+	}
 
 # Make sure options are valid for domain
 if ($dom->{'parent'}) {

--- a/modify-mail.pl
+++ b/modify-mail.pl
@@ -93,6 +93,7 @@ $config{'mail'} || &usage("Email is not enabled for Virtualmin");
 &set_all_text_print();
 
 # Parse command-line args
+$is_master = &master_admin();
 while(@ARGV > 0) {
 	my $a = shift(@ARGV);
 	if ($a eq "--domain") {
@@ -137,6 +138,7 @@ while(@ARGV > 0) {
 		$autoconfig = 0;
 		}
 	elsif ($a eq "--dkim-key") {
+		$is_master || &usage("The --dkim-key option is only available to the master administrator");
 		$keyfile = shift(@ARGV);
 		$key = &read_file_contents($keyfile);
 		$key || &usage("DKIM key file $keyfile does not exist");
@@ -185,6 +187,14 @@ while(@ARGV > 0) {
 defined($bcc) || defined($rbcc) || defined($aliascopy) || defined($dependent) ||
     defined($autoconfig) || defined($key) || defined($cloud) ||
     defined($cloudsmtp) || defined($mta_sts) || &usage("Nothing to do");
+if (!$is_master) {
+	defined($bcc) && $bcc ne "" && $bcc !~ /^\S+\@\S+$/ &&
+		&usage("The sender BCC must be an email address");
+	defined($rbcc) && $rbcc ne "" && $rbcc !~ /^\S+\@\S+$/ &&
+		&usage("The recipient BCC must be an email address");
+	defined($autoconfig) &&
+		&usage("Mail auto-configuration can only be changed by the master administrator");
+	}
 
 # Get domains to update
 if ($all_doms == 1) {
@@ -194,8 +204,17 @@ else {
 	# Get domains by name and user
 	@doms = &get_domains_by_names_users(\@dnames, \@users, \&usage);
 	}
+@doms = &get_remote_api_domains(\@doms, $all_doms || @users);
 @doms = grep { $_->{'mail'} } @doms;
 @doms || &usage("None of the selected domains have email enabled");
+if (!$is_master) {
+	foreach my $d (@doms) {
+		defined($dependent) && !$d->{'ip'} &&
+			&usage("Outgoing IP addresses are not available for $d->{'dom'}");
+		defined($mta_sts) && !&can_mta_sts($d) &&
+			&usage("MTA-STS is not available for $d->{'dom'}");
+		}
+	}
 
 # Check supported features
 if (defined($bcc) && !$supports_bcc) {
@@ -209,14 +228,17 @@ if (defined($dependent) && !$supports_dependent) {
 	}
 
 # Check cloud mail filter
+my %cloud_provs;
 if ($cloud) {
-	@provs = &list_cloud_mail_providers();
-	($prov) = grep { $_->{'name'} eq $cloud } @provs;
-	$prov || &usage("Valid cloud mail filter providers are : ".
-			join(" ", map { $_->{'name'} } @provs));
-	if ($prov->{'id'} && !$cloudid) {
-		&usage("The cloud mail filter ".$cloud." requires a customer ".
-		       "ID to be set with the --cloud-mail-filter-id flag");
+	foreach my $d (@doms) {
+		my @provs = &list_cloud_mail_providers($d, $cloudid);
+		my ($prov) = grep { $_->{'name'} eq $cloud } @provs;
+		$prov || &usage("Cloud mail filter $cloud is not available for ".
+				$d->{'dom'});
+		$prov->{'id'} && !$cloudid &&
+			&usage("The cloud mail filter $cloud requires a customer ".
+			       "ID to be set with the --cloud-mail-filter-id flag");
+		$cloud_provs{$d->{'id'}} = $prov;
 		}
 	}
 
@@ -339,16 +361,11 @@ foreach $d (@doms) {
 	if (defined($cloud)) {
 		my $err;
 		my $oldprov = &get_domain_cloud_mail_provider($d);
+		my $prov = $cloud_provs{$d->{'id'}};
 		if ($prov) {
 			if (!$oldprov ||
 			    $prov->{'name'} ne $oldprov->{'name'} ||
 			    $cloudid ne $d->{'cloud_mail_id'}) {
-				# Re-fetch provider object for THIS domain, and
-				# apply it
-				my @provs = &list_cloud_mail_providers(
-						$d, $cloudid);
-				($prov) = grep { $_->{'name'} eq $cloud }
-					       @provs;
 				&$first_print("Configuring MX records for ".
 					      "filter $prov->{'name'} ..");
 				$err = &save_domain_cloud_mail_provider(

--- a/modify-php-ini.pl
+++ b/modify-php-ini.pl
@@ -93,6 +93,20 @@ while(@ARGV > 0) {
 @ini_names || &usage("The --ini-name parameter must be given at least once");
 @ini_names == @ini_values ||
 	&usage("The number of names and values must be the same");
+!&master_admin() && $type &&
+	&usage("--fpm-admin-value is only available to the master administrator");
+if (!&master_admin()) {
+	foreach my $name (@ini_names) {
+		$name =~ /^[a-z0-9_\.\-]+$/i ||
+			&usage("Invalid PHP configuration setting $name");
+		}
+	foreach my $value (grep { defined($_) } @ini_values) {
+		$value !~ /[\r\n]/ ||
+			&usage("PHP configuration values cannot contain newlines");
+		}
+	# Never preserve or create an administrator-only FPM value
+	$type = 0;
+	}
 
 # Get the domains
 if (@domains || @users) {
@@ -101,6 +115,7 @@ if (@domains || @users) {
 else {
 	@doms = &list_domains();
 	}
+@doms = &get_remote_api_domains(\@doms, $all_doms || @users);
 
 # Do each domain
 foreach my $d (@doms) {

--- a/modify-proxy.pl
+++ b/modify-proxy.pl
@@ -68,10 +68,16 @@ while(@ARGV > 0) {
 		}
 	}
 $domain && $path || &usage("No domain or URL path specified");
-$d = &get_domain_by("dom", $domain);
+$d = &get_remote_api_domain("dom", $domain);
 $d || usage("Virtual server $domain does not exist");
 &has_proxy_balancer($d) || &usage("Proxy balancers cannot be configured for this virtual server");
 !$newpath || $newpath =~ /^\/\S*$/ || &error("Path must be like / or /foo");
+if (!&master_admin()) {
+	foreach my $url (@urls) {
+		$url =~ /^(http|https):\/\/\S+$/ ||
+			&usage("Proxy URLs must start with http:// or https://");
+		}
+	}
 
 # Get the balancer
 &obtain_lock_web($d);
@@ -93,6 +99,12 @@ elsif (@urls) {
 	}
 if (defined($websockets)) {
 	$b->{'websockets'} = $websockets;
+	}
+if (!&master_admin() && $b->{'websockets'} &&
+    ($b->{'none'} || $b->{'balancer'} || !$b->{'urls'} ||
+     @{$b->{'urls'}} != 1 ||
+     $b->{'urls'}->[0] !~ /^(http|https):\/\//)) {
+	&usage("WebSockets proxying requires one HTTP or HTTPS URL");
 	}
 
 # Update it

--- a/modify-scheduled-backup.pl
+++ b/modify-scheduled-backup.pl
@@ -57,6 +57,12 @@ $schedid || &usage("Missing backup ID flag");
 @scheds = &list_scheduled_backups();
 ($sched) = grep { $_->{'id'} eq $schedid } @scheds;
 $sched || &usage("No scheduled backup with ID $schedid found");
+if (!&master_admin()) {
+	# Only schedules owned by this user can be changed, and schedule 1
+	# also holds the global backup settings
+	&can_backup_sched($sched) && $sched->{'id'} ne '1' ||
+		&usage("No scheduled backup with ID $schedid found");
+	}
 
 # Make any changes
 if (defined($enabled)) {

--- a/modify-spam.pl
+++ b/modify-spam.pl
@@ -191,6 +191,8 @@ while(@ARGV > 0) {
 defined($mode{'spam'}) || defined($mode{'virus'}) || $spam_client ||
     $virus_scanner || defined($auto) || defined($spamlevel) ||
     defined($spamtrap) || &usage("Nothing to do");
+!&master_admin() && ($spam_client || $virus_scanner) &&
+	&usage("Spam and virus scanning clients can only be changed by the master administrator");
 
 # Get domains to update
 if ($all_doms) {
@@ -198,12 +200,13 @@ if ($all_doms) {
 	}
 else {
 	foreach $n (@dnames) {
-		$d = &get_domain_by("dom", $n);
+		$d = &get_remote_api_domain("dom", $n);
 		$d || &usage("Domain $n does not exist");
 		$d->{'spam'} || &usage("Virtual server $n does not have spam filtering enabled");
 		push(@doms, $d);
 		}
 	}
+@doms = &get_remote_api_domains(\@doms, $all_doms);
 
 # Do it for all domains
 foreach $d (@doms) {

--- a/modify-user.pl
+++ b/modify-user.pl
@@ -440,7 +440,7 @@ foreach $e (@addemails) {
 	# Additional addresses must belong to an accessible mail domain
 	if (!$is_master) {
 		my ($eu, $ed) = ($1, &parse_domain_name($2));
-		my $edom = &get_remote_api_domain("dom", $ed);
+		my $edom = &get_remote_api_owned_domain("dom", $ed);
 		$edom->{'mail'} || &usage(&text('user_eextra2', $ed));
 		!$edom->{'alias'} || !$edom->{'aliascopy'} ||
 			&usage(&text('user_eextra7', $ed));

--- a/modify-web.pl
+++ b/modify-web.pl
@@ -364,6 +364,7 @@ while(@ARGV > 0) {
 		}
 	elsif ($a eq "--php-log") {
 		$phplog = shift(@ARGV);
+		$custom_phplog = 1;
 		$phplog =~ /^\S+$/ || &usage("--php-log must be followed by ".
 					     "a filename");
 		}
@@ -441,12 +442,53 @@ if ($all_doms) {
 	}
 else {
 	foreach $n (@dnames) {
-		$d = &get_domain_by("dom", $n);
+		$d = &get_remote_api_domain("dom", $n);
 		$d || &usage("Domain $n does not exist");
 		&domain_has_website($d) ||
 		  &usage("Virtual server $n does not have a web site enabled");
 		push(@doms, $d);
 		}
+	}
+@doms = &get_remote_api_domains(\@doms, $all_doms);
+
+# Enforce the capability for each kind of requested website change
+my $phpmode_change = $mode || $rubymode || defined($children) ||
+	defined($phplog) || defined($webmail) || defined($matchall) ||
+	defined($timeout) || $htmldir || defined($includes) || $fixhtmldir ||
+	$fpmport || $fpmsock || $fpmtype || $defmode || defined($cgimode) ||
+	$subprefix || $protocols || $fix_mod_php || defined($phpmail) ||
+	defined($proxyhost) || $fixoptions;
+my $ssl_change = defined($renew) || $breakcert || $linkcert;
+my $master_change = $accesslog || $errorlog || $port || $sslport ||
+	$urlport || $sslurlport || @add_dirs || @remove_dirs || $ssl_cert ||
+	$ssl_key || $ssl_ca || $custom_phplog || $fixhtmldir || $fixoptions ||
+	$fix_mod_php;
+foreach my $d (@doms) {
+	&require_remote_api_capability($d, &can_edit_phpmode($d))
+		if ($phpmode_change);
+	&require_remote_api_capability($d, &can_edit_phpver($d)) if ($version);
+	&require_remote_api_capability($d, &can_edit_html($d))
+		if (defined($content));
+	&require_remote_api_capability($d, &can_edit_redirect($d))
+		if (defined($wwwredir) || defined($aliasredir));
+	&require_remote_api_capability($d, &can_edit_ssl($d))
+		if ($ssl_change);
+	&require_remote_api_capability($d, &can_edit_letsencrypt($d))
+		if (defined($renew));
+	&require_remote_api_capability($d,
+		&can_edit_ssl($d) && &can_edit_dns($d)) if ($tlsa);
+	&require_remote_api_capability($d, &can_default_website($d))
+		if ($defwebsite);
+	&require_remote_api_capability($d, 0) if ($master_change);
+	&require_remote_api_capability($d, 0) if ($children_no_check);
+	}
+if (!&master_admin() && $htmldir && $htmldir =~ /^domains(?:\/|$)/i) {
+	&usage("Document directory cannot be under the domains directory");
+	}
+if (!&master_admin() && $subprefix &&
+    ($subprefix !~ /^[a-z0-9\.\_\/-]+$/i ||
+     $subprefix =~ /^\// || $subprefix =~ /\/$/ || $subprefix =~ /\.\./)) {
+	&usage("Invalid sub-domain document directory");
 	}
 
 # Check if webmail is supported
@@ -482,7 +524,7 @@ foreach $d (@doms) {
 		&usage("The selected Ruby execution mode cannot be used with $d->{'dom'}");
 	}
 
-if ($defaultwebsite && @doms > 1) {
+if ($defwebsite && @doms > 1) {
 	&usage("The --default-website flag can only be applied to a single virtual server");
 	}
 

--- a/rename-domain.pl
+++ b/rename-domain.pl
@@ -93,6 +93,12 @@ $d = &get_remote_api_domain("dom", $domain);
 $d || usage("Virtual server $domain does not exist.");
 $newdomain || $newuser || $newhome || $newprefix ||
 	&usage("No changes specified");
+if ($newdomain) {
+	# Validate the new name, as the rename function does not
+	$newdomain = lc(&parse_domain_name($newdomain));
+	my $err = &valid_domain_name($newdomain);
+	&usage($err) if ($err);
+	}
 
 # Do the rename
 $err = &rename_virtual_server($d, $newdomain, $newuser, $newhome, $newprefix);

--- a/rename-domain.pl
+++ b/rename-domain.pl
@@ -30,9 +30,9 @@ if (!$module_name) {
 	else {
 		chop($pwd = `pwd`);
 		}
-	$0 = "$pwd/modify-domain.pl";
+	$0 = "$pwd/rename-domain.pl";
 	require './virtual-server-lib.pl';
-	$< == 0 || die "modify-domain.pl must be run as root";
+	$< == 0 || die "rename-domain.pl must be run as root";
 	}
 @OLDARGV = @ARGV;
 &set_all_text_print();
@@ -47,15 +47,30 @@ while(@ARGV > 0) {
 		$newdomain = lc(shift(@ARGV));
 		}
 	elsif ($a eq "--new-user") {
+		# Selecting a Unix login is only offered to those who can
+		# rename and choose a username
+		&can_rename_domains() == 2 ||
+			&usage("--new-user is only available to the master ".
+			       "administrator");
 		$newuser = lc(shift(@ARGV));
 		}
 	elsif ($a eq "--auto-user") {
+		&can_rename_domains() == 2 ||
+			&usage("--auto-user is only available to the master ".
+			       "administrator");
 		$newuser = "auto";
 		}
 	elsif ($a eq "--new-home") {
+		# An arbitrary home directory can only be set by the master
+		&can_rehome_domains() == 2 ||
+			&usage("--new-home is only available to the master ".
+			       "administrator");
 		$newhome = lc(shift(@ARGV));
 		}
 	elsif ($a eq "--auto-home") {
+		&can_rehome_domains() ||
+			&usage("You are not allowed to change the home ".
+			       "directory");
 		$newhome = "auto";
 		}
 	elsif ($a eq "--new-prefix") {
@@ -74,7 +89,7 @@ while(@ARGV > 0) {
 
 # Find the domain and validate inputss
 $domain || usage("No domain specified");
-$d = &get_domain_by("dom", $domain);
+$d = &get_remote_api_domain("dom", $domain);
 $d || usage("Virtual server $domain does not exist.");
 $newdomain || $newuser || $newhome || $newprefix ||
 	&usage("No changes specified");

--- a/resend-email.pl
+++ b/resend-email.pl
@@ -46,7 +46,7 @@ while(@ARGV > 0) {
 
 # Find the domain
 $domain || usage("No domain specified");
-$dom = &get_domain_by("dom", $domain);
+$dom = &get_remote_api_domain("dom", $domain);
 $dom || usage("Virtual server $domain does not exist");
 
 if (&will_send_domain_email($dom)) {

--- a/reset-feature.pl
+++ b/reset-feature.pl
@@ -74,6 +74,15 @@ while(@ARGV > 0) {
 # Get domains to update
 @dnames || @users || usage("No domains or users specified");
 @doms = &get_domains_by_names_users(\@dnames, \@users, \&usage);
+@doms = &get_remote_api_domains(\@doms);
+
+# Only features the caller has been granted can be reset
+if (!&master_admin()) {
+	foreach my $f (keys %feature, keys %plugin) {
+		&can_use_feature($f) ||
+			&usage("You are not allowed to reset the $f feature");
+		}
+	}
 
 # Do it for all domains, aliases first
 $failed = 0;

--- a/reset-pass.pl
+++ b/reset-pass.pl
@@ -42,6 +42,7 @@ if (!$module_name) {
 	require './virtual-server-lib.pl';
 	$< == 0 || die "reset-pass.pl must be run as root";
 	}
+my $is_master = &master_admin();
 
 # Parse command-line args
 while(@ARGV > 0) {
@@ -77,12 +78,18 @@ if ($all) {
 else {
 	@doms = &get_domains_by_names_users(\@dnames, \@users, \&usage);
 	}
+@doms = &get_remote_api_domains(\@doms, $all);
+# Domain owner passwords are managed as part of the virtual server
+$exclude_owner = 1 if (!$is_master);
 
 # Change the password
 foreach my $d (@doms) {
 	my @users = &list_domain_users($d, 0, 0, 0, 0);
     my @users_users = grep { !$_->{'domainowner'} } @users;
     my @users_owners = grep { $_->{'domainowner'} } @users;
+	# Feature-managed users must be changed by their owning plugin
+	@users_users = grep { !$_->{'feature_user'} && !$_->{'noactions'} }
+		@users_users if (!$is_master);
 	if (%usernames) {
 		@users_users = grep { $usernames{$_->{'user'}} ||
 				$usernames{&remove_userdom($_->{'user'}, $d)} }
@@ -133,6 +140,11 @@ foreach my $d (@doms) {
         my ($u) = grep { $_->{'user'} eq $user } @users;
         my $oldu = $u;
         my $passwd = $pass || &random_password();
+		if (!$is_master) {
+			my $checku = { %$u, 'plainpass' => $passwd };
+			my $err = &check_password_restrictions($checku, 0, $d);
+			&usage($err) if ($err);
+			}
         #
         &push_all_print();
         &set_all_null_print();

--- a/restore-domain.pl
+++ b/restore-domain.pl
@@ -154,27 +154,48 @@ while(@ARGV > 0) {
 		@rfeats = grep { $_ ne $f } @rfeats;
 		}
 	elsif ($a eq "--all-domains") {
+		&master_admin() ||
+			&usage("--all-domains is only available to the master ".
+			       "administrator");
 		$all_doms = 1;
 		}
 	elsif ($a eq "--test") {
 		$test = 1;
 		}
 	elsif ($a eq "--reuid") {
+		&master_admin() ||
+			&usage("--reuid is only available to the master ".
+			       "administrator");
 		$reuid = 1;
 		}
 	elsif ($a eq "--no-reuid") {
+		&master_admin() ||
+			&usage("--no-reuid is only available to the master ".
+			       "administrator");
 		$reuid = 0;
 		}
 	elsif ($a eq "--reuser") {
+		&master_admin() ||
+			&usage("--reuser is only available to the master ".
+			       "administrator");
 		$reuser = 1;
 		}
 	elsif ($a eq "--no-reuser") {
+		&master_admin() ||
+			&usage("--no-reuser is only available to the master ".
+			       "administrator");
 		$reuser = 0;
 		}
 	elsif ($a eq "--fix") {
+		&master_admin() ||
+			&usage("--fix is only available to the master ".
+			       "administrator");
 		$fix = 1;
 		}
 	elsif ($a eq "--option") {
+		&master_admin() ||
+			&usage("--option is only available to the master ".
+			       "administrator");
 		$optf = shift(@ARGV);
 		if ($optf =~ /^(\S+)\s+(\S+)\s+(\S+)$/) {
 			$optf = $1;
@@ -197,34 +218,58 @@ while(@ARGV > 0) {
 		$asowner = 1;
 		}
 	elsif ($a eq "--virtualmin") {
+		&master_admin() ||
+			&usage("--virtualmin is only available to the master ".
+			       "administrator");
 		$v = shift(@ARGV);
 		&indexof($v, @virtualmin_backups) >= 0 ||
 			&usage("Unknown --virtualmin option $v. Available options are : ".join(" ", @virtualmin_backups));
 		push(@vbs, $v);
 		}
 	elsif ($a eq "--all-virtualmin") {
+		&master_admin() ||
+			&usage("--all-virtualmin is only available to the master ".
+			       "administrator");
 		@vbs = @virtualmin_backups;
 		}
 	elsif ($a eq "--only-features") {
+		&master_admin() ||
+			&usage("--only-features is only available to the master ".
+			       "administrator");
 		$onlyfeats = 1;
 		}
 	elsif ($a eq "--only-missing") {
+		&master_admin() ||
+			&usage("--only-missing is only available to the master ".
+			       "administrator");
 		$onlymissing = 1;
 		}
 	elsif ($a eq "--only-existing") {
+		&master_admin() ||
+			&usage("--only-existing is only available to the master ".
+			       "administrator");
 		$onlyexisting = 1;
 		}
 	elsif ($a eq "--delete-existing") {
+		&master_admin() ||
+			&usage("--delete-existing is only available to the master ".
+			       "administrator");
 		$delete_existing = 1;
 		}
 
 	# Alternate IPv4 options
 	elsif ($a eq "--default-ip") {
+		&master_admin() ||
+			&usage("--default-ip is only available to the master ".
+			       "administrator");
 		$ipinfo = { %$ipinfo,
 			    'virt' => 0, 'ip' => &get_default_ip(),
 			    'virtalready' => 0, 'mode' => 0 };
 		}
 	elsif ($a eq "--shared-ip") {
+		&master_admin() ||
+			&usage("--shared-ip is only available to the master ".
+			       "administrator");
 		$sharedip = shift(@ARGV);
 		&indexof($sharedip, &list_shared_ips()) >= 0 ||
 		    &usage("$sharedip is not in the shared IP addresses list");
@@ -233,6 +278,9 @@ while(@ARGV > 0) {
 			    'virtalready' => 0, 'mode' => 3 };
 		}
 	elsif ($a eq "--ip") {
+		&master_admin() ||
+			&usage("--ip is only available to the master ".
+			       "administrator");
 		$ip = shift(@ARGV);
 		&check_ipaddress($ip) || &usage("Invalid IP address");
 		&check_virt_clash($ip) &&
@@ -242,6 +290,9 @@ while(@ARGV > 0) {
 			    'virtalready' => 0, 'mode' => 1 };
 		}
 	elsif ($a eq "--allocate-ip") {
+		&master_admin() ||
+			&usage("--allocate-ip is only available to the master ".
+			       "administrator");
 		$tmpl = &get_template(0);
 		($ip, $netmask) = &free_ip_address($tmpl);
 		$ipinfo = { %$ipinfo,
@@ -250,6 +301,9 @@ while(@ARGV > 0) {
 			    'mode' => 2 };
 		}
 	elsif ($a eq "--original-ip") {
+		&master_admin() ||
+			&usage("--original-ip is only available to the master ".
+			       "administrator");
 		$tmpl = &get_template(0);
 		($ip, $netmask) = &free_ip_address($tmpl);
 		$ipinfo = { %$ipinfo,
@@ -258,17 +312,26 @@ while(@ARGV > 0) {
 			    'mode' => 5 };
 		}
 	elsif ($a eq "--no-ip") {
+		&master_admin() ||
+			&usage("--no-ip is only available to the master ".
+			       "administrator");
 		$ipinfo = { %$ipinfo,
 			    'mode' => -2 };
 		}
 
 	# Alternate IPv6 options
 	elsif ($a eq "--default-ip6") {
+		&master_admin() ||
+			&usage("--default-ip6 is only available to the master ".
+			       "administrator");
 		$ipinfo = { %$ipinfo,
 			    'virt6' => 0, 'ip6' => &get_default_ip6(),
 			    'virt6already' => 0, 'mode6' => 0 };
 		}
 	elsif ($a eq "--shared-ip6") {
+		&master_admin() ||
+			&usage("--shared-ip6 is only available to the master ".
+			       "administrator");
 		$sharedip6 = shift(@ARGV);
 		&indexof($sharedip6, &list_shared_ip6s()) >= 0 ||
 		  &usage("$sharedip is not in the shared IPv6 addresses list");
@@ -277,6 +340,9 @@ while(@ARGV > 0) {
 			    'virt6already' => 0, 'mode6' => 3 };
 		}
 	elsif ($a eq "--ip6") {
+		&master_admin() ||
+			&usage("--ip6 is only available to the master ".
+			       "administrator");
 		$ip6 = shift(@ARGV);
 		&check_ip6address($ip6) || &usage("Invalid IPv6 address");
 		&check_virt6_clash($ip6) &&
@@ -286,6 +352,9 @@ while(@ARGV > 0) {
 			    'virt6already' => 0, 'mode6' => 1 };
 		}
 	elsif ($a eq "--allocate-ip6") {
+		&master_admin() ||
+			&usage("--allocate-ip6 is only available to the master ".
+			       "administrator");
 		$tmpl = &get_template(0);
 		($ip6, $netmask6) = &free_ip6_address($tmpl);
 		$ipinfo = { %$ipinfo,
@@ -294,6 +363,9 @@ while(@ARGV > 0) {
 			    'mode6' => 2 };
 		}
 	elsif ($a eq "--original-ip6") {
+		&master_admin() ||
+			&usage("--original-ip6 is only available to the master ".
+			       "administrator");
 		$tmpl = &get_template(0);
 		($ip6, $netmask6) = &free_ip6_address($tmpl);
 		$ipinfo = { %$ipinfo,
@@ -302,20 +374,32 @@ while(@ARGV > 0) {
 			    'mode6' => 5 };
 		}
 	elsif ($a eq "--no-ip6") {
+		&master_admin() ||
+			&usage("--no-ip6 is only available to the master ".
+			       "administrator");
 		$ipinfo = { %$ipinfo,
 			    'mode6' => -2 };
 		}
 
 	elsif ($a eq "--skip-warnings") {
+		&master_admin() ||
+			&usage("--skip-warnings is only available to the master ".
+			       "administrator");
 		$skipwarnings = 1;
 		}
 	elsif ($a eq "--continue-on-error") {
+		&master_admin() ||
+			&usage("--continue-on-error is only available to the master ".
+			       "administrator");
 		$continue = 1;
 		}
 	elsif ($a eq "--key") {
 		$keyid = shift(@ARGV);
 		}
 	elsif ($a eq "--replication") {
+		&master_admin() ||
+			&usage("--replication is only available to the master ".
+			       "administrator");
 		$replication = 1;
 		}
 	elsif ($a eq "--multiline") {
@@ -330,6 +414,28 @@ while(@ARGV > 0) {
 	}
 $src || usage("Missing --source parameter");
 @rdoms || $all_doms || @vbs || usage("No domains to restore specified");
+
+# Work out what kind of restore the caller is allowed to do. Mode 1 is a full
+# restore, mode 2 is the limited restore offered to resellers and domain
+# owners, which can only touch data-only features of existing domains.
+my $crmode = &can_restore_domain();
+$crmode || &usage("You are not allowed to restore virtual servers");
+my $safe_backup = $crmode == 1 ? 1 : 0;
+if (!$safe_backup) {
+	# The source must be one of the caller's own backups
+	my $od = &get_domain_by_user($base_remote_user);
+	my ($newsrc, $serr) = &confine_backup_dest($src, $crmode, $od);
+	$serr && &usage($serr);
+	$src = $newsrc;
+	# Only features that cannot change a server's configuration may be
+	# restored, exactly as restore.cgi limits them
+	foreach my $f (@rfeats) {
+		&indexof($f, @safe_backup_features) >= 0 ||
+		  &plugin_call($f, "feature_backup_safe") ||
+			&usage("The $f feature cannot be restored by ".
+			       "anyone other than the master administrator");
+		}
+	}
 if (@rdoms || $all_doms) {
 	@rfeats || $fix || usage("No features to restore specified");
 	}
@@ -347,9 +453,12 @@ if ($keyid) {
 		  	$_->{'key'} eq $keyid ||
 		  	$_->{'desc'} eq $keyid } &list_backup_keys();
 	$key || &usage("No backup key with ID or description $keyid exists");
+	$safe_backup || !defined(&can_backup_key) || &can_backup_key($key) ||
+		&usage("No backup key with ID or description $keyid exists");
 	}
 
 # Find the owner of a domain
+$asowner = 1 if (!$safe_backup);
 if ($asowner && @rdoms) {
 	$asd = &get_domain_by("dom", $rdoms[0]);
 	}
@@ -369,14 +478,25 @@ foreach $dname (@rdoms) {
 		$dinfo = undef;
 		}
 	if ($dname eq "virtualmin") {
+		$safe_backup ||
+			&usage("Virtualmin configuration can only be ".
+			       "restored by the master administrator");
 		$got_vbs = 1;
 		}
 	elsif ($dinfo) {
 		# Domain exists on this system already
+		if (!$safe_backup) {
+			&can_edit_domain($dinfo) ||
+				&usage(&text('remote_ecannotdom', $dname));
+			}
 		push(@doms, $dinfo);
 		}
 	else {
 		# Doesn't exist, will need to be re-created
+		$safe_backup ||
+			&usage("Virtual server $dname does not exist, and ".
+			       "only the master administrator can re-create ".
+			       "servers from a backup");
 		push(@doms, { 'dom' => $dname,
 			      'missing' => 1 });
 		}

--- a/set-php-directory.pl
+++ b/set-php-directory.pl
@@ -60,7 +60,7 @@ while(@ARGV > 0) {
 $domain || &usage("No domain specified");
 $dir || &usage("No directory specified");
 $version || &usage("No PHP version specified");
-$d = &get_domain_by("dom", $domain);
+$d = &get_remote_api_domain("dom", $domain);
 $d || usage("Virtual server $domain does not exist");
 $mode = &get_domain_php_mode($d);
 $mode eq "mod_php" &&
@@ -76,6 +76,8 @@ if ($dir eq ".") {
 elsif ($dir !~ /^\//) {
 	$dir = &public_html_dir($d)."/".$dir;
 	}
+!&master_admin() && !&is_under_directory(&public_html_dir($d), $dir) &&
+	&usage("The PHP directory must be under the website root");
 
 # Make the change
 &obtain_lock_web($d);

--- a/start-stop-script.pl
+++ b/start-stop-script.pl
@@ -69,7 +69,7 @@ while(@ARGV > 0) {
 
 # Validate args
 $domain || &usage("No domain specified");
-$d = &get_domain_by("dom", $domain);
+$d = &get_remote_api_domain("dom", $domain);
 $d || usage("Virtual server $domain does not exist");
 $mode || &usage("Missing one of --start, --stop or --restart");
 
@@ -91,6 +91,12 @@ else {
 	@matches || &usage("No script install for $sname was found for this virtual server");
 	@matches == 1 || &usage("More than one script install for $sname was found for this virtual server. Use the --id option to specify the exact install, or --version to select a version");
 	$sinfo = $matches[0];
+	}
+
+# Global defaults affect other virtual servers
+if (!&master_admin() && $sinfo->{'opts'}->{'global_def'}) {
+	&usage("Global default scripts can only be managed by the ".
+	       "master administrator");
 	}
 
 # Do the action

--- a/start-stop-script.pl
+++ b/start-stop-script.pl
@@ -28,7 +28,7 @@ if (!$module_name) {
 	else {
 		chop($pwd = `pwd`);
 		}
-	$0 = "$pwd/delete-script.pl";
+	$0 = "$pwd/start-stop-script.pl";
 	require './virtual-server-lib.pl';
 	$< == 0 || die "start-stop-script.pl must be run as root";
 	}

--- a/syncmx-domain.pl
+++ b/syncmx-domain.pl
@@ -66,6 +66,8 @@ else {
 	# By domain or user
 	@doms = &get_domains_by_names_users(\@domains, \@users, \&usage);
 	}
+@doms = &get_remote_api_domains(\@doms, $all_doms || @users);
+@doms || &usage("No virtual servers selected");
 
 # Make sure MXs exist
 @servers = &list_mx_servers();

--- a/t/remote-api-access.t
+++ b/t/remote-api-access.t
@@ -50,7 +50,7 @@ my %expected_commands = (
 	'generate-letsencrypt-cert' => 'can_remote_edit_acme',
 	'get-command' => 'can_use_remote_api',
 	'get-dns' => 'can_edit_records',
-	'get-logs' => 'can_edit_domain',
+	'get-logs' => 'can_remote_read_logs',
 	'get-ssl' => 'can_edit_ssl',
 	'import-database' => 'can_remote_import_databases',
 	'install-cert' => 'can_edit_ssl',
@@ -60,7 +60,7 @@ my %expected_commands = (
 	'list-available-scripts' => 'can_edit_scripts',
 	'list-available-shells' => 'can_edit_users',
 	'list-backup-keys' => 'can_backup_keys',
-	'list-bandwidth' => 'can_edit_domain',
+	'list-bandwidth' => 'can_remote_read_bandwidth',
 	'list-certs' => 'can_edit_ssl',
 	'list-certs-expiry' => 'can_edit_ssl',
 	'list-commands' => 'can_use_remote_api',
@@ -230,6 +230,39 @@ my %expected_commands = (
 {
 	no warnings qw(once redefine);
 	local %main::access = ( 'edit_remote_api' => 1 );
+	local %main::config = ( 'bw_active' => 0 );
+	my ($logs, $bandwidth) = (0, 0);
+	local *main::master_admin = sub { 0 };
+	local *main::reseller_admin = sub { 0 };
+	local *main::can_edit_domain = sub { 1 };
+	local *main::foreign_available = sub {
+		return $_[0] eq 'logviewer' && $logs;
+		};
+	local *main::can_monitor_bandwidth = sub { $bandwidth };
+	my $domain = { 'dom' => 'example.test' };
+	ok(!&remote_api_can_domain($domain, 'get-logs'),
+		'web logs require access to the log viewer module');
+	$logs = 1;
+	ok(&remote_api_can_domain($domain, 'get-logs'),
+		'web logs pass when the log viewer is available');
+	ok(!&remote_api_can_domain($domain, 'list-bandwidth'),
+		'bandwidth data is denied when monitoring is disabled');
+	$main::config{'bw_active'} = 1;
+	ok(!&remote_api_can_domain($domain, 'list-bandwidth'),
+		'bandwidth data is denied for an unmonitored domain');
+	$bandwidth = 1;
+	# Isolate the bw_active gate: monitoring available but accounting off
+	$main::config{'bw_active'} = 0;
+	ok(!&remote_api_can_domain($domain, 'list-bandwidth'),
+		'bandwidth data is denied when accounting is turned off');
+	$main::config{'bw_active'} = 1;
+	ok(&remote_api_can_domain($domain, 'list-bandwidth'),
+		'bandwidth data passes for a monitored domain');
+	}
+
+{
+	no warnings qw(once redefine);
+	local %main::access = ( 'edit_remote_api' => 1 );
 	local %main::text = (
 		'remote_ecannotcmd' => 'You are not allowed to run this command',
 		);
@@ -341,6 +374,10 @@ foreach my $command (sort keys %expected_commands) {
 			unlike($source, qr/`virtualmin\s+list-certs/,
 				"$command does not bypass ACLs through the root CLI");
 			}
+		elsif ($command eq 'list-backup-keys') {
+			like($source, qr/can_use_backup_key\s*\(/,
+				"$command includes keys shared for creating backups");
+			}
 		}
 	elsif ($object_commands{$command}) {
 		# Their capability takes an object, so they must not resolve a
@@ -377,6 +414,29 @@ foreach my $command (sort keys %expected_commands) {
 		like($source,
 			qr/elsif \(\$a eq "--post-command"\) \{\s*\$is_master \|\|/s,
 			"$command keeps post-creation commands master-only");
+		like($source,
+			qr/if \(!\$skipwarnings \|\| !\$is_master\) \{\s*\$err = &valid_domain_name/s,
+			"$command always validates owner-supplied domain names");
+		like($source,
+			qr/if \(!\$skipwarnings \|\| !\$is_master\) \{\s*foreach my \$ff \(&forbidden_domain_features/s,
+			"$command does not let owners skip forbidden features");
+		like($source, qr/defined\(\$jail\).*master administrator/s,
+			"$command keeps jail selection master-only");
+		like($source, qr/\(\$myserver \|\| \$pgserver\).*master administrator/s,
+			"$command keeps database server selection master-only");
+		like($source, qr/defined\(\$dns_ip\).*can_dnsip/s,
+			"$command requires DNS IP permission");
+		like($source, qr/\$fwdto.*can_edit_catchall/s,
+			"$command requires catch-all permission");
+		like($source, qr/defined\(\$content\).*can_edit_html/s,
+			"$command requires website content permission");
+		like($source, qr/\$proxy_pass_mode.*can_edit_forward/s,
+			"$command requires proxy permission");
+		like($source,
+			qr/\$proxy_pass !~ \/\^\(http\|https\).*Proxy URLs must start/s,
+			"$command validates owner-supplied proxy URLs");
+		like($source, qr/defined\(\$aliasredir\).*can_edit_redirect/s,
+			"$command requires redirect permission");
 		}
 	else {
 		like($source, qr/get_remote_api_domain(?:s)?\s*\(/,
@@ -386,6 +446,16 @@ foreach my $command (sort keys %expected_commands) {
 				"$command enforces the domain password policy");
 			like($source, qr/virtual_server_limits\s*\(/,
 				"$command enforces domain plan limits");
+			}
+		elsif ($command eq 'enable-feature') {
+			like($source,
+				qr/!\$skipwarnings \|\| !\$is_master.*\@forbidden_domain_features/s,
+				"$command does not let owners skip forbidden features");
+			}
+		elsif ($command eq 'backup-domain' ||
+		       $command eq 'create-scheduled-backup') {
+			like($source, qr/can_use_backup_key\s*\(/,
+				"$command permits keys shared for creating backups");
 			}
 		}
 	}

--- a/t/remote-api-access.t
+++ b/t/remote-api-access.t
@@ -13,6 +13,102 @@ my $loaded = do $lib;
 die $@ if ($@);
 die "Failed to load $lib: $!" if (!defined($loaded));
 
+my %expected_commands = (
+	'create-admin' => 'can_edit_admins',
+	'create-alias' => 'can_edit_aliases',
+	'create-database' => 'can_edit_databases',
+	'create-domain' => 'can_create_sub_servers',
+	'create-proxy' => 'can_edit_forward',
+	'create-redirect' => 'can_edit_redirect',
+	'create-simple-alias' => 'can_edit_aliases',
+	'backup-domain' => 'can_backup_domain',
+	'check-connectivity' => 'can_edit_domain',
+	'clone-domain' => 'can_create_sub_servers',
+	'create-scheduled-backup' => 'can_backup_domain',
+	'create-user' => 'can_edit_users',
+	'delete-admin' => 'can_edit_admins',
+	'delete-alias' => 'can_edit_aliases',
+	'delete-backup' => 'can_backup_log',
+	'delete-database' => 'can_edit_databases',
+	'delete-domain' => 'can_delete_domain',
+	'delete-php-directory' => 'can_edit_phpver',
+	'delete-scheduled-backup' => 'can_backup_sched',
+	'delete-proxy' => 'can_edit_forward',
+	'delete-redirect' => 'can_edit_redirect',
+	'delete-script' => 'can_edit_scripts',
+	'delete-user' => 'can_edit_users',
+	'detect-scripts' => 'can_edit_scripts',
+	'disable-domain' => 'can_disable_domain',
+	'disable-feature' => 'can_config_domain',
+	'disconnect-database' => 'can_remote_import_databases',
+	'enable-domain' => 'can_disable_domain',
+	'enable-feature' => 'can_config_domain',
+	'generate-acme-cert' => 'can_remote_edit_acme',
+	'fix-domain-permissions' => 'can_config_domain',
+	'fix-domain-quota' => 'can_edit_quotas',
+	'generate-cert' => 'can_edit_ssl',
+	'generate-letsencrypt-cert' => 'can_remote_edit_acme',
+	'get-command' => 'can_use_remote_api',
+	'get-dns' => 'can_edit_records',
+	'get-logs' => 'can_edit_domain',
+	'get-ssl' => 'can_edit_ssl',
+	'import-database' => 'can_remote_import_databases',
+	'install-cert' => 'can_edit_ssl',
+	'install-script' => 'can_edit_scripts',
+	'list-admins' => 'can_edit_admins',
+	'list-aliases' => 'can_edit_aliases',
+	'list-available-scripts' => 'can_edit_scripts',
+	'list-available-shells' => 'can_edit_users',
+	'list-backup-keys' => 'can_backup_keys',
+	'list-bandwidth' => 'can_edit_domain',
+	'list-certs' => 'can_edit_ssl',
+	'list-certs-expiry' => 'can_edit_ssl',
+	'list-commands' => 'can_use_remote_api',
+	'list-custom' => 'can_edit_domain',
+	'list-databases' => 'can_edit_databases',
+	'list-domains' => 'can_edit_domain',
+	'list-features' => 'can_edit_domain',
+	'list-backup-logs' => 'can_backup_log',
+	'list-mailbox' => 'can_remote_read_mailbox',
+	'list-php-directories' => 'can_edit_phpver',
+	'list-php-ini' => 'can_edit_phpmode',
+	'list-php-versions' => 'can_edit_phpver',
+	'list-ports' => 'can_edit_domain',
+	'list-proxies' => 'can_edit_forward',
+	'list-redirects' => 'can_edit_redirect',
+	'list-scheduled-backups' => 'can_backup_sched',
+	'list-scripts' => 'can_edit_scripts',
+	'list-service-certs' => 'can_edit_ssl',
+	'list-simple-aliases' => 'can_edit_aliases',
+	'list-users' => 'can_edit_users',
+	'modify-admin' => 'can_edit_admins',
+	'modify-custom' => 'can_config_domain',
+	'modify-domain' => 'can_config_domain',
+	'modify-database-hosts' => 'can_remote_edit_database_hosts',
+	'modify-database-pass' => 'can_edit_databases',
+	'modify-database-user' => 'can_edit_databases',
+	'modify-dns' => 'can_remote_edit_dns',
+	'modify-mail' => 'can_edit_mail',
+	'modify-php-ini' => 'can_edit_phpmode',
+	'modify-proxy' => 'can_edit_forward',
+	'modify-scheduled-backup' => 'can_backup_sched',
+	'modify-spam' => 'can_edit_spam',
+	'modify-user' => 'can_edit_users',
+	'modify-web' => 'can_remote_edit_web',
+	'resend-email' => 'can_edit_users',
+	'reset-feature' => 'can_config_domain',
+	'restore-domain' => 'can_restore_domain',
+	'rename-domain' => 'can_rename_domains',
+	'reset-pass' => 'can_edit_users',
+	'search-maillogs' => 'can_view_maillog',
+	'set-php-directory' => 'can_edit_phpver',
+	'start-stop-script' => 'can_edit_scripts',
+	'syncmx-domain' => 'can_edit_mail',
+	'unalias-domain' => 'can_config_domain',
+	'unsub-domain' => 'can_config_domain',
+	'validate-domains' => 'can_use_validation',
+	);
+
 {
 	no warnings qw(once redefine);
 	local @main::plugins = ();
@@ -31,28 +127,19 @@ die "Failed to load $lib: $!" if (!defined($loaded));
 		'domain owner can use the remote API when granted permission');
 	ok(&can_remote_as_user('configure-script'),
 		'existing user API commands remain available when permitted');
-	ok(&can_remote_as_user('list-databases'),
-		'database listing is allowed for non-master API users');
-	ok(&can_remote_as_user('list-proxies.pl'),
-		'allowed command names are normalized');
-	ok(&can_remote_as_user('list-redirects'),
-		'redirect listing is allowed for non-master API users');
-	ok(&can_remote_as_user('modify-user'),
-		'user modification is allowed for non-master API users');
-	ok(!&can_remote_as_user('list-users'),
+	foreach my $command (sort keys %expected_commands) {
+		ok(&can_remote_as_user($command),
+			"$command is allowed for permitted non-master API users");
+		is(&get_user_remote_api_command($command.'.pl'),
+			$expected_commands{$command},
+			"$command has its audited capability");
+		}
+	ok(!&can_remote_as_user('modify-limits'),
 		'unaudited core commands remain denied');
 	delete($main::access{'edit_remote_api'});
 	$reseller = 1;
 	ok(&can_use_remote_api(),
 		'reseller remote API behavior remains unchanged');
-	is(&get_user_remote_api_command('list-databases'),
-		'can_edit_databases', 'database capability is registered');
-	is(&get_user_remote_api_command('list-proxies'),
-		'can_edit_forward', 'proxy capability is registered');
-	is(&get_user_remote_api_command('list-redirects'),
-		'can_edit_redirect', 'redirect capability is registered');
-	is(&get_user_remote_api_command('modify-user'),
-		'can_edit_users', 'user modification capability is registered');
 	}
 
 {
@@ -85,7 +172,7 @@ die "Failed to load $lib: $!" if (!defined($loaded));
 		{ 'allowed' => 1 }, 'list-databases.pl'),
 		'owned domain is denied without the required capability');
 	ok(!&remote_api_can_domain(
-		{ 'allowed' => 1 }, 'list-users.pl'),
+		{ 'allowed' => 1 }, 'modify-limits.pl'),
 		'unaudited command is denied at the domain boundary');
 
 	local *main::can_edit_users = sub { 0 };
@@ -117,6 +204,55 @@ die "Failed to load $lib: $!" if (!defined($loaded));
 
 {
 	no warnings qw(once redefine);
+	local %main::access = ( 'edit_remote_api' => 1 );
+	my ($import, $hosts) = (0, 0);
+	local *main::master_admin = sub { 0 };
+	local *main::reseller_admin = sub { 0 };
+	local *main::can_edit_domain = sub { 1 };
+	local *main::can_edit_databases = sub { 1 };
+	local *main::can_import_servers = sub { $import };
+	local *main::can_allowed_db_hosts = sub { $hosts };
+	my $domain = { 'dom' => 'example.test' };
+	ok(!&remote_api_can_domain($domain, 'import-database'),
+		'database imports require import permission');
+	$import = 1;
+	ok(&remote_api_can_domain($domain, 'import-database'),
+		'database imports pass with both permissions');
+	ok(!&remote_api_can_domain($domain, 'modify-database-hosts'),
+		'database host changes require allowed-host permission');
+	$hosts = 1;
+	ok(&remote_api_can_domain($domain, 'modify-database-hosts'),
+		'database host changes pass with both permissions');
+	ok(&remote_api_can_domain($domain, 'modify-database-user'),
+		'database login changes require database permission only');
+	}
+
+{
+	no warnings qw(once redefine);
+	local %main::access = ( 'edit_remote_api' => 1 );
+	local %main::text = (
+		'remote_ecannotcmd' => 'You are not allowed to run this command',
+		);
+	local *main::master_admin = sub { 0 };
+	local *main::reseller_admin = sub { 0 };
+	local *main::can_edit_scripts = sub { 1 };
+	my ($status, $out) =
+		&run_command_guard('list-available-scripts.pl');
+	ok(!$status, 'domainless command passes its capability check');
+	is($out, '', 'allowed domainless command produces no guard output');
+	local *main::can_edit_scripts = sub { 0 };
+	($status, $out) = &run_command_guard('list-available-scripts.pl');
+	ok($status, 'domainless command is denied without its capability');
+	is($out, "You are not allowed to run this command\n",
+		'domainless command denial has a clear error');
+	($status, $out) = &run_command_guard('modify-limits.pl');
+	ok($status, 'unregistered domainless command is denied');
+	is($out, "You are not allowed to run this command\n",
+		'unregistered domainless command has a clear error');
+	}
+
+{
+	no warnings qw(once redefine);
 	my @guard;
 	my $domain = { 'dom' => 'example.test' };
 	local *main::get_domain_by = sub {
@@ -133,16 +269,125 @@ die "Failed to load $lib: $!" if (!defined($loaded));
 		'remote domain helper leaves program detection to the guard');
 	}
 
-foreach my $command (
-	qw(list-databases.pl list-proxies.pl list-redirects.pl modify-user.pl)
-	) {
-	my $path = File::Spec->catfile($root, $command);
+{
+	no warnings qw(once redefine);
+	my @checked;
+	my @domains = (
+		{ 'dom' => 'owned.test', 'allowed' => 1 },
+		{ 'dom' => 'foreign.test', 'allowed' => 0 },
+		);
+	local *main::master_admin = sub { 0 };
+	local *main::can_edit_domain = sub { $_[0]->{'allowed'} };
+	local *main::require_remote_api_domain = sub { push(@checked, $_[0]) };
+	my @filtered = &get_remote_api_domains(\@domains, 1, 'list-domains');
+	is_deeply(\@filtered, [ $domains[0] ],
+		'all-domain requests are limited to visible domains');
+	is_deeply(\@checked, [ $domains[0] ],
+		'filtered domains are authorized without another lookup');
+	@checked = ( );
+	my @explicit = &get_remote_api_domains([ $domains[0] ], 0,
+		'list-domains');
+	is_deeply(\@explicit, [ $domains[0] ],
+		'explicit domain requests preserve their targets');
+	is_deeply(\@checked, [ $domains[0] ],
+		'explicit targets use the same authorization boundary');
+	}
+
+my %pro_only = map { $_, 1 } &list_pro_only_api_commands();
+my %object_capabilities = map { $_, 1 }
+	qw(can_backup_log can_backup_sched can_view_maillog);
+my %object_commands = (
+	'delete-backup' => 'can_backup_log',
+	'search-maillogs' => 'can_view_maillog',
+	'list-backup-logs' => 'can_backup_log',
+	'list-scheduled-backups' => 'can_backup_sched',
+	'delete-scheduled-backup' => 'can_backup_sched',
+	'modify-scheduled-backup' => 'can_backup_sched',
+	);
+my %domainless_commands = map { $_, 1 }
+	qw(get-command list-available-scripts list-available-shells list-backup-keys
+	   list-certs-expiry list-commands);
+foreach my $command (sort keys %expected_commands) {
+	my $path = File::Spec->catfile($root, $command.'.pl');
+	if ($object_capabilities{$expected_commands{$command}}) {
+		ok($object_commands{$command},
+			"$command uses an object capability and is declared as ".
+			"an object command");
+		}
+	if (!-f $path) {
+		# Commands that ship only in the Pro edition live in a
+		# separate repository, checked out alongside this one
+		my $propath = File::Spec->catfile(
+			dirname($root), 'virtualmin-pro', $command.'.pl');
+		if ($pro_only{$command.'.pl'} && !-f $propath) {
+			ok(1, "$command is a Pro command, not checked out");
+			next;
+			}
+		ok($pro_only{$command.'.pl'},
+			"$command is missing here so must be a Pro command");
+		$path = $propath;
+		}
+	ok(-f $path, "$command script exists");
 	open(my $fh, '<', $path) || die "Cannot read $path: $!";
 	local $/ = undef;
 	my $source = <$fh>;
 	close($fh);
-	like($source, qr/get_remote_api_domain\s*\("dom",\s*\$domain\)/,
-		"$command uses the shared domain boundary");
+	if ($domainless_commands{$command}) {
+		like($source, qr/require_remote_api_command\s*\(/,
+			"$command uses the shared command boundary");
+		if ($command eq 'list-certs-expiry') {
+			like($source, qr/get_remote_api_domains\s*\(/,
+				"$command limits certificate collection by domain");
+			unlike($source, qr/`virtualmin\s+list-certs/,
+				"$command does not bypass ACLs through the root CLI");
+			}
+		}
+	elsif ($object_commands{$command}) {
+		# Their capability takes an object, so they must not resolve a
+		# domain through the shared boundary with it
+		unlike($source, qr/get_remote_api_domain(?:s)?\s*\(/,
+			"$command does not mix an object capability with a ".
+			"domain boundary");
+		# These authorize their own object or scope rather than a domain
+		like($source, qr/$object_commands{$command}\s*\(/,
+			"$command checks its own object permission");
+		}
+	elsif ($command eq 'restore-domain') {
+		# Its targets come from inside the archive, so it authorizes
+		# each one directly and limits what may be restored
+		like($source, qr/can_restore_domain\s*\(/,
+			"$command checks the restore permission");
+		like($source, qr/can_edit_domain\s*\(\s*\$dinfo\s*\)/,
+			"$command checks ownership of each restored domain");
+		like($source, qr/safe_backup_features/,
+			"$command limits non-master restores to safe features");
+		}
+	elsif ($command eq 'create-domain') {
+		# Creation has no target domain yet, so it authorizes the
+		# parent that the new sub-server will be created under
+		like($source, qr/can_create_sub_servers\s*\(/,
+			"$command checks the sub-server creation permission");
+		like($source, qr/can_edit_domain\s*\(\s*\$parent\s*\)/,
+			"$command checks ownership of the parent domain");
+		like($source, qr/allowed_domain_name\s*\(\s*\$parent\s*,/,
+			"$command checks name restrictions against the parent");
+		like($source,
+			qr/elsif \(\$a eq "--pre-command"\) \{\s*\$is_master \|\|/s,
+			"$command keeps pre-creation commands master-only");
+		like($source,
+			qr/elsif \(\$a eq "--post-command"\) \{\s*\$is_master \|\|/s,
+			"$command keeps post-creation commands master-only");
+		}
+	else {
+		like($source, qr/get_remote_api_domain(?:s)?\s*\(/,
+			"$command uses a shared domain boundary");
+		if ($command eq 'modify-domain') {
+			like($source, qr/check_password_restrictions\s*\(/,
+				"$command enforces the domain password policy");
+			like($source, qr/virtual_server_limits\s*\(/,
+				"$command enforces domain plan limits");
+			}
+		}
 	}
 
 done_testing();
@@ -160,6 +405,29 @@ if (!$pid) {
 	open(STDOUT, '>&', $writer) || die "redirect failed: $!";
 	close($writer);
 	&require_remote_api_domain($domain, $requested, $program);
+	exit(0);
+	}
+close($writer);
+local $/ = undef;
+my $output = <$reader>;
+close($reader);
+waitpid($pid, 0);
+return ($?, $output);
+}
+
+# run_command_guard(program-name)
+# Runs the terminating command guard in a child and returns status and output.
+sub run_command_guard
+{
+my ($program) = @_;
+pipe(my $reader, my $writer) || die "pipe failed: $!";
+my $pid = fork();
+defined($pid) || die "fork failed: $!";
+if (!$pid) {
+	close($reader);
+	open(STDOUT, '>&', $writer) || die "redirect failed: $!";
+	close($writer);
+	&require_remote_api_command($program);
 	exit(0);
 	}
 close($writer);

--- a/t/remote-api-access.t
+++ b/t/remote-api-access.t
@@ -446,6 +446,10 @@ foreach my $command (sort keys %expected_commands) {
 				"$command enforces the domain password policy");
 			like($source, qr/virtual_server_limits\s*\(/,
 				"$command enforces domain plan limits");
+			like($source, qr/can_edit_exclude\s*\(/,
+				"$command requires backup exclusion permission");
+			like($source, qr/\$e !~ \/\\\.\\\.\//,
+				"$command rejects parent paths in backup exclusions");
 			}
 		elsif ($command eq 'enable-feature') {
 			like($source,

--- a/unalias-domain.pl
+++ b/unalias-domain.pl
@@ -53,9 +53,18 @@ while(@ARGV > 0) {
 
 # Find the domain
 $domain || usage("No domain specified");
-$d = &get_domain_by("dom", $domain);
+$d = &get_remote_api_domain("dom", $domain);
 $d || usage("Virtual server $domain does not exist.");
 $d->{'alias'} || &usage("The given virtual server is not an alias");
+$d->{'parent'} || &master_admin() ||
+	&usage("Only a sub-server alias can be converted");
+
+# An alias becomes a real sub-server, so it counts against that limit
+if (!&master_admin()) {
+	my ($dleft, $dreason, $dmax) = &count_domains("realdoms");
+	$dleft == 0 && &usage("You have reached the maximum of $dmax ".
+			      "virtual servers that can be created");
+	}
 
 # Call the move function
 &$first_print(&text('unalias_doing', "<tt>$d->{'dom'}</tt>"));

--- a/unsub-domain.pl
+++ b/unsub-domain.pl
@@ -53,9 +53,11 @@ while(@ARGV > 0) {
 
 # Find the domain
 $domain || usage("No domain specified");
-$d = &get_domain_by("dom", $domain);
+$d = &get_remote_api_domain("dom", $domain);
 $d || usage("Virtual server $domain does not exist.");
 $d->{'subdom'} || &usage("Only sub-domains can be converted to sub-servers");
+$d->{'parent'} || &master_admin() ||
+	&usage("Only a sub-server sub-domain can be converted");
 
 # Call the move function
 &$first_print(&text('unsub_doing', "<tt>$d->{'dom'}</tt>"));

--- a/validate-domains.pl
+++ b/validate-domains.pl
@@ -36,13 +36,14 @@ while(@ARGV > 0) {
 	if ($a eq "--domain") {
 		# Add a domain to validate
 		$dname = shift(@ARGV);
-		$d = &get_domain_by("dom", $dname);
+		$d = &get_remote_api_domain("dom", $dname);
 		$d || &usage("Virtual server $dname does not exist");
 		push(@doms, $d);
 		}
 	elsif ($a eq "--all-domains") {
 		# Validating all domains
 		@doms = &list_domains();
+		$all_doms = 1;
 		}
 	elsif ($a eq "--feature") {
 		# Add a feature to validate
@@ -80,6 +81,8 @@ while(@ARGV > 0) {
 		&usage("Unknown parameter $a");
 		}
 	}
+
+@doms = &get_remote_api_domains(\@doms, $all_doms);
 
 # Validate args
 @doms || &usage("No virtual servers to validate specified");

--- a/virtual-server-lib-funcs.pl
+++ b/virtual-server-lib-funcs.pl
@@ -19949,12 +19949,15 @@ $flags{'argv'} = &urlize(join(" ", @qargv));
 # Log it
 my $script = $0;
 $script =~ s/^.*\///;
-local $remote_user = "root";
-local $WebminCore::remote_user = "root";
+my $api = $main::virtualmin_remote_api || $ENV{'VIRTUALMIN_REMOTE_API'};
+# Attribute a remote API call to the user who made it, not to root
+my $loguser = $api && !&master_admin() && $base_remote_user
+		? $base_remote_user : "root";
+local $remote_user = $loguser;
+local $WebminCore::remote_user = $loguser;
 my $rh = $ENV{'REMOTE_HOST'};
 local $ENV{'REMOTE_HOST'} = $rh || "127.0.0.1";
-&webmin_log($main::virtualmin_remote_api ||
-	    $ENV{'VIRTUALMIN_REMOTE_API'} ? "remote" : "cmd",
+&webmin_log($api ? "remote" : "cmd",
 	    $script, $d ? $d->{'dom'} : undef, \%flags);
 }
 


### PR DESCRIPTION
Hey Jamie,

This PR completes the ability for domain owners to use the remote API what was previously started in https://github.com/virtualmin/virtualmin-gpl/pull/1258.

So, about 90 commands are covered — users, aliases, databases, DNS, SSL, PHP, scripts, backups and domain management.

Owners can create sub-servers but not top-level ones, restores are limited to dir/mysql/postgres like in the UI, and backups can only go to their own backup directory.

Anything above the domain level (plans, templates, resellers, limits) stays root-only.

Also tested with t/remote-api-access.t and against a real install as a domain owner.

Similar changes submitted directly without PRs:

https://github.com/virtualmin/virtualmin-htpasswd/commit/e7993fa1c0887e1694dc7f48d5733a3a488be930
https://github.com/virtualmin/virtualmin-pro/commit/c2a38845d1b39915d1fdf1b7cb2f3df7ab3a8e7e
