### PR TITLE
Fix DNS provider overrides during switch

### DIFF
--- a/feature-dns.pl
+++ b/feature-dns.pl
@@ -47,11 +47,11 @@ if (!$d->{'dns'}) {
 return undef;
 }
 
-# setup_dns(&domain)
-# Set up a zone for a domain
+# setup_dns(&domain, [keep-provider])
+# Set up a zone for a domain, optionally keeping its selected DNS provider
 sub setup_dns
 {
-my ($d) = @_;
+my ($d, $keep_provider) = @_;
 &require_bind();
 my $tmpl = &get_template($d->{'template'});
 my $ip = $d->{'dns_ip'} || $d->{'ip'};
@@ -104,8 +104,8 @@ if ($d->{'provision_dns'} || $d->{'dns_cloud'}) {
 	$info->{'recs'} = $recs;
 	}
 
-# Select where DNS will be hosted based on the template
-&set_provision_features($d, ["dns"]);
+# Apply provider defaults only when no migration destination was selected
+&set_provision_features($d, ["dns"]) if (!$keep_provider);
 
 if ($d->{'provision_dns'}) {
 	# Create on provisioning server
@@ -5903,7 +5903,8 @@ elsif ($server) {
 	$d->{'dns_remote'} = $server->{'host'};
 	}
 $print_output = "";
-$ok = &setup_dns($d);
+# Keep the requested provider even if the template or alias target differs
+$ok = &setup_dns($d, 1);
 my $setup_err;
 if (!$ok) {
 	# Setup failed! Try to put everything back so we don't end up in a
@@ -5912,7 +5913,7 @@ if (!$ok) {
 	$d->{'dns_remote'} = $oldremote;
 	$d->{'provision_dns'} = $oldprov;
 	$setup_err = "Failed to setup new DNS zone : $print_output";
-	&setup_dns($d);
+	&setup_dns($d, 1);
 	}
 &save_domain($d);
 &pop_all_print();

--- a/feature-dns.pl
+++ b/feature-dns.pl
@@ -47,11 +47,14 @@ if (!$d->{'dns'}) {
 return undef;
 }
 
-# setup_dns(&domain, [keep-provider])
-# Set up a zone for a domain, optionally keeping its selected DNS provider
+# setup_dns(&domain)
+# Set up a zone for a domain. The temporary dns_keep_provider field preserves
+# its selected DNS provider instead of applying template or alias defaults.
 sub setup_dns
 {
-my ($d, $keep_provider) = @_;
+my ($d) = @_;
+# Consume the override before setup helpers can save the domain
+my $keep_provider = delete($d->{'dns_keep_provider'});
 &require_bind();
 my $tmpl = &get_template($d->{'template'});
 my $ip = $d->{'dns_ip'} || $d->{'ip'};
@@ -5904,7 +5907,8 @@ elsif ($server) {
 	}
 $print_output = "";
 # Keep the requested provider even if the template or alias target differs
-$ok = &setup_dns($d, 1);
+$d->{'dns_keep_provider'} = 1;
+$ok = &setup_dns($d);
 my $setup_err;
 if (!$ok) {
 	# Setup failed! Try to put everything back so we don't end up in a
@@ -5913,7 +5917,8 @@ if (!$ok) {
 	$d->{'dns_remote'} = $oldremote;
 	$d->{'provision_dns'} = $oldprov;
 	$setup_err = "Failed to setup new DNS zone : $print_output";
-	&setup_dns($d, 1);
+	$d->{'dns_keep_provider'} = 1;
+	&setup_dns($d);
 	}
 &save_domain($d);
 &pop_all_print();

--- a/t/README.md
+++ b/t/README.md
@@ -28,11 +28,17 @@ names with direct IP requests, cleans up both domains, and skips non-Apache
 website plugins. Internal lock cleanup and nested SSL cache behavior are covered
 by `apache-clone-locks.t`.
 
+On a disposable Virtualmin Pro host, run
+`VIRTUALMIN_DNS_VM_TEST=1 prove -v t/dns-cloud-migration-vm.t` to test DNS
+migration with real BIND zones and a simulated cloud provider. It creates and
+removes a DNS-only `.invalid` domain and does not contact Cloudflare.
+
 ## Current tests
 
 | File | What it checks |
 | --- | --- |
 | `compile.t` | Every discovered `.pl` and `.cgi` parses cleanly with `perl -c`. It catches syntax and compile-time module-loading breakage without running normal script bodies. |
+| `dns-cloud-migration-vm.t` | Explicit DNS migration destinations override templates and alias targets, preserve records, and restore the original provider after a setup failure. Requires a disposable Virtualmin Pro host. |
 | `apache-clone-locks.t` | Apache cloning keeps parsed directives under a web lock, preserves them across nested SSL updates, and releases locks when either virtual host is missing. |
 | `btrfs-lib.t` | Btrfs qgroup unit conversion, mount-path mapping, hierarchy repair, and safe subvolume lifecycle behavior. |
 | `configure-commands.t` | Preferred command names, hidden repository alias, live download progress, argument forwarding, help and API access. |

--- a/t/dns-cloud-migration-vm.t
+++ b/t/dns-cloud-migration-vm.t
@@ -1,0 +1,170 @@
+#!/usr/bin/perl
+
+use strict;
+use warnings;
+no warnings qw(once redefine);
+use Test::More;
+use FindBin;
+use Storable qw(dclone);
+
+plan skip_all => 'Set VIRTUALMIN_DNS_VM_TEST=1 on a disposable Virtualmin Pro VM'
+	unless $ENV{'VIRTUALMIN_DNS_VM_TEST'};
+
+$ENV{'WEBMIN_CONFIG'} = '/etc/webmin';
+$ENV{'WEBMIN_VAR'} = '/var/webmin';
+open(my $mc, '<', '/etc/webmin/miniserv.conf') or die $!;
+my ($root) = map { /^root=(.*)/ ? $1 : () } <$mc>;
+close($mc);
+chdir("$root/virtual-server") or die $!;
+$0 = "$root/virtual-server/dns-cloud-migration-test.pl";
+unshift(@INC, $root);
+require WebminCore;
+WebminCore->import();
+init_config();
+foreign_require('virtual-server');
+
+# Load the candidate without replacing the VM's installed module.
+my $source = "$FindBin::Bin/../feature-dns.pl";
+{
+	package virtual_server;
+	do $source or die $@ || $!;
+}
+
+my $name = "codex-dns-migration-$$.invalid";
+my ($created, $d);
+END {
+	# DNS-only fixtures have no Unix account, home directory or website.
+	if ($created) {
+		# Never let cleanup contact the real cloud API after a failed test.
+		if ($d) {
+			delete @{$d}{qw(dns_cloud dns_cloud_id dns_cloud_location alias)};
+			virtual_server::save_domain($d);
+			virtual_server::release_lock_dns($d);
+			}
+		run_cli('delete-domain', '--domain', $name);
+		}
+}
+my ($status, $output) = run_cli('create-domain', '--domain', $name,
+	'--pass', 'unused-dns-only-fixture', '--dns', '--cloud-dns', 'local',
+	'--skip-warnings');
+$created = !$status;
+BAIL_OUT("Cannot create DNS fixture: $output") if $status;
+virtual_server::flush_virtualmin_caches();
+$d = virtual_server::get_domain_by('dom', $name);
+BAIL_OUT('DNS fixture not found') unless $d;
+
+my $get_template = \&virtual_server::get_template;
+my $get_domain = \&virtual_server::get_domain;
+my $template = { %{$get_template->($d->{'template'})},
+	'dns_cloud' => 'cloudflare', 'dnssec' => 'no', 'dns_sub' => 'no' };
+my ($cloud_records, $cloud_reads, $cloud_creates, $fail_create) = ([], 0, 0, 0);
+
+{
+	local *virtual_server::get_template = sub { return $template; };
+	local *virtual_server::get_domain = sub {
+		return { 'id' => 'test-alias-target', 'dom' => 'alias-target.invalid',
+			'dns' => 1, 'dns_cloud' => 'cloudflare' }
+			if $_[0] eq 'test-alias-target';
+		return $get_domain->(@_);
+		};
+	local $virtual_server::first_print = sub { };
+	local $virtual_server::second_print = sub { };
+
+	# Simulate only the cloud provider. Zone files, migration, saving domains,
+	# record parsing and local BIND configuration use the real implementation.
+	local *virtual_server::dnscloud_cloudflare_check = sub { return undef; };
+	local *virtual_server::dnscloud_cloudflare_get_state = sub { return { 'ok' => 1 }; };
+	local *virtual_server::dnscloud_cloudflare_test = sub { return undef; };
+	local *virtual_server::dnscloud_cloudflare_valid_domain = sub { return undef; };
+	local *virtual_server::dnscloud_cloudflare_create_domain = sub {
+		$cloud_creates++;
+		return (0, 'simulated create failure') if $fail_create;
+		$cloud_records = dclone($_[1]->{'recs'} || []);
+		return (1, 'test-zone-id');
+		};
+	local *virtual_server::dnscloud_cloudflare_delete_domain = sub {
+		$cloud_records = [];
+		return (1, undef);
+		};
+	local *virtual_server::dnscloud_cloudflare_get_records = sub {
+		$cloud_reads++;
+		return (1, dclone($cloud_records));
+		};
+	local *virtual_server::dnscloud_cloudflare_put_records = sub {
+		$cloud_records = dclone($_[1]->{'recs'});
+		return (1, undef);
+		};
+	local *virtual_server::dnscloud_cloudflare_get_nameservers = sub { return []; };
+
+	# Include a custom TXT record to detect migrations that silently replace
+	# the old records with template defaults.
+	my ($records, $file) = virtual_server::get_domain_dns_records_and_file($d);
+	virtual_server::create_dns_record($records, $file, {
+		'name' => "migration.$name.", 'type' => 'TXT', 'class' => 'IN',
+		'ttl' => 300, 'values' => ['preserve-this-record'] });
+	my $err = virtual_server::post_records_change($d, $records, $file);
+	BAIL_OUT($err) if $err;
+	my $expected = record_values($records);
+
+	foreach my $alias (0, 1) {
+		$template->{'dns_cloud'} = $alias ? 'local' : 'cloudflare';
+		subtest $alias ? 'alias target cannot override local migration' :
+			'Cloudflare template cannot override local migration' => sub {
+			$d->{'alias'} = 'test-alias-target' if $alias;
+			$d->{'aliasdns'} = 1 if $alias;
+			is(virtual_server::modify_dns_cloud($d, 'cloudflare'), undef,
+				'moves fixture records to the simulated cloud');
+			is($d->{'dns_cloud'}, 'cloudflare', 'cloud provider selected');
+			my $creates = $cloud_creates;
+			is(virtual_server::modify_dns_cloud($d, 'local'), undef,
+				'migration to local succeeds');
+			is($cloud_creates, $creates, 'does not recreate the cloud zone');
+			ok(!$d->{'dns_cloud'} && !$d->{'dns_cloud_id'},
+				'cloud provider and zone ID are cleared');
+			my $saved = $get_domain->($d->{'id'}, undef, 1);
+			ok(!$saved->{'dns_cloud'}, 'local provider is saved to disk');
+
+			$cloud_reads = 0;
+			my ($recs, $zone) = virtual_server::get_domain_dns_records_and_file($saved, 1);
+			my $local_zone = virtual_server::get_domain_dns_file_from_bind($saved);
+			ok($zone && -f $zone && $local_zone && $zone eq $local_zone,
+				'DNS Records reads the zone configured in local BIND');
+			is($cloud_reads, 0, 'listing local records makes no cloud calls');
+			is_deeply(record_values($recs), $expected, 'original records survive');
+			system('named-checkzone', '-q', $name, $zone);
+			is($? >> 8, 0, 'BIND accepts the migrated zone');
+			};
+		}
+
+	# A failed migration must restore local DNS even with a cloud template.
+	delete($d->{'alias'});
+	delete($d->{'aliasdns'});
+	$template->{'dns_cloud'} = 'cloudflare';
+	$fail_create = 1;
+	$err = virtual_server::modify_dns_cloud($d, 'cloudflare');
+	like($err, qr/Failed to setup new DNS zone/, 'reports destination setup failure');
+	ok(!$d->{'dns_cloud'}, 'rollback restores the original local provider');
+	my ($recs, $zone) = virtual_server::get_domain_dns_records_and_file($d, 1);
+	is_deeply(record_values($recs), $expected, 'rollback restores the original records');
+	virtual_server::save_domain($d);
+}
+
+done_testing();
+
+sub record_values
+{
+my ($records) = @_;
+return [ sort map { join('|', $_->{'name'}, $_->{'type'}, @{$_->{'values'}}) }
+	grep { $_->{'name'} && $_->{'type'} && $_->{'type'} !~ /^(SOA|NS)$/ }
+	@$records ];
+}
+
+sub run_cli
+{
+open(my $fh, '-|', 'virtualmin', @_) or die $!;
+my $output = do { local $/; <$fh> };
+close($fh);
+my $status = $? >> 8;
+diag($output) if $status;
+return ($status, $output);
+}

--- a/t/dns-cloud-migration-vm.t
+++ b/t/dns-cloud-migration-vm.t
@@ -5,6 +5,7 @@ use warnings;
 no warnings qw(once redefine);
 use Test::More;
 use FindBin;
+use File::Temp qw(tempfile);
 use Storable qw(dclone);
 
 plan skip_all => 'Set VIRTUALMIN_DNS_VM_TEST=1 on a disposable Virtualmin Pro VM'
@@ -44,8 +45,17 @@ END {
 		run_cli('delete-domain', '--domain', $name);
 		}
 }
+# Generate the fixture password only on the VM, in a private temporary file.
+my ($passfh, $passfile) = tempfile('dns-migration-pass-XXXXXX',
+	DIR => '/tmp', UNLINK => 1);
+open(my $random, '<', '/dev/urandom') or die $!;
+my $bytes;
+read($random, $bytes, 32) == 32 or die 'Cannot generate fixture password';
+close($random);
+print $passfh unpack('H*', $bytes) or die $!;
+close($passfh) or die $!;
 my ($status, $output) = run_cli('create-domain', '--domain', $name,
-	'--pass', 'unused-dns-only-fixture', '--dns', '--cloud-dns', 'local',
+	'--passfile', $passfile, '--dns', '--cloud-dns', 'local',
 	'--skip-warnings');
 $created = !$status;
 BAIL_OUT("Cannot create DNS fixture: $output") if $status;
@@ -115,6 +125,7 @@ my ($cloud_records, $cloud_reads, $cloud_creates, $fail_create) = ([], 0, 0, 0);
 			is(virtual_server::modify_dns_cloud($d, 'cloudflare'), undef,
 				'moves fixture records to the simulated cloud');
 			is($d->{'dns_cloud'}, 'cloudflare', 'cloud provider selected');
+			ok(!exists($d->{'dns_keep_provider'}), 'switch flag is consumed during setup');
 			my $creates = $cloud_creates;
 			is(virtual_server::modify_dns_cloud($d, 'local'), undef,
 				'migration to local succeeds');
@@ -123,6 +134,7 @@ my ($cloud_records, $cloud_reads, $cloud_creates, $fail_create) = ([], 0, 0, 0);
 				'cloud provider and zone ID are cleared');
 			my $saved = $get_domain->($d->{'id'}, undef, 1);
 			ok(!$saved->{'dns_cloud'}, 'local provider is saved to disk');
+			ok(!exists($saved->{'dns_keep_provider'}), 'switch flag is not saved to disk');
 
 			$cloud_reads = 0;
 			my ($recs, $zone) = virtual_server::get_domain_dns_records_and_file($saved, 1);
@@ -144,6 +156,9 @@ my ($cloud_records, $cloud_reads, $cloud_creates, $fail_create) = ([], 0, 0, 0);
 	$err = virtual_server::modify_dns_cloud($d, 'cloudflare');
 	like($err, qr/Failed to setup new DNS zone/, 'reports destination setup failure');
 	ok(!$d->{'dns_cloud'}, 'rollback restores the original local provider');
+	ok(!exists($d->{'dns_keep_provider'}), 'rollback consumes the switch flag');
+	my $restored = $get_domain->($d->{'id'}, undef, 1);
+	ok(!exists($restored->{'dns_keep_provider'}), 'rollback does not save the switch flag');
 	my ($recs, $zone) = virtual_server::get_domain_dns_records_and_file($d, 1);
 	is_deeply(record_values($recs), $expected, 'rollback restores the original records');
 	virtual_server::save_domain($d);


### PR DESCRIPTION
Hi Jamie,

This PR prevent template and alias defaults from overriding the explicitly selected DNS provider during switch. This fixes moves to local DNS that could report success while leaving the domain configured for Cloudflare.

Preserve the original provider during rollback. Normal domain creation continues to use template defaults.

Fixes https://forum.virtualmin.com/t/the-cloud-dns-provider-with-the-cloudflare-identifier-is-either-not-supported-or-not-configured-on-this-system/137922