### PR TITLE
Fix ProFTPD SFTP and TLS log rotation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 #### Version 8.2.1
 * Add Matomo web analytics installer to Virtualmin GPL, including detection of existing installs and display of the tracking code to embed in website pages
+* Fix missing ProFTPD SFTP and TLS log rotation while preserving existing rotation rules
 * Fix cloning Apache virtual servers overwriting newly issued SSL certificates with the source server's certificate [#1280](https://github.com/virtualmin/virtualmin-gpl/issues/1280)
 * Fix incorrect SSL certificate paths left by older releases when breaking certificate sharing, recovering the current certificate and any missing CA chain from the combined file
 * Fix batch-created virtual servers not applying the template's initial website content

--- a/postinstall.pl
+++ b/postinstall.pl
@@ -644,6 +644,9 @@ if ($config{'rs_endpoint'} eq 'https://lon.auth.api.rackspacecloud.com/v1.0') {
 # Unlock config now we're done with it
 &unlock_file($module_config_file);
 
+# Repair ProFTPd log rotation on upgrades after releasing the config lock.
+&setup_proftpd_logrotate();
+
 if (!defined($gconfig{'forgot_pass'})) {
 	# Enable Webmin forgotten password recovery
 	&lock_file("$config_directory/config");

--- a/proftpd-lib.pl
+++ b/proftpd-lib.pl
@@ -29,6 +29,27 @@ return !$@ && ref($conf) ? 1 : 0;
 sub setup_proftpd_logrotate
 {
 return 0 if (!$config{'logrotate'} || !&has_proftpd_support());
+
+# Read current paths, including logs in virtual hosts and included files.
+# The installer may have changed them since the configuration was cached.
+@proftpd::get_config_cache = ();
+my $conf = &proftpd::get_config();
+my $systemlog = &proftpd::find_directive('SystemLog', $conf);
+my @pending = @$conf;
+my @logs;
+while (my $dir = shift(@pending)) {
+	push(@pending, @{$dir->{'members'}}) if ($dir->{'members'});
+	next if ($dir->{'name'} !~ /^(SFTPLog|TLSLog)$/i);
+	my $path = $dir->{'words'}->[0];
+	# Ignore disabled logging, special files, and paths that the logrotate
+	# parser cannot represent as literal filenames. Missing files are valid.
+	next if (!$path || $path !~ /^\// ||
+		 $path =~ /[\x00-\x1f\x7f"'\\#{}*?\[\]]/ ||
+		 -l $path || (-e $path && !-f $path));
+	push(@logs, $path);
+	}
+@logs = &unique(@logs);
+return 0 if (!@logs);
 &require_logrotate();
 &obtain_lock_logrotate();
 
@@ -37,7 +58,6 @@ return 0 if (!$config{'logrotate'} || !&has_proftpd_support());
 my $parent = &logrotate::get_config_parent();
 my @blocks = grep { ref($_->{'name'}) eq 'ARRAY' }
 		 @{$parent->{'members'}};
-my @logs = ( '/var/log/proftpd/sftp.log', '/var/log/proftpd/tls.log' );
 
 # Match configured patterns even before the logs have been created.
 foreach my $block (@blocks) {
@@ -46,10 +66,11 @@ foreach my $block (@blocks) {
 		}
 	}
 
-# Reuse the package's options and restart script. Only extend a block that
-# permits missing logs, since SFTP and TLS logs are created on first use.
+# Reuse the configured system log's options and restart script. Only extend
+# a block that permits missing logs, since SFTP and TLS logs are created on use.
 my ($block) = grep {
-	&indexof('/var/log/proftpd/proftpd.log', @{$_->{'name'}}) >= 0 &&
+	$systemlog && $systemlog =~ /^\// &&
+	(grep { &proftpd_log_matches($systemlog, $_) } @{$_->{'name'}}) &&
 	&logrotate::find('missingok', $_->{'members'}) &&
 	!&logrotate::find('nomissingok', $_->{'members'})
 	} @blocks;
@@ -59,7 +80,8 @@ if (@logs && $block) {
 		&logrotate::ensure_writable_config_file($block->{'file'}) :
 		$block->{'file'};
 	my $lref = &read_file_lines($file);
-	splice(@$lref, $block->{'line'}, 0, @logs);
+	splice(@$lref, $block->{'line'}, 0,
+	       map { &logrotate::join_words($_) } @logs);
 	&flush_file_lines($file);
 	&clear_logrotate_caches();
 	}

--- a/proftpd-lib.pl
+++ b/proftpd-lib.pl
@@ -24,6 +24,80 @@ my $conf = eval { &proftpd::get_config() };
 return !$@ && ref($conf) ? 1 : 0;
 }
 
+# setup_proftpd_logrotate()
+# Add uncovered SFTP and TLS logs to the existing system log rotation block.
+sub setup_proftpd_logrotate
+{
+return 0 if (!$config{'logrotate'} || !&has_proftpd_support());
+&require_logrotate();
+&obtain_lock_logrotate();
+
+# Re-read coverage under the lock, including rules added since an earlier read.
+&clear_logrotate_caches();
+my $parent = &logrotate::get_config_parent();
+my @blocks = grep { ref($_->{'name'}) eq 'ARRAY' }
+		 @{$parent->{'members'}};
+my @logs = ( '/var/log/proftpd/sftp.log', '/var/log/proftpd/tls.log' );
+
+# Match configured patterns even before the logs have been created.
+foreach my $block (@blocks) {
+	foreach my $pattern (@{$block->{'name'}}) {
+		@logs = grep { !&proftpd_log_matches($_, $pattern) } @logs;
+		}
+	}
+
+# Reuse the package's options and restart script. Only extend a block that
+# permits missing logs, since SFTP and TLS logs are created on first use.
+my ($block) = grep {
+	&indexof('/var/log/proftpd/proftpd.log', @{$_->{'name'}}) >= 0 &&
+	&logrotate::find('missingok', $_->{'members'}) &&
+	!&logrotate::find('nomissingok', $_->{'members'})
+	} @blocks;
+if (@logs && $block) {
+	# Add only filename lines so custom scripts and comments stay intact.
+	my $file = defined(&logrotate::ensure_writable_config_file) ?
+		&logrotate::ensure_writable_config_file($block->{'file'}) :
+		$block->{'file'};
+	my $lref = &read_file_lines($file);
+	splice(@$lref, $block->{'line'}, 0, @logs);
+	&flush_file_lines($file);
+	&clear_logrotate_caches();
+	}
+&release_lock_logrotate();
+return $block ? scalar(@logs) : 0;
+}
+
+# proftpd_log_matches(path, pattern)
+# Match a logrotate glob without requiring the log file to exist.
+sub proftpd_log_matches
+{
+my ($path, $pattern) = @_;
+my $re = '';
+while (length($pattern)) {
+	if ($pattern =~ s/^\\(.)//s) {
+		$re .= quotemeta($1);
+		}
+	elsif ($pattern =~ s/^\*//) {
+		$re .= '[^/]*';
+		}
+	elsif ($pattern =~ s/^\?//) {
+		$re .= '[^/]';
+		}
+	elsif ($pattern =~ s/^\[([!^]?\]?(?:\\.|\[:\w+:\]|[^\]\\])+)\]//) {
+		# Shell character classes use ! for negation; wildcards never
+		# cross directory boundaries, including negated classes.
+		my $class = $1;
+		$class =~ s/^[!^]/^/;
+		$re .= '(?!/)['.$class.']';
+		}
+	else {
+		$pattern =~ s/^(.)//s;
+		$re .= quotemeta($1);
+		}
+	}
+return eval { $path =~ /\A$re\z/ } ? 1 : 0;
+}
+
 # restart_proftpd()
 # Tell ProFTPd to re-read its config file. Does nothing if run from inetd.
 sub restart_proftpd

--- a/t/proftpd-logrotate-live-vm.py
+++ b/t/proftpd-logrotate-live-vm.py
@@ -1,0 +1,141 @@
+"""Opt-in live test for a disposable Debian/Ubuntu Virtualmin VM.
+
+Run with VIRTUALMIN_PROFTPD_LIVE_VM_TEST=1. Temporarily changes ProFTPD log
+paths and restarts the service; restores configuration and removes task data.
+"""
+
+import ftplib
+import os
+from pathlib import Path
+import re
+import shutil
+import socket
+import ssl
+import subprocess
+import tempfile
+import time
+
+if os.environ.get("VIRTUALMIN_PROFTPD_LIVE_VM_TEST") != "1":
+    raise SystemExit("Set VIRTUALMIN_PROFTPD_LIVE_VM_TEST=1 on a disposable VM")
+
+source = Path(__file__).resolve().parent.parent / "proftpd-lib.pl"
+main = Path("/etc/proftpd/proftpd.conf")
+included = Path("/etc/proftpd/conf.d/virtualmin.conf")
+rule = Path("/etc/logrotate.d/proftpd-core")
+original = {path: path.read_bytes() for path in (main, included, rule)}
+checks = 0
+
+
+def check(condition, description):
+    global checks
+    if not condition:
+        raise AssertionError(description)
+    checks += 1
+    print(f"PASS {checks}: {description}", flush=True)
+
+
+def run(*args):
+    result = subprocess.run(args, text=True, stdout=subprocess.PIPE,
+                            stderr=subprocess.STDOUT, timeout=30)
+    if result.returncode:
+        raise RuntimeError(f"{args[0]} failed ({result.returncode}): {result.stdout}")
+    return result.stdout
+
+
+def set_log(text, directive, path):
+    updated, count = re.subn(rf"(?m)^([ \t]*{directive}[ \t]+).*$",
+                            lambda match: f'{match[1]}"{path}"', text)
+    if count != 1:
+        raise AssertionError(f"Expected one {directive} directive, found {count}")
+    return updated
+
+
+def connections():
+    # Opening sessions is enough to exercise both service log destinations.
+    with socket.create_connection(("127.0.0.1", 2222), timeout=10) as client:
+        check(client.recv(4096).startswith(b"SSH-2.0-mod_sftp"), "real SFTP server answers")
+        client.sendall(b"SSH-2.0-logrotate-path-test\r\n")
+        time.sleep(0.3)
+    with ftplib.FTP_TLS(context=ssl._create_unverified_context(), timeout=10) as client:
+        client.connect("127.0.0.1", 21)
+        client.auth()
+        check(isinstance(client.sock, ssl.SSLSocket), "real FTP TLS handshake succeeds")
+        client.quit()
+    time.sleep(1)
+
+
+# Load the candidate helper into the installed Webmin runtime, without
+# replacing any installed module code or exposing configuration contents.
+apply_code = r'''
+use strict;
+use warnings;
+no warnings qw(once redefine);
+$ENV{'WEBMIN_CONFIG'} = '/etc/webmin';
+$ENV{'WEBMIN_VAR'} = '/var/webmin';
+open(my $mc, '<', '/etc/webmin/miniserv.conf') or die $!;
+my ($root) = map { /^root=(.*)/ ? $1 : () } <$mc>;
+close($mc);
+chdir("$root/virtual-server") or die $!;
+$0 = "$root/virtual-server/proftpd-live-test.pl";
+unshift(@INC, $root);
+require WebminCore;
+WebminCore->import();
+init_config();
+foreign_require('virtual-server');
+{
+    package virtual_server;
+    do $ARGV[0] or die $@ || $!;
+}
+print virtual_server::setup_proftpd_logrotate(), "\n";
+'''
+
+check(run("systemctl", "is-active", "proftpd").strip() == "active", "ProFTPD starts active")
+logdir = Path(tempfile.mkdtemp(prefix="codex-proftpd-paths-", dir="/var/log"))
+try:
+    with tempfile.TemporaryDirectory(prefix="proftpd-paths-live-") as work:
+        system = logdir / "daemon.log"
+        sftp = logdir / "secure shell.log"
+        tls = logdir / "encrypted.log"
+        main.write_text(set_log(original[main].decode(), "SystemLog", system))
+        included.write_text(set_log(set_log(original[included].decode(), "TLSLog", tls), "SFTPLog", sftp))
+        stock_rule = original[rule].decode()
+        if stock_rule.count("/var/log/proftpd/proftpd.log") != 1:
+            raise AssertionError("Expected the stock ProFTPD SystemLog rotation entry")
+        custom_rule = stock_rule.replace("/var/log/proftpd/proftpd.log", str(system))
+        rule.write_text(custom_rule)
+        run("proftpd", "-t")
+        run("systemctl", "restart", "proftpd")
+        check(run("perl", "-e", apply_code, str(source)).strip() == "2", "repair reads both custom paths from the live ProFTPD configuration")
+        check(rule.read_text().split("{", 1)[1] == custom_rule.split("{", 1)[1], "repair preserves all package options and restart scripts")
+        check(run("perl", "-e", apply_code, str(source)).strip() == "0", "second repair makes no changes")
+        run("logrotate", "--debug", "--state", "/dev/null", "/etc/logrotate.conf")
+        check(True, "complete native logrotate configuration is valid")
+        connections()
+        check(all(path.exists() and path.stat().st_size for path in (system, sftp, tls)), "real service traffic populates all three custom logs")
+        before = {path: path.stat() for path in (sftp, tls)}
+        old_pid = run("systemctl", "show", "proftpd", "--property=MainPID", "--value")
+        run("logrotate", "--force", "--state", str(Path(work) / "state"), str(rule))
+        check(run("systemctl", "is-active", "proftpd").strip() == "active", "ProFTPD remains active after rotation")
+        new_pid = run("systemctl", "show", "proftpd", "--property=MainPID", "--value")
+        check(int(new_pid) > 0 and new_pid != old_pid, "actual package postrotate command restarts ProFTPD")
+        for path in (sftp, tls):
+            check(Path(str(path) + ".1").stat().st_ino == before[path].st_ino, f"{path.name} rotates into its archive")
+            check(path.stat().st_ino != before[path].st_ino, f"{path.name} gets a new active inode")
+            check(path.stat().st_mode & 0o7777 == 0o640, f"{path.name} has package permissions")
+        sizes = {path: path.stat().st_size for path in (sftp, tls)}
+        archives = {path: Path(str(path) + ".1").read_bytes() for path in (sftp, tls)}
+        connections()
+        for path in (sftp, tls):
+            check(path.stat().st_size > sizes[path], f"new connections write to the new {path.name}")
+            check(Path(str(path) + ".1").read_bytes() == archives[path], f"archived {path.name} stays unchanged")
+finally:
+    # Restore the service before removing its temporary log destinations.
+    for path, contents in original.items():
+        path.write_bytes(contents)
+    run("proftpd", "-t")
+    run("systemctl", "restart", "proftpd")
+    check(all(path.read_bytes() == contents for path, contents in original.items()), "original configuration restored exactly")
+    check(run("systemctl", "is-active", "proftpd").strip() == "active", "ProFTPD is active with its original configuration")
+    shutil.rmtree(logdir)
+
+print(f"PASS: all {checks} live checks passed", flush=True)

--- a/t/proftpd-logrotate-vm.t
+++ b/t/proftpd-logrotate-vm.t
@@ -1,0 +1,162 @@
+use strict;
+use warnings;
+no warnings qw(once redefine);
+use File::Temp qw(tempdir);
+use Test::More;
+use FindBin;
+
+plan skip_all => 'Set VIRTUALMIN_PROFTPD_VM_TEST=1 on a disposable Webmin VM'
+    unless $ENV{'VIRTUALMIN_PROFTPD_VM_TEST'};
+
+$ENV{'WEBMIN_CONFIG'} = '/etc/webmin';
+$ENV{'WEBMIN_VAR'} = '/var/webmin';
+open(my $mc, '<', '/etc/webmin/miniserv.conf') or die $!;
+my ($root) = map { /^root=(.*)/ ? $1 : () } <$mc>;
+close($mc);
+chdir("$root/virtual-server") or die $!;
+$0 = "$root/virtual-server/proftpd-logrotate-test.pl";
+unshift(@INC, $root);
+require WebminCore;
+WebminCore->import();
+init_config();
+foreign_require('virtual-server');
+foreign_require('logrotate');
+
+my $source = "$FindBin::Bin/../proftpd-lib.pl";
+{
+    package virtual_server;
+    do $source or die $@ || $!;
+}
+
+# Use the VM's real parser and complete configuration in a temporary copy.
+my $tmp = tempdir('proftpd-logrotate-XXXXXX', TMPDIR => 1, CLEANUP => 1);
+mkdir("$tmp/conf.d") or die $!;
+my %original;
+foreach my $file (glob('/etc/logrotate.d/*')) {
+    next unless -f $file;
+    (my $name = $file) =~ s{.*/}{};
+    open(my $fh, '<', $file) or die $!;
+    $original{$name} = do { local $/; <$fh> };
+    close($fh);
+}
+open(my $main, '<', '/etc/logrotate.conf') or die $!;
+my $maintext = do { local $/; <$main> };
+close($main);
+$maintext =~ s{/etc/logrotate.d}{$tmp/conf.d}g;
+write_text("$tmp/main.conf", $maintext);
+$logrotate::config{'logrotate_conf'} = "$tmp/main.conf";
+$logrotate::config{'add_file'} = "$tmp/conf.d";
+$virtual_server::config{'logrotate'} = 1;
+
+my $debian = exists($original{'proftpd-core'});
+my $rule = $debian ? 'proftpd-core' : 'proftpd';
+reset_config();
+my $before = read_text("$tmp/conf.d/$rule");
+my $count = virtual_server::setup_proftpd_logrotate();
+is($count, $debian ? 2 : 0, 'adds only logs absent from the package rules');
+my $after = read_text("$tmp/conf.d/$rule");
+if (!$debian) {
+    is($after, $before, 'package wildcard remains byte-for-byte unchanged');
+}
+is(virtual_server::setup_proftpd_logrotate(), 0, 'second call makes no changes');
+is(read_text("$tmp/conf.d/$rule"), $after, 'second call preserves file contents');
+check_config('complete configuration remains valid');
+
+if ($debian) {
+    # A configuration parsed before locking must not hide an administrator's
+    # new rule when the repair checks for existing coverage.
+    reset_config();
+    logrotate::get_config_parent();
+    write_text("$tmp/conf.d/custom", "/var/log/proftpd/sftp.log {\n missingok\n daily\n rotate 7\n}\n");
+    is(virtual_server::setup_proftpd_logrotate(), 1, 'reloads coverage after acquiring the lock');
+    check_config('a rule added after caching does not cause a duplicate');
+
+    # Adding filenames must not rewrite custom scripts or their heredocs.
+    reset_config();
+    my $custom = $original{$rule};
+    $custom =~ s{(\tpostrotate\n)}{$1cat <<EOF > $tmp/heredoc-result\nkeep this script intact\nEOF\n};
+    write_text("$tmp/conf.d/$rule", $custom);
+    clear_cache();
+    is(virtual_server::setup_proftpd_logrotate(), 2, 'adds logs to a block with a custom script');
+    my $updated = read_text("$tmp/conf.d/$rule");
+    my ($oldbody) = $custom =~ /(\{.*)/s;
+    my ($newbody) = $updated =~ /(\{.*)/s;
+    is($newbody, $oldbody, 'preserves scripts, comments, and all existing directives exactly');
+    check_config('configuration with a heredoc remains valid');
+    reset_config();
+    virtual_server::setup_proftpd_logrotate();
+
+    # The saved block retains its existing policy and postrotate command.
+    my ($block) = grep { ref($_->{'name'}) && grep { $_ eq '/var/log/proftpd/sftp.log' } @{$_->{'name'}} } @{logrotate::get_config()};
+    is(logrotate::find_value('create', $block->{'members'}), '640 root adm', 'keeps package ownership and permissions');
+    like(logrotate::find_value('postrotate', $block->{'members'}), qr/invoke-rc.d proftpd restart/, 'keeps package restart command');
+    ok(logrotate::find('missingok', $block->{'members'}), 'absent logs remain permitted');
+
+    # Force real logrotate on isolated files, recording the postrotate call.
+    # The actual service restart command was checked above.
+    mkdir("$tmp/logs") or die $!;
+    my @members = map { +{ %$_ } } @{$block->{'members'}};
+    my ($post) = grep { $_->{'name'} eq 'postrotate' } @members;
+    $post->{'script'} = "echo rotated >> $tmp/postrotate-count\n";
+    my @paths = map { "$tmp/logs/$_.log" } qw(sftp tls);
+    my $fixture = { name => \@paths, members => \@members };
+    write_text("$tmp/rotation.conf", join("\n", logrotate::directive_lines($fixture, ''))."\n");
+    write_text($_, "rotation test\n") foreach @paths;
+    my $out = `logrotate --force --state $tmp/state $tmp/rotation.conf 2>&1`;
+    is($? >> 8, 0, 'forced rotation succeeds') or diag($out);
+    foreach my $path (@paths) {
+        ok(-s "$path.1" && -f $path && !-s $path, "$path rotates and is recreated");
+        is((stat($path))[2] & 07777, 0640, 'recreated log has package permissions');
+    }
+    is(read_text("$tmp/postrotate-count"), "rotated\n", 'shared postrotate runs once for both logs');
+
+    foreach my $case (
+        ['explicit SFTP rule', '/var/log/proftpd/sftp.log', 1],
+        ['wildcard SFTP rule', '/var/log/proftpd/s*.log', 1],
+        ['wildcard for both missing logs', '/var/log/proftpd/[st]*.log', 0],
+        ['wildcard in a different directory', '/var/log/*ftp*.log', 2],
+    ) {
+        reset_config();
+        write_text("$tmp/conf.d/custom", "$case->[1] {\n missingok\n daily\n rotate 7\n}\n");
+        clear_cache();
+        is(virtual_server::setup_proftpd_logrotate(), $case->[2], $case->[0]);
+        check_config("$case->[0]: no duplicate entries");
+    }
+    reset_config();
+    my $nomissing = $original{$rule};
+    $nomissing =~ s/\bmissingok\b/nomissingok/g;
+    write_text("$tmp/conf.d/$rule", $nomissing);
+    is(virtual_server::setup_proftpd_logrotate(), 0, 'does not add absent logs to a block requiring them');
+    is(read_text("$tmp/conf.d/$rule"), $nomissing, 'custom missing-file policy remains unchanged');
+    reset_config();
+    unlink("$tmp/conf.d/$rule") or die $!;
+    is(virtual_server::setup_proftpd_logrotate(), 0, 'does not invent a rule when the package block is absent');
+}
+done_testing();
+
+sub write_text {
+    my ($file, $text) = @_;
+    open(my $fh, '>', $file) or die "$file: $!";
+    print $fh $text;
+    close($fh) or die $!;
+}
+sub read_text {
+    open(my $fh, '<', $_[0]) or die "$_[0]: $!";
+    return do { local $/; <$fh> };
+}
+sub clear_cache {
+    %logrotate::get_config_cache = ();
+    %logrotate::get_config_lnum_cache = ();
+    %logrotate::get_config_files_cache = ();
+    $logrotate::get_config_parent_cache = undef;
+}
+sub reset_config {
+    unlink("$tmp/conf.d/custom") if -e "$tmp/conf.d/custom";
+    write_text("$tmp/conf.d/$_", $original{$_}) foreach keys %original;
+    clear_cache();
+}
+sub check_config {
+    my ($name) = @_;
+    my $out = `logrotate --debug --state /dev/null $tmp/main.conf 2>&1`;
+    is($? >> 8, 0, $name) or diag($out);
+}

--- a/t/proftpd-logrotate-vm.t
+++ b/t/proftpd-logrotate-vm.t
@@ -223,6 +223,86 @@ if ($debian) {
     unlink("$tmp/conf.d/$rule") or die $!;
     is(virtual_server::setup_proftpd_logrotate(), 0, 'does not invent a rule when the package block is absent');
 }
+
+# Parse custom paths from an included ProFTPD file using the VM's real parser.
+# Keep the package rules present to catch accidental use of default paths.
+{
+    local $proftpd::config{'proftpd_conf'} = "$tmp/proftpd.conf";
+    my $system = "$tmp/system logs/daemon.log";
+    my $sftp = "$tmp/custom logs/ssh sessions.log";
+    my $tls = "$tmp/custom logs/encrypted.log";
+    mkdir("$tmp/system logs") or die $!;
+    mkdir("$tmp/custom logs") or die $!;
+    my $included = "<Global>\n TLSLog \"$tls\"\n</Global>\n".
+                   "<VirtualHost 127.0.0.1>\n SFTPLog \"$sftp\"\n TLSLog \"$tls\"\n</VirtualHost>\n";
+    my $policy = " {\n weekly\n rotate 2\n missingok\n notifempty\n create 640 root root\n sharedscripts\n".
+                 " postrotate\n echo rotated >> $tmp/custom-postrotate\n endscript\n}\n";
+    write_text("$tmp/proftpd.conf", "SystemLog \"$system\"\nInclude $tmp/proftpd-extra.conf\n");
+    write_text("$tmp/proftpd-extra.conf", $included);
+    reset_config();
+    write_text("$tmp/conf.d/custom", "\"$system\"$policy");
+    is(virtual_server::setup_proftpd_logrotate(), 2, 'reads unique custom SFTP and TLS paths from included virtual host and global sections');
+    my ($custom) = grep { ref($_->{'name'}) && grep { $_ eq $system } @{$_->{'name'}} } @{logrotate::get_config()};
+    is_deeply([sort @{$custom->{'name'}}], [sort($system, $sftp, $tls)], 'extends the configured SystemLog block with correctly quoted paths');
+    is(read_text("$tmp/conf.d/$rule"), $original{$rule}, 'custom paths leave the stock package rule untouched');
+    is(virtual_server::setup_proftpd_logrotate(), 0, 'custom paths with spaces are not added twice');
+    check_config('custom paths are accepted by native logrotate');
+
+    # Exercise the resulting filenames and preserved policy, including spaces.
+    write_text($_, "custom rotation test\n") foreach ($sftp, $tls);
+    my $out = `logrotate --force --state $tmp/custom-state $tmp/conf.d/custom 2>&1`;
+    is($? >> 8, 0, 'native logrotate rotates the configured custom paths') or diag($out);
+    foreach my $path ($sftp, $tls) {
+        is(read_text("$path.1"), "custom rotation test\n", 'custom log contents are preserved in the archive');
+        ok(-f $path && !-s $path, 'custom log is recreated');
+        is((stat($path))[2] & 07777, 0640, 'custom log keeps the rotation policy permissions');
+    }
+    is(read_text("$tmp/custom-postrotate"), "rotated\n", 'custom block runs its shared postrotate script once');
+
+    # Coverage and block selection must also work with configured wildcards.
+    reset_config();
+    write_text("$tmp/conf.d/custom", "\"$tmp/system logs/*.log\"$policy");
+    is(virtual_server::setup_proftpd_logrotate(), 2, 'finds the SystemLog rotation block through a wildcard');
+    check_config('custom SystemLog wildcard remains valid');
+    reset_config();
+    write_text("$tmp/conf.d/custom", "\"$system\"$policy\n\"$sftp\"$policy");
+    is(virtual_server::setup_proftpd_logrotate(), 1, 'skips a custom SFTP path covered by a separate exact rule');
+    check_config('custom exact coverage does not produce duplicate entries');
+    reset_config();
+    write_text("$tmp/conf.d/custom", "\"$system\"$policy\n\"$tmp/custom logs/*.log\"$policy");
+    is(virtual_server::setup_proftpd_logrotate(), 0, 'skips custom logs covered by a wildcard');
+    check_config('custom wildcard coverage remains valid');
+
+    # The installer's earlier parse must not hide freshly written directives.
+    reset_config();
+    write_text("$tmp/conf.d/custom", "\"$system\"$policy");
+    write_text("$tmp/proftpd-extra.conf", "TLSLog none\n");
+    @proftpd::get_config_cache = ();
+    proftpd::get_config();
+    write_text("$tmp/proftpd-extra.conf", $included);
+    is(virtual_server::setup_proftpd_logrotate(), 2, 'reloads ProFTPD configuration after the installer changes it');
+
+    # Disabled logging and special files do not become rotation targets.
+    reset_config();
+    write_text("$tmp/conf.d/custom", "\"$system\"$policy");
+    write_text("$tmp/proftpd-extra.conf", "TLSLog none\n<VirtualHost 127.0.0.1>\n SFTPLog none\n</VirtualHost>\n");
+    is(virtual_server::setup_proftpd_logrotate(), 0, 'disabled logging adds no default paths');
+    write_text("$tmp/proftpd-extra.conf", "TLSLog /dev/null\nSFTPLog relative.log\n");
+    is(virtual_server::setup_proftpd_logrotate(), 0, 'ignores device files and non-absolute paths');
+    write_text("$tmp/proftpd-extra.conf", "TLSLog \"$tmp/custom logs/*.log\"\n");
+    is(virtual_server::setup_proftpd_logrotate(), 0, 'does not turn a literal ProFTPD filename into a rotation wildcard');
+    write_text("$tmp/proftpd-extra.conf", '');
+    is(virtual_server::setup_proftpd_logrotate(), 0, 'absent log directives add nothing');
+    is(read_text("$tmp/conf.d/custom"), "\"$system\"$policy", 'ignored log settings leave the rotation rule unchanged');
+
+    # Do not guess a destination block when SystemLog is absent or unrotated.
+    write_text("$tmp/proftpd-extra.conf", $included);
+    reset_config();
+    is(virtual_server::setup_proftpd_logrotate(), 0, 'unrotated SystemLog does not cause unrelated package rules to change');
+    is(read_text("$tmp/conf.d/$rule"), $original{$rule}, 'stock rule remains unchanged when custom SystemLog has no rule');
+    write_text("$tmp/proftpd.conf", "Include $tmp/proftpd-extra.conf\n");
+    is(virtual_server::setup_proftpd_logrotate(), 0, 'missing SystemLog does not select an arbitrary rotation block');
+}
 done_testing();
 
 sub write_text {

--- a/t/proftpd-logrotate-vm.t
+++ b/t/proftpd-logrotate-vm.t
@@ -2,6 +2,7 @@ use strict;
 use warnings;
 no warnings qw(once redefine);
 use File::Temp qw(tempdir);
+use POSIX ();
 use Test::More;
 use FindBin;
 
@@ -50,6 +51,96 @@ $virtual_server::config{'logrotate'} = 1;
 
 my $debian = exists($original{'proftpd-core'});
 my $rule = $debian ? 'proftpd-core' : 'proftpd';
+
+# Run the actual postinstall section with real Webmin locks. Other upgrade
+# migrations are outside this test's scope.
+my $postinstall = read_text("$FindBin::Bin/../postinstall.pl");
+my ($hook_source) = $postinstall =~ /(# Unlock config now we're done with it\n.*?)\nif \(!defined\(\$gconfig\{'forgot_pass'\}\)\)/s;
+die 'Cannot locate postinstall repair section' unless $hook_source;
+my $hook = eval "package virtual_server; no strict 'vars'; sub { $hook_source }";
+die $@ unless $hook;
+reset_config();
+{
+    local $virtual_server::module_config_file = "$tmp/virtualmin-config";
+    write_text($virtual_server::module_config_file, "fixture=1\n");
+    my $repair = \&virtual_server::setup_proftpd_logrotate;
+    my @repairs;
+    local *virtual_server::setup_proftpd_logrotate = sub {
+        ok(!defined($main::locked_file_list{$virtual_server::module_config_file}),
+            'postinstall releases the module configuration lock before repair');
+        push(@repairs, $repair->());
+        return $repairs[-1];
+    };
+    for (1 .. 2) {
+        lock_file($virtual_server::module_config_file);
+        $hook->();
+        ok(!-e "$tmp/conf.d.lock" && !-e "$tmp/main.conf.lock" &&
+            !$main::got_lock_logrotate, 'postinstall repair releases its logrotate locks');
+    }
+    is_deeply(\@repairs, [$debian ? 2 : 0, 0], 'postinstall repairs once and is safe to repeat');
+    check_config('configuration repaired by postinstall remains valid');
+
+    # A competing process holds the logrotate lock, then needs the module
+    # configuration lock. Postinstall must release its lock before waiting.
+    reset_config();
+    pipe(my $ready, my $notify) or die $!;
+    lock_file($virtual_server::module_config_file);
+    my $child = fork();
+    die "fork: $!" unless defined($child);
+    if (!$child) {
+        close($ready);
+        # The child must not inherit ownership of its parent's locks.
+        %main::locked_file_list = ();
+        @main::temporary_files = ();
+        my $error;
+        {
+            local $SIG{'ALRM'} = sub { die "competing lock timeout\n" };
+            eval {
+                alarm(15);
+                lock_file("$tmp/conf.d", 0, 0, 1);
+                die 'Competing lock was not created' unless -e "$tmp/conf.d.lock";
+                syswrite($notify, "ready\n");
+                lock_file($virtual_server::module_config_file, 0, 0, 1);
+                unlock_file($virtual_server::module_config_file);
+                unlock_file("$tmp/conf.d");
+                alarm(0);
+            };
+            $error = $@;
+            alarm(0);
+        }
+        unlock_all_files();
+        print STDERR $error if $error;
+        close($notify);
+        POSIX::_exit($error ? 1 : 0);
+    }
+    close($notify);
+    my ($completed, $waited);
+    {
+        local $SIG{'ALRM'} = sub { die "postinstall lock timeout\n" };
+        eval {
+            alarm(20);
+            my $signal = <$ready>;
+            die 'Competing process did not acquire its lock' unless $signal && $signal eq "ready\n";
+            $hook->();
+            waitpid($child, 0);
+            $waited = 1;
+            $completed = $? == 0;
+            alarm(0);
+        };
+        alarm(0);
+        diag($@) if $@;
+    }
+    close($ready);
+    if (!$waited) {
+        kill('KILL', $child);
+        waitpid($child, 0);
+    }
+    ok($completed, 'postinstall and a competing configuration editor both finish without deadlock');
+    ok(!-e "$tmp/virtualmin-config.lock" && !-e "$tmp/conf.d.lock" &&
+        !-e "$tmp/main.conf.lock" && !$main::got_lock_logrotate,
+        'competing processes leave no configuration locks behind');
+}
+
 reset_config();
 my $before = read_text("$tmp/conf.d/$rule");
 my $count = virtual_server::setup_proftpd_logrotate();

--- a/t/proftpd-logrotate.t
+++ b/t/proftpd-logrotate.t
@@ -1,0 +1,43 @@
+#!/usr/bin/perl
+
+use strict;
+use warnings;
+use Test::More;
+use FindBin;
+
+do "$FindBin::Bin/../proftpd-lib.pl"
+	or die "Failed to load proftpd-lib.pl: $@ $!";
+
+# Coverage must depend on the configured pattern, not existing files. Include
+# directory boundaries and shell character classes to catch false matches.
+my $log = '/var/log/proftpd/sftp.log';
+foreach my $test (
+	[ $log, 1 ],
+	[ '/var/log/proftpd/tls.log', 0 ],
+	[ '/var/log/proftpd/*.log', 1 ],
+	[ '/var/log/*/*.log', 1 ],
+	[ '/var/log/*.log', 0 ],
+	[ '/var/log/proftpd/sft?.log', 1 ],
+	[ '/var/log/proftpd/????.log', 1 ],
+	[ '/var/log/proftpd/???.log', 0 ],
+	[ '/var/log/proftpd/[st]*.log', 1 ],
+	[ '/var/log/proftpd/[!t]*.log', 1 ],
+	[ '/var/log/proftpd/[!s]*.log', 0 ],
+	[ '/var/log/proftpd/[a-z]*.log', 1 ],
+	[ '/var/log/proftpd/[[:alpha:]]*.log', 1 ],
+	[ '/var/log/proftpd/[[:digit:]]*.log', 0 ],
+	[ '/var/log/proftpd/\\*.log', 0 ],
+	[ '/var/log/proftpd/sftp?log', 1 ],
+	[ '/var/log/proftpd/sftp.log.*', 0 ],
+	[ '/var/log/proftpd[!x]sftp.log', 0 ],
+	[ '/var/log/proftpd/[sftp.log', 0 ],
+	) {
+	is(proftpd_log_matches($log, $test->[0]), $test->[1], $test->[0]);
+	}
+
+ok(proftpd_log_matches('/var/log/proftpd/tls.log', '/var/log/proftpd/*.log'),
+	'the package wildcard also covers TLS logs');
+ok(!proftpd_log_matches('/var/log/proftpd/sftpXlog', $log),
+	'literal dots do not match arbitrary characters');
+
+done_testing();

--- a/virtual-server-lib-funcs.pl
+++ b/virtual-server-lib-funcs.pl
@@ -17498,6 +17498,9 @@ if ($config{'logrotate'}) {
 		return &text('index_elogrotatever', "/logrotate/",
 				   $clink, $ver, 3.6);
 
+	# Repair missing ProFTPd log rotation on existing installations too.
+	&setup_proftpd_logrotate();
+
 	# Make sure the current config is OK
 	my $out = &backquote_with_timeout(
 		"$logrotate::config{'logrotate'} -d -f ".

--- a/virtual-server-lib-funcs.pl
+++ b/virtual-server-lib-funcs.pl
@@ -17498,9 +17498,6 @@ if ($config{'logrotate'}) {
 		return &text('index_elogrotatever', "/logrotate/",
 				   $clink, $ver, 3.6);
 
-	# Repair missing ProFTPd log rotation on existing installations too.
-	&setup_proftpd_logrotate();
-
 	# Make sure the current config is OK
 	my $out = &backquote_with_timeout(
 		"$logrotate::config{'logrotate'} -d -f ".


### PR DESCRIPTION
Hey Jamie,

This PR adds uncovered SFTP and TLS logs to the existing rotation block, preserving its settings and avoiding duplicate rules.

Verified on Debian, Ubuntu, AlmaLinux, and Rocky Linux VMs.

Fixes https://forum.virtualmin.com/t/possible-virtualmin-proftpd-sftp-log-rotation-oversight/137938.